### PR TITLE
Bug fix for sitespeed.io file not found

### DIFF
--- a/bin/sitespeed.io-sites
+++ b/bin/sitespeed.io-sites
@@ -189,7 +189,7 @@ function analyze {
 if hash sitespeed.io 2>/dev/null; then
        SITESPEED_IO=sitespeed.io
     else
-       SITESPEED_IO="bash ./sitespeed.io"
+       SITESPEED_IO="bash ./bin/sitespeed.io"
 fi
 
 local runs=0
@@ -204,7 +204,7 @@ echo "Will analyze ${#urls[@]} sites"
 
 for url in "${urls[@]}"
 do
-    "$SITESPEED_IO" -u $url "$@" -r "$REPORT_BASE_DIR/$NOW"
+    $SITESPEED_IO -u $url "$@" -r "$REPORT_BASE_DIR/$NOW"
     runs=$[$runs+1]
     if [ $(($runs%20)) == 0 ]; then
       echo "Analyzed $runs sites out of ${#urls[@]}"


### PR DESCRIPTION
According to the docs, when running sitespeed.io-sites, you run it from the base directory of the project, but this results in the script not being able to find sitespeed.io, as it is looking in the wrong place, causing an errror:

Will analyze 2 sites
./bin/sitespeed.io-sites: line 207: bash ./sitespeed.io: No such file or directory
./bin/sitespeed.io-sites: line 207: bash ./sitespeed.io: No such file or directory
