### PR TITLE
allow for user-specific config file

### DIFF
--- a/bin/sitespeed.io
+++ b/bin/sitespeed.io
@@ -120,6 +120,12 @@ BROWSERTIME_JAR=browsertime-0.5-full.jar
 # Don't fetch Navigation Timing metrics by default
 COLLECT_BROWSER_TIMINGS=false
 
+# Load user-specific config file if it exists
+if [ -f ~/.sitespeedio ]
+then
+    source ~/.sitespeedio
+fi
+
 # Store the input to be able to log exactly how/what was done
 INPUT="$@"
 


### PR DESCRIPTION
It'd be handy to be able to define user-specific defaults, so that they don't need to be specified via the cli. The command _could_ just be wrapped in an alias but allowing for a `~/.sitespeedio` file is more convenient.
