### PR TITLE
Connect via any SSL protocol

### DIFF
--- a/bin/sitespeed.io
+++ b/bin/sitespeed.io
@@ -746,7 +746,7 @@ for url in "${URLS[@]}"
   do
     local imagefilename=$(get_filename $url $runs)
     echo "Creating screenshot for $url $REPORT_IMAGE_PAGES_DIR/$imagefilename.png "
-    phantomjs --ignore-ssl-errors=yes $PROXY_PHANTOMJS $DEPENDENCIES_DIR/screenshot.js "$url" "$REPORT_IMAGE_PAGES_DIR/$imagefilename.png" $width $height "$USER_AGENT" true  > /dev/null 2>&1
+    phantomjs --ssl-protocol=any --ignore-ssl-errors=yes $PROXY_PHANTOMJS $DEPENDENCIES_DIR/screenshot.js "$url" "$REPORT_IMAGE_PAGES_DIR/$imagefilename.png" $width $height "$USER_AGENT" true  > /dev/null 2>&1
 
     if $PNGCRUSH_EXIST
       then
@@ -820,7 +820,7 @@ function analyze() {
     local pagefilename=$(get_filename $1 $2)
 
     echo "Analyzing $url"
-    phantomjs --ignore-ssl-errors=yes $PROXY_PHANTOMJS $YSLOW_FILE -d -r $RULESET -f xml --ua "$USER_AGENT_YSLOW" $VIEWPORT_YSLOW -n "$REPORT_DATA_HAR_DIR/$pagefilename.har" "$url"  >"$REPORT_DATA_PAGES_DIR/$pagefilename.xml"  2>> $REPORT_DATA_DIR/phantomjs.error.log || echo "PhantomJS could not handle $url , check the error log:  $REPORT_DATA_DIR/phantomjs.error.log"
+    phantomjs --ssl-protocol=any --ignore-ssl-errors=yes $PROXY_PHANTOMJS $YSLOW_FILE -d -r $RULESET -f xml --ua "$USER_AGENT_YSLOW" $VIEWPORT_YSLOW -n "$REPORT_DATA_HAR_DIR/$pagefilename.har" "$url"  >"$REPORT_DATA_PAGES_DIR/$pagefilename.xml"  2>> $REPORT_DATA_DIR/phantomjs.error.log || echo "PhantomJS could not handle $url , check the error log:  $REPORT_DATA_DIR/phantomjs.error.log"
 
     local s=$(du -k "$REPORT_DATA_PAGES_DIR/$pagefilename.xml" | cut -f1)
     # Check that the size is bigger than 0
@@ -830,7 +830,7 @@ function analyze() {
       ## do the same thing again but setting console to log the error to output
       log_error "Could not analyze $url unrecoverable error when parsing the page"
       log_error "Input parameters: $INPUT"
-      phantomjs --ignore-ssl-errors=yes $PROXY_PHANTOMJS $YSLOW_FILE -d -r $RULESET -f xml "$USER_AGENT_YSLOW" $VIEWPORT_YSLOW "$url" -c 2  2>&1 >> $REPORT_DATA_DIR/$ERROR_LOG
+      phantomjs --ssl-protocol=any --ignore-ssl-errors=yes $PROXY_PHANTOMJS $YSLOW_FILE -d -r $RULESET -f xml "$USER_AGENT_YSLOW" $VIEWPORT_YSLOW "$url" -c 2  2>&1 >> $REPORT_DATA_DIR/$ERROR_LOG
 
       ## write the error url to the list
       echo "sitespeed.io got an unrecoverable error when parsing the page,$url" >> $REPORT_DATA_DIR/errorurls.txt


### PR DESCRIPTION
When connecting to a site that does not support SSLv3, the following error is triggered:

"Could not analyze $url unrecoverable error when parsing the page..."

PhantomJS defaults to using [SSLv3](http://phantomjs.org/api/command-line.html) when making secure connections with a site. If the site does not support SSLv3, the result of calling `require('webpage').open` in the YSlow script is a status of ["fail"](https://github.com/marcelduran/yslow/blob/ef14079f850180f65f4351bba1aa73d981cc1e0b/src/phantomjs/). PhantomJS allows you to specify the protocol to use when opening a page; however, the sitespeed.io script does not allow this parameter to be specified, which results in the default value of SSLv3 always being used. This "fail" status causes the "unrecoverable" error in the sitespeed.io script.

SSLv3 is an outdated protocol with known security [vulnerabilities](http://www.acunetix.com/vulnerabilities/tls1sslv3-renegotiation-v/). It would be nice to use sitespeed.io with sites that do not support the protocol.

To fix this issue, the `--ssl-protocol=any` argument can be sent to the PhantomJS call. This allows the connection to be made via SSLv3, SSLv2, or TLSv1. I think that specifying this argument as "any" allows for the best user experience as it should just work when testing against SSL. This commit adds this parameter.

I will email @soulgalore with a URL for testing as I do not want it public.
