### PR TITLE
Fixed JAVA_HOME problem in git bash for windows

### DIFF
--- a/bin/sitespeed.io
+++ b/bin/sitespeed.io
@@ -184,7 +184,7 @@ hash phantomjs >/dev/null 2>&1 || { echo >&2 "Missing phantomjs, please install 
 hash curl >/dev/null 2>&1 || { echo >&2 "Missing curl, please install it to be able to run sitespeed.io"; exit 1; }
 
 # JAVA_HOME has problems in windows with git bash
-if [[ `echo $(uname 2>&1) | grep "not found" 2>&1` ]] || [[ ( $(uname | grep "windows" 2>&1) || $(uname | grep "W32_NT" 2>&1) ) ]]
+if [[ `echo $JAVA_HOME | egrep "[A-Z]:\\\\" 2>&1 | grep " " 2>&1` ]]
 then
   JAVA=$(java -version 2>&1)
   if `echo ${JAVA} | grep "not found" 1>/dev/null 2>&1`
@@ -194,7 +194,7 @@ then
 fi
 
 # Respect JAVA_HOME if set
-if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]]
+if ! [[ "$JAVA" ]] && [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]]
 then
     JAVA="$JAVA_HOME/bin/java"
 else


### PR DESCRIPTION
When the JAVA_HOME is used, the $JAVA variable had the following value:
**"C:\Program Files\Java\jre7/bin/java"**

The only way i found to solve this just on windows was using the java from the PATH
