### PR TITLE
possible to set absolute or relative result path

### DIFF
--- a/lib/conf.js
+++ b/lib/conf.js
@@ -287,7 +287,11 @@ config.run.date = new Date();
 // Setup the absolute result dir
 if (config.url) {
   config.urlObject = urlParser.parse(config.url);
-  config.run.absResultDir = path.join(__dirname, '../',config.resultBaseDir, config.urlObject.hostname, dateFormat(config.run.date, "yyyy-mm-dd-HH-MM-ss") );
+    if(/^\/.*$/.test(config.resultBaseDir) || /^\.\.\/.*$/.test(config.resultBaseDir)) {
+    config.run.absResultDir = path.join(config.resultBaseDir, config.urlObject.hostname, dateFormat(config.run.date, "yyyy-mm-dd-HH-MM-ss") );
+  } else {
+    config.run.absResultDir = path.join(__dirname, '../',config.resultBaseDir, config.urlObject.hostname, dateFormat(config.run.date, "yyyy-mm-dd-HH-MM-ss") );
+  }
 } else if (config.file) {
   // TODO handle the file name in a good way if it contains chars that will not fit in a dir
   config.run.absResultDir = path.join(__dirname, '../',config.resultBaseDir, config.file, dateFormat(config.run.date, "yyyy-mm-dd-HH-MM-ss") );


### PR DESCRIPTION
Added a workaround to use absolute and relative path with the "-r" tag.
