### PR TITLE
Added support for request headers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,10 @@
 CHANGELOG sitespeed.io
+
+version 2.5.8
+------------------------
+* Added support for custom headers (new -H argument)
+* Fixed bug with curl user agent argument 
+
 version 2.5.7
 ------------------------
 * Upgraded to YSlow 3.1.8 (with configurable CDN)


### PR DESCRIPTION
This is a fix for the issue I raised in #452. Basically I've added support for request headers, and fixed a minor bug with the user agent argument on one of the phantomjs calls

I added this because I'm testing APIs that require a custom header, and return JSON not HTML. You can use the new -H parameter to test it

```
sitespeed.io -H "{\"x-business-group-id\":\"http://aaa.bbbb.com/business-groups/b\",\"Accept\":\"application/json\"}" -r "$WORKSPACE/sitespeed-result/" -f "/home/nick/Documents/b-urls.txt"
```
