### PR TITLE
Possibility to choose test (folder) name instead of current datetime

### DIFF
--- a/bin/sitespeed.io
+++ b/bin/sitespeed.io
@@ -422,7 +422,7 @@ fi
 if [ "$UNIQUE_TEST_IDENTIFIER" == "" ]
 then
 	local now=$(date +"%Y-%m-%d-%H-%M-%S")
-    UNIQUE_TEST_IDENTIFIER=$now
+  UNIQUE_TEST_IDENTIFIER=$now
 fi
 
 }
@@ -463,7 +463,7 @@ VELOCITY_DIR="$SITESPEED_HOME"/report/velocity
 PROPERTIES_DIR="$SITESPEED_HOME"/report/properties
 
 if [ -d "$REPORT_DIR" ]; then
-  echo 'You must provide a unique test indentifier name.'
+  echo "You must provide a unique test name. There is already a test with this name: $UNIQUE_TEST_IDENTIFIER"
   help
   exit 1
 fi


### PR DESCRIPTION
Add extra parameter to the run command with unique test name. I use this to create URL for the Jenkins Plot plugin: /sitespeed-result/%index%/index.html

```
./bin/sitespeed.io -u http://www.sitespeed.io/ -i build1

Folder: sitespeed.io\sitespeed-result\www.sitespeed.io\build1\index.html
```

![sitespeed unique url example in jekins](https://cloud.githubusercontent.com/assets/657797/4353157/fcf0f30e-422e-11e4-9b75-24a71f7bb801.png)
