### PR TITLE
[BUG] set viewPort size for yslow analysis

### DIFF
--- a/lib/analyze/yslow.js
+++ b/lib/analyze/yslow.js
@@ -95,6 +95,8 @@ function analyzeUrl(args, asyncDoneCallback) {
     '-yslow.json');
   childArgs.push('--file', resultsPath);
 
+  childArgs.push('-vp', config.viewPort);
+
   childArgs.push(url);
 
   log.log('info', 'Running YSlow for ' + url);


### PR DESCRIPTION
Got "Images scaled by the browser" message because the viewport was too small.
