### PR TITLE
Eliminate "has no method 'forEach'" errors when the number of WebPageTest runs is 1

### DIFF
--- a/lib/aggregators/webpagetest/repeatViewBytes.js
+++ b/lib/aggregators/webpagetest/repeatViewBytes.js
@@ -6,14 +6,16 @@
  */
 var Aggregator = require('../aggregator');
 
-module.exports = new Aggregator('firstViewBytesWPT',
+module.exports = new Aggregator('repeatViewBytesWPT',
   'Size Repeat View',
   'The size in bytes for the repeat view', 'pagemetric', 'bytes', 0,
   function(pageData) {
     if (pageData.webpagetest) {
       var stats = this.stats;
       pageData.webpagetest.response.data.run.forEach(function(run) {
-        stats.push(run.repeatView.results.bytesIn);
+        if (typeof run.repeatView != 'undefined') {
+          stats.push(run.repeatView.results.bytesIn);
+        }
       });
     }
   });

--- a/lib/aggregators/webpagetest/repeatViewFirstPaint.js
+++ b/lib/aggregators/webpagetest/repeatViewFirstPaint.js
@@ -13,7 +13,9 @@ module.exports = new Aggregator('repeatViewFirstPaintWPT',
     if (pageData.webpagetest) {
       var stats = this.stats;
       pageData.webpagetest.response.data.run.forEach(function(run) {
-        stats.push(run.repeatView.results.firstPaint);
+        if (typeof run.repeatView != 'undefined') {
+          stats.push(run.repeatView.results.firstPaint);
+        }
       });
     }
   });

--- a/lib/aggregators/webpagetest/repeatViewLoadTime.js
+++ b/lib/aggregators/webpagetest/repeatViewLoadTime.js
@@ -13,7 +13,9 @@ module.exports = new Aggregator('repeatViewLoadTimeWPT',
     if (pageData.webpagetest) {
       var stats = this.stats;
       pageData.webpagetest.response.data.run.forEach(function(run) {
-        stats.push(run.repeatView.results.loadTime);
+        if (typeof run.repeatView != 'undefined') {
+          stats.push(run.repeatView.results.loadTime);
+        }
       });
     }
   });

--- a/lib/aggregators/webpagetest/repeatViewRequest.js
+++ b/lib/aggregators/webpagetest/repeatViewRequest.js
@@ -6,14 +6,16 @@
  */
 var Aggregator = require('../aggregator');
 
-module.exports = new Aggregator('firstViewRequestsWPT',
+module.exports = new Aggregator('repeatViewRequestsWPT',
   'Requests Repeat View',
   'The number of requests for the repeat view', 'pagemtric', '', 0,
   function(pageData) {
     if (pageData.webpagetest) {
       var stats = this.stats;
       pageData.webpagetest.response.data.run.forEach(function(run) {
-        stats.push(run.repeatView.results.requests);
+        if (typeof run.repeatView != 'undefined') {
+          stats.push(run.repeatView.results.requests);
+        }
       });
     }
   });

--- a/lib/aggregators/webpagetest/repeatViewSpeedIndex.js
+++ b/lib/aggregators/webpagetest/repeatViewSpeedIndex.js
@@ -14,7 +14,9 @@ module.exports = new Aggregator('repeatViewSpeedIndexWPT',
     if (pageData.webpagetest) {
       var stats = this.stats;
       pageData.webpagetest.response.data.run.forEach(function(run) {
-        stats.push(run.repeatView.results.SpeedIndex);
+        if (typeof run.repeatView != 'undefined') {
+          stats.push(run.repeatView.results.SpeedIndex);
+        }
       });
     }
   });

--- a/lib/aggregators/webpagetest/repeatViewVisualComplete.js
+++ b/lib/aggregators/webpagetest/repeatViewVisualComplete.js
@@ -13,7 +13,9 @@ module.exports = new Aggregator('repeatViewVisualCompleteWPT',
     if (pageData.webpagetest) {
       var stats = this.stats;
       pageData.webpagetest.response.data.run.forEach(function(run) {
-        stats.push(run.repeatView.results.visualComplete);
+        if (typeof run.repeatView != 'undefined') {
+          stats.push(run.repeatView.results.visualComplete);
+        }
       });
     }
   });

--- a/lib/analyze/webpagetest.js
+++ b/lib/analyze/webpagetest.js
@@ -43,6 +43,10 @@ module.exports = {
               log.log('error', 'Error running WebPageTest: ' + err);
               errors[u] = err;
             } else {
+              //Always return an array for consistency in how we process aggregators
+              if (!Array.isArray(data.wpt.response.data.run)) {
+                data.wpt.response.data.run = [data.wpt.response.data.run];
+              }
               pageData[u] = data;
             }
           });

--- a/lib/collectors/pages.js
+++ b/lib/collectors/pages.js
@@ -148,7 +148,11 @@ function collectWPT(pageData, p) {
   p.wpt = {};
 
   // here's the data that we will collect from WPT
-  var views = ['firstView', 'repeatView'];
+  var views = ['firstView'];
+  if (typeof pageData.webpagetest.response.data.run.repeatView != 'undefined') {
+    views.push('repeatView');
+  }
+
   var sizes = ['image_savings', 'image_total', 'bytesIn', 'bytesInDoc'];
   var timings = ['SpeedIndex', 'firstPaint', 'TTFB', 'visualComplete', 'domContentLoadedEventEnd', 'loadTime'];
   var others = ['requests'];


### PR DESCRIPTION
This should resolve Issue 532.  

I debated a bit on how to solve this issue - I could have solved it via modifying each aggregator to test whether it was an array, or I could have solved it by detecting when there is a single object being returned and wrapping it in an array.  I opted for the latter because it seems to simply the aggregator code.

I also solved two other issues:
1. If "firstViewOnly" in wptConfig was set to true, you'd get related errors from the aggregators assuming the existence of the repeatView object.  This fix required a change in pages.js as well.
2. Two of the aggregators for repeat view had a copy paste error and were still named "firstView".  This exposed itself during the error condition described in #1 where it named the incorrect aggregators as being in fault.  It may have corrected other issues too - I suspect that the corresponding firstView metrics were being overwritten in the summary.json file.
