### PR TITLE
Added option to write junit file to specified directory instead of console

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -225,7 +225,20 @@ var fs = require('fs-extra'),
     },
     junit: {
       flag: true,
-      help: 'Create JUnit output to the console.'
+      help: 'Create JUnit output. By default, prints to the console.'
+    },
+	junitDir: {
+      metavar: '<DIR>',
+      help: 'JUnit output xml file will be written to specified directory instead of console. Use with --junit option.',
+      callback: function(file) {
+        if (!fs.existsSync(file)) {
+          fs.mkdirs(file, function(err) {
+            if (err) {
+              return 'Couldn\'t create the junit results dir:' + err;
+            }
+          });
+        }
+      }
     },
     tap: {
       flag: true,

--- a/lib/tests/jUnitTestSuites.js
+++ b/lib/tests/jUnitTestSuites.js
@@ -1,4 +1,6 @@
-var builder = require('xmlbuilder');
+var builder = require('xmlbuilder'),
+fs = require('fs-extra'),
+path = require('path');
 
 function JUnitTestSuites(filename, config) {
   this.config = config;
@@ -59,8 +61,18 @@ JUnitTestSuites.prototype.render = function(cb) {
     newline: '\n'
   });
 
-  console.log(xml);
-  cb();
+  if (this.config.junitDir) {
+    var resultFile = path.join(this.config.junitDir, 'junit.xml');
+    fs.writeFile(resultFile, xml, function(err) {
+      if (err) {
+        log.log('error', 'Couldn\'t write junit xml file to disk:' + resultFile + ' ' + err);
+      }
+      cb(err);
+    });
+  } else {
+    console.log(xml);
+	cb();
+  }
 };
 
 module.exports = JUnitTestSuites;


### PR DESCRIPTION
This was present in 2.5.7 and I still have jenkins set up to grab the junit file from a directory.
