### PR TITLE
Fix for exception throwing Java version check

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -358,8 +358,8 @@ module.exports = {
             if (err) {
               return callback(err);
             }
-            var matches = stderr.match(/java version "(.*)"/);
-            var version = matches.length === 2 ? matches[1] : 'unknown';
+            var matches = stderr.match(/(java version|openjdk version) "(.*)"/);
+            var version = (matches && matches.length === 3) ? matches[2] : 'unknown';
             return callback(null, version);
           });
         }


### PR DESCRIPTION
Just run in this issue.

At my machine:

```
stefan @ stefan-mac: ~/Desktop/sitespeed-test
> java -version                                          [12:50:24]
openjdk version "1.7.0-jdk7u4-b21"
OpenJDK Runtime Environment (build 1.7.0-jdk7u4-b21-20120427)
OpenJDK 64-Bit Server VM (build 23.0-b21, mixed mode)
```

So `matches` becomes `null` and sitespeed is crashing. Fixed it in this PR.