### PR TITLE
Ability to avoid sandbox mode when running Chrome.

### DIFF
--- a/lib/analyze/browsertime.js
+++ b/lib/analyze/browsertime.js
@@ -141,6 +141,7 @@ function runBrowsertime(args, callback) {
 		headers: config.requestHeaders,
 		size: config.viewPort,
 		userAgent: config.userAgent,
+		noSandbox: config.noSandbox,
 		harFile: harFile,
 		filename: measurementFile,
 		connection: config.connection,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -203,6 +203,10 @@ var cli = nomnom.help(
 			}
 		}
 	},
+	noSandbox: {
+		flag: true,
+		help: 'Runs Chrome browser not in sandbox mode. May help when having issues in special environments (e.g. Jenkins or IDEs).'
+	},
 	connection: {
 		default: 'cable',
 		help: 'Limit the speed by simulating connection types. Choose between ' + defaultConfig.connection


### PR DESCRIPTION
This may resolve issues when running from within continuous integration systems (e.g. Jenkins) or IDEs.

See: https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start

This is a follow-up commit to support the new browsertime feature (https://github.com/tobli/browsertime/pull/85)