### PR TITLE
enhanced the getGraphiteURLKey function to replace additional characters

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -300,7 +300,7 @@ module.exports = {
         pathName = 'slash';
       }
 
-      var replace = ['.', '~', ' ', '/'];
+      var replace = ['.', '~', ' ', '/', '+', '%7C', ','];
       replace.forEach(function(replaceMe) {
         if (pathName.indexOf(replaceMe) > -1) {
           pathName = pathName.split(replaceMe).join(char);

--- a/test/util/utilTest.js
+++ b/test/util/utilTest.js
@@ -141,7 +141,26 @@ describe('util', function() {
 			var result = util.getGraphiteURLKey('http://www.sitespeed.io/image.gif');
 			assert.deepEqual(result,'http.www_sitespeed_io._image_gif');
 		});
-
+                
+                it('Should escape pipes that make graphite data retrieval problematic', function() {
+                        var result = util.getGraphiteURLKey('http://www.example.com/browse|ID|4.html');
+                        assert.deepEqual(result,'http.www_example_com._browse_ID_4_html');
+                });
+                
+                it('Should escape encoded pipe characters that make graphite data retrieval problematic', function() {
+                        var result = util.getGraphiteURLKey('http://www.example.com/browse%7CID%7C4.html');
+                        assert.deepEqual(result,'http.www_example_com._browse_ID_4_html');
+                });
+                
+                it('Should escape "+" that make graphite data retrieval problematic', function() {
+                        var result = util.getGraphiteURLKey('http://www.example.com/browse/hello+world');
+                        assert.deepEqual(result,'http.www_example_com._browse_hello_world');
+                });
+                
+                it('Should escape "," (comma) that makes graphite functions fail', function() {
+                        var result = util.getGraphiteURLKey('http://www.example.com/browse/hello,world');
+                        assert.deepEqual(result,'http.www_example_com._browse_hello_world');
+                });
 
 	});
 });


### PR DESCRIPTION
Fixes #651 

I run into some issues with certain characters on URI that where clashing with graphite functionality or caused parsing issues for grafana when trying to retrieve data from graphite

The characters are:

* pipe (|)
* comma (,)
* plus (+)

... they are replaced by a ```_``` (as the others are)  
