### PR TITLE
When analyzing a single page, pass basic auth credentials if configured.

### DIFF
--- a/lib/analyzeOneSite.js
+++ b/lib/analyzeOneSite.js
@@ -119,6 +119,12 @@ AnalyzeOneSite.prototype._verifyURL = function(callback) {
     });
   }
 
+  if (this.config.basicAuth) {
+    options.auth = {
+      user: this.config.basicAuth.split(':')[0],
+      pass: this.config.basicAuth.split(':')[1]
+    };
+  }
 
   request(options, function(error, response, body) {
     // request follow redirects and we want to end up


### PR DESCRIPTION
Looks like this wiring must have gotten missed when the feature was implemented.