### PR TITLE
use query string in url for graphite

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -291,7 +291,7 @@ module.exports = {
       var join = '.';
       var char = '_';
 
-      var myUrl = url.parse(theUrl);
+      var myUrl = url.parse(theUrl, true);
       var protocol = myUrl.protocol.replace(':', '');
       var hostname = myUrl.hostname.split('.').join(char);
       var pathName = myUrl.pathname;
@@ -308,7 +308,29 @@ module.exports = {
         }
       });
 
-      return protocol + join + hostname + join + pathName;
+      var query = myUrl.query;
+      var queryKeys = Object.keys(query);
+      var queryArr = [];
+      var queryString = '';
+      if (queryKeys.length) {
+        queryKeys.forEach(function(key) {
+          queryArr.push(key);
+          if (query[key].trim() !== '') {
+            queryArr.push(query[key]);
+          }
+        });
+        queryString = queryArr.join(char);
+      }
+
+      return [
+        protocol,
+        hostname,
+        pathName,
+        queryString
+      ].filter(function(item) {
+        return item.trim() !== '';
+      }).join(join);
+
     },
     fineTuneUrls: function(okUrls, errorUrls, maxPagesToTest, absResultDir, callback) {
       var log = winston.loggers.get('sitespeed.io');


### PR DESCRIPTION
We use query string to toggle things like ads and Optimizely.  The tests are run against the same URL's with ads on and off.  I noticed our scores seemed a little too forgiving for a site with ads.  It looks like query strings aren't taken into account when sending the data to Graphite.

This change combines the query string to an object which then converts it to an underscore delimited string.  It takes into account an empty value and filters empty strings when returning the `getGraphiteURLKey`. 