### PR TITLE
All args to the headless script should be passed in the right order

### DIFF
--- a/lib/analyze/headless.js
+++ b/lib/analyze/headless.js
@@ -92,7 +92,11 @@ function runHeadless(args, asyncDoneCallback) {
     } else {
       a.push('--ssl-protocol=any', '--ignore-ssl-errors=yes');
     }
+
+    // Script to run on the  headless browser
     a.push(path.join(__dirname, '..', 'headless', 'scripts', 'collectTimings.js'));
+
+    // Arguments to that script
     a.push(url);
     a.push(path.join(config.run.absResultDir, config.dataDir, PATH, util.getFileName(url) +
     '-' + run + '.json'));
@@ -102,11 +106,15 @@ function runHeadless(args, asyncDoneCallback) {
     a.push(config.viewPort.split('x')[1]);
     a.push(config.userAgent);
     a.push(config.waitScript);
-    if (config.basicAuth) {
-      a.push(config.basicAuth);
-    }
     if (config.requestHeaders) {
       a.push(JSON.stringify(config.requestHeaders));
+    } else {
+      childArgs.push('false');
+    }
+    if (config.basicAuth) {
+      a.push(config.basicAuth);
+    } else {
+      childArgs.push('false');
     }
     return a;
   }


### PR DESCRIPTION
Similar issue to #724.
This one fixes the usage of " --browser headless" with basic auth and request headers.