### PR TITLE
#651 Create same Graphite namespace structure for the domain url as for per-page metrics

### DIFF
--- a/conf/defaultConfig.js
+++ b/conf/defaultConfig.js
@@ -13,6 +13,7 @@ var defaultConfig = {
   graphitePort: 2003,
   graphiteNamespace: 'sitespeed.io',
   graphiteData: 'all',
+  updatedGraphiteDomainSection: false,
   resultBaseDir: 'sitespeed-result',
   viewPort: '1280x800',
   waitScript: ' if (window.performance && window.performance.timing)'

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -358,6 +358,11 @@ var cli = nomnom.help(
 		default: defaultConfig.graphiteData,
 		help: 'Choose which data to send to Graphite by a comma separated list. Default all data is sent. [summary,rules,pagemetrics,timings,requests]'
 	},
+	updatedGraphiteDomainSection: {
+		flag: true,
+		default: defaultConfig.updatedGraphiteDomainSection,
+		help: 'Use the updated domain section when sending data to Graphite "http.www.sitespeed.io" to "http.www_sitespeed_io" (issue #651)'
+	},
 	gpsiKey: {
 		help: 'Your Google API Key, configure it to also fetch data from Google Page Speed Insights.'
 	},

--- a/lib/graphite/graphiteCollector.js
+++ b/lib/graphite/graphiteCollector.js
@@ -44,7 +44,12 @@ GraphiteCollector.prototype.collect = function(aggregates, pages, domains) {
   var config = this.config;
   var self = this;
   var statistics = '';
-  var domainKey = util.getGraphiteURLKey(config.urlObject).replace(/(\.slash)/, '');
+  var domainKey = config.urlObject.hostname;
+
+  // use updated domain section, behind flag so we don't break compatibility
+  if (this.config.updatedGraphiteDomainSection) {
+    var domainKey = util.getGraphiteURLKey(config.urlObject).replace(/(\.slash)/, '');
+  }
 
   pages.forEach(function(page) {
     statistics += self._getPageStats(page);

--- a/lib/graphite/graphiteCollector.js
+++ b/lib/graphite/graphiteCollector.js
@@ -44,7 +44,7 @@ GraphiteCollector.prototype.collect = function(aggregates, pages, domains) {
   var config = this.config;
   var self = this;
   var statistics = '';
-  var domainKey = util.getGraphiteURLKey(config.urlObject);
+  var domainKey = util.getGraphiteURLKey(config.urlObject).replace(/(\.slash)/, '');
 
   pages.forEach(function(page) {
     statistics += self._getPageStats(page);

--- a/lib/graphite/graphiteCollector.js
+++ b/lib/graphite/graphiteCollector.js
@@ -44,16 +44,18 @@ GraphiteCollector.prototype.collect = function(aggregates, pages, domains) {
   var config = this.config;
   var self = this;
   var statistics = '';
+  var domainKey = util.getGraphiteURLKey(config.urlObject);
+
   pages.forEach(function(page) {
     statistics += self._getPageStats(page);
   });
 
   if (this.config.graphiteData.indexOf('summary') > -1 || this.config.graphiteData.indexOf(
       'all') > -1) {
-    statistics += this._getSummaryStats(aggregates, config.urlObject.hostname, pages.length);
+    statistics += this._getSummaryStats(aggregates, domainKey, pages.length);
   }
 
-  statistics += self._getDomainStats(domains, config.urlObject.hostname);
+  statistics += self._getDomainStats(domains, domainKey);
 
 	statistics += self._getMeta(pages);
 


### PR DESCRIPTION
This should fix issue #651.

Crawling **http://www.jeroenvdb.be** creates
````
sitespeed.io.http.www_jeroenvdb_be.slash.*
sitespeed.io.summary.http.www_jeroenvdb_be.slash.*
````
instead of www_jeroenvdb_be and www.jeroenvdb.be:
````
sitespeed.io.http.www_jeroenvdb_be.slash.*
sitespeed.io.summary.www.jeroenvdb.be.*
````