### PR TITLE
ensure running slimerjs doesn't require phantomjs

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -11,6 +11,7 @@ var crypto = require('crypto'),
   path = require('path'),
   async = require('async'),
   phantomjsPath = require('phantomjs').path,
+  slimerPath = require('slimerjs').path,
   childProcess = require('child_process'),
   fileHelper = require('./fileHelpers'),
   winston = require('winston'),
@@ -364,7 +365,13 @@ module.exports = {
 
       async.parallel([
           function(callback) {
-            childProcess.execFile(config.phantomjsPath || phantomjsPath, ['--version'], {
+            var path = '';
+            if (config.headless === 'slimerjs') {
+              path = config.slimerPath || slimerPath
+            } else {
+              path = config.phantomjsPath || phantomjsPath
+            }
+            childProcess.execFile(path, ['--version'], {
               timeout: 120000
             }, function(err, stdout) {
               if (err) {
@@ -393,12 +400,13 @@ module.exports = {
           }
 
           var osVersion = os.platform() + ' ' + os.release();
-          var phantomjsVersion = results[0];
+          var headlessVersion = results[0];
           var javaVersion = results[1];
+          var headlessName = config.headless === 'slimerjs' ? 'SlimerJS' : 'PhantomJS';
 
           log.info(
-            'OS: \'%s\', Node.js: \'%s\', sitespeed.io: \'%s\', PhantomJS: \'%s\', java: \'%s\', browsertime: \'%s\'',
-            osVersion, process.version, sitespeedVersion, phantomjsVersion, javaVersion, browserTimeVersion);
+            'OS: \'%s\', Node.js: \'%s\', sitespeed.io: \'%s\', %s: \'%s\', java: \'%s\', browsertime: \'%s\'',
+            osVersion, process.version, sitespeedVersion, headlessName, headlessVersion, javaVersion, browserTimeVersion);
           return cb();
         });
 


### PR DESCRIPTION
This fixes #805.

Basically if `--headless slimerjs` is passed, then it calls `slimerjs --version` instead of `phantomjs --version` when getting version info. This means when `--headless slimerjs` is specified, the phantomjs bin is actually never called.