### PR TITLE
Add support for specifying JUnit report file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -265,7 +265,11 @@ var cli = nomnom.help(
 	},
 	junit: {
 		flag: true,
-		help: 'Create JUnit output to the console.'
+		help: 'Create JUnit output. If --junitFile file name is present then the output is directed to the file. Otherwise, it is directed to the console.'
+	},
+	junitFile: {
+		metavar: '<FILENAME>',
+		help: 'Specify the file name where JUnit output will be directed. The file will be created and stored inside {resultBaseDir}/sites/{yyyy-MM-dd-HH-mm-ss} folder.'
 	},
 	tap: {
 		flag: true,

--- a/lib/tests/jUnitTestSuites.js
+++ b/lib/tests/jUnitTestSuites.js
@@ -6,7 +6,8 @@
  */
 'use strict';
 
-var builder = require('xmlbuilder');
+var builder = require('xmlbuilder'),
+    fileHelper = require('../util/fileHelpers');
 
 function JUnitTestSuites(filename, config) {
   this.config = config;
@@ -67,8 +68,19 @@ JUnitTestSuites.prototype.render = function(cb) {
     newline: '\n'
   });
 
-  console.log(xml);
-  cb();
+  if (this.filename) {
+    fileHelper.writeFile(this.config, '..', this.filename, xml, function(err) {
+      if (err) {
+        return cb(err);
+      } else {
+        cb();
+      }
+    });
+
+  } else {
+    console.log(xml);
+    cb();
+  }
 };
 
 module.exports = JUnitTestSuites;

--- a/lib/tests/testRenderer.js
+++ b/lib/tests/testRenderer.js
@@ -28,7 +28,7 @@ function TestRenderer(config) {
       this.log.log('info', 'Using default web perf budget:' + JSON.stringify(this.budget));
     }
   }
-  this.suites = new JUnitTestSuites(path.join(this.config.run.absResultDir, 'sitespeed.io.junit.xml'), this.config);
+  this.suites = new JUnitTestSuites(this.config.junitFile, this.config);
 
 }
 TestRenderer.prototype.forEachPage = function(url, pageData) {

--- a/lib/util/fileHelpers.js
+++ b/lib/util/fileHelpers.js
@@ -62,6 +62,18 @@ module.exports = {
       }
       cb(err, null);
     });
+  },
+
+  writeFile: function(config, optionalPath, fileName, data, cb) {
+    var log = winston.loggers.get('sitespeed.io');
+    // write the file
+    var file = path.join(config.run.absResultDir, optionalPath, fileName);
+    fs.writeFile(file, data, function(err) {
+      if (err) {
+        log.log('error', 'Couldn\'t write file to disk:' + file + ' ' + err);
+      }
+      cb(err, null);
+    });
   }
 
 };


### PR DESCRIPTION
I'm using docker (sitespeed.io & selenium) on my CI server and followed the approach mentioned on [Continuous Integration] (https://www.sitespeed.io/documentation/continuous-integration/#junit-reporting) page, in order to generate a JUnit report file and let Atlassian Bamboo parse the results.

However, there is a problem which is that directing the output to a file by using "> sitespeed.io.xml" results in some Selenium related logs to be printed in the file. Thus the final XML is invalid. 

`
Tue Mar 22 22:06:01 UTC 2016
ChromeDriver 2.14.313457 (3d645c400edf2e2c500566c9aa096063e707c9cf)
Google Chrome 43.0.2357.81 
Mozilla Firefox 38.0
Starting Xvfb ...
Starting Selenium server ... access it at http://127.0.0.1:4444/wd/hub
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
`

As a temporary workaround, I'm removing the extra data from the file through a shell script. 

`tail -n +7 sitespeed.io.xml > sitespeed.io.xml.tmp && mv sitespeed.io.xml.tmp sitespeed.io.xml`

This PR contains a new config property named _junitFile_. In case _junitFile_ property is not present then the JUnit XML output is forwarded to the console (as-is behavior). Otherwise, if _junitFile_ is present then the output is directed to the specified file.

Example

_--junitFile sitespeed.io.junit.xml_ creates a sitespeed.io.junit.xml inside the parent directory of config.run.absResultDir