### PR TITLE
Add bin alias "sitespeed" to better support running sitespeed.io on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "sitespeed.io",
   "version": "3.11.5",
-  "bin": "./bin/sitespeed.js",
+  "bin": { 
+    "sitespeed.io": "./bin/sitespeed.js",
+    "sitespeed": "./bin/sitespeed.js"
+  },
   "description": "Analyze the web performance of your site",
   "keywords": [
     "performance",


### PR DESCRIPTION
Currently on windows when starting "sitespeed.io" a system dialog opens to choose a program to open sitespeed.io. This is not a desired behavior. This commit adds a binary alias "sitespeed" for sitespeed.io to run sitespeed.io without being bugged by windows.