### PR TITLE
Chrome throws error on sitespeed results due to about:blank captured as domain in HAR

### DIFF
--- a/lib/plugins/domains/aggregator.js
+++ b/lib/plugins/domains/aggregator.js
@@ -36,6 +36,11 @@ function getDomainEntry(domainName) {
 module.exports = {
   addToAggregate(har) {
     har.log.entries.forEach((entry) => {
+        // Temporarily exclude new window's about:blank for Chrome until it
+        // can be excluded from browsertime HAR results
+        if(entry.request.url == "about:blank") {
+            return;
+        }
       const domainName = parseDomainName(entry.request.url),
         domain = getDomainEntry(domainName);
 

--- a/lib/support/statsHelpers.js
+++ b/lib/support/statsHelpers.js
@@ -50,7 +50,7 @@ module.exports = {
       if (Number.isFinite(percentile)) {
         data[name] = percentile.toFixed(decimals);
       } else {
-        throw new Error('Failed to calculate percentile ' + p + ' for stats: ' + JSON.stringify(stats, null, 2));
+        throw new Error('Failed to calculate percentile ' + p + ' for ' + name + ' stats: ' + JSON.stringify(stats, null, 2));
       }
     });
     if (options.includeSum) {


### PR DESCRIPTION
Temp fixing issue where about:blank is being reported as a domain and causing an error in sitespeed when running with -b chrome option. Most likely an issue that can be pushed over to browsertime. Adding this patch for now to allow sitespeed to continue to work for chrome.