### PR TITLE
#908 - Adding docker-compose.yml for testing grafana, graphite, and influxdb

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '2'
+services:
+    grafana:
+        image: grafana/grafana
+        depends_on:
+            - graphite
+            - influxdb
+        links:
+            - graphite
+            - influxdb
+        ports:
+            - "3000:3000"
+    graphite:
+        image: sitespeedio/graphite
+        ports:
+            - "2003:2003"
+            - "8080:80"
+    influxdb:
+        image: tutum/influxdb
+        environment:
+            - PRE_CREATE_DB="sitespeed"
+            - ADMIN_USER="root"
+            - INFLUXDB_INIT_PWD="root"
+        ports:
+            - "8083:8083"
+            - "8086:8086"
+            - "8090:8090"
+            - "8099:8099"

--- a/tools/graphite.sh
+++ b/tools/graphite.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -e
-
-# Start local Graphite and Grafana instances, for testing Graphite reporting
-
-docker run -d -p 8080:80 -p 2003:2003 sitespeedio/graphite
-docker run -d -p 3000:3000 grafana/grafana

--- a/tools/influxdb.sh
+++ b/tools/influxdb.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -e
-
-# Start local InfluxDB and Grafana instances, for testing InfluxDB reporting
-#  -e ADMIN_USER="root" -e INFLUXDB_INIT_PWD="root"
-docker run -d -p 8083:8083 -p 8086:8086 --expose 8090 --expose 8099 -e PRE_CREATE_DB="sitespeed" tutum/influxdb
-docker run -d -p 3000:3000 grafana/grafana


### PR DESCRIPTION
Added docker-compose.yml for #908 

Mac steps
```
cd tools
docker-compose up -d
docker-machine ls
```
Note IP address from docker-machine command and use that for the url in grafana's data source setup.