### PR TITLE
Adding lodash.groupBy module requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lodash.difference": "4.2.0",
     "lodash.foreach": "4.2.0",
     "lodash.get": "4.2.1",
+    "lodash.groupby": "^4.3.0",
     "lodash.merge": "4.3.5",
     "lodash.reduce": "4.3.0",
     "lodash.set": "4.1.0",


### PR DESCRIPTION
Checked out the latest 4.0 branch seems we need lodash.groupBy which was missing in the package.json