### PR TITLE
Unescaping <br> in page summary report for dns-prefetch

### DIFF
--- a/lib/plugins/html/templates/url/coach/index.jade
+++ b/lib/plugins/html/templates/url/coach/index.jade
@@ -97,4 +97,7 @@ script(type='text/javascript').
           each value, key in advice.info.resourceHints
             tr
               td #{key}
-              td.url !{value.join('<br>')}
+              td.url
+                ul
+                  each url in value
+                    li #{url}

--- a/lib/plugins/html/templates/url/coach/index.jade
+++ b/lib/plugins/html/templates/url/coach/index.jade
@@ -97,4 +97,4 @@ script(type='text/javascript').
           each value, key in advice.info.resourceHints
             tr
               td #{key}
-              td.url #{value.join('<br>')}
+              td.url !{value.join('<br>')}


### PR DESCRIPTION
Notice the <br> tag was printed due to being escaped by default.