### PR TITLE
Missing newline caused last metrics to be lost when sent to graphite #932

### DIFF
--- a/lib/plugins/graphite/data-generator.js
+++ b/lib/plugins/graphite/data-generator.js
@@ -30,7 +30,7 @@ class GraphiteDataGenerator {
       let fullKey = util.format('%s.%s.%s', this.namespace, keypath, key);
       entries.push(util.format('%s %s %s', fullKey, value, timestamp));
       return entries;
-    }, []).join('\n');
+    }, []).join('\n') + '\n';
   }
 }
 


### PR DESCRIPTION
The missing newline after last metric was causing the last metric in every section to not make it to graphite.