### PR TITLE
Show other results even if one plugin has error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - sitespeed.io
 
+## UNRELEASED
+-------------------------
+### Fixed
+* Show results from other plugins even if one plugin has an error (e.g. WebPageTest fails but Browsertime succeeds).
+
 version 4.0.0-alpha1 - 2016-05-22
 -------------------------
 ### Changed

--- a/lib/plugins/html/assets/css/sitespeed.css
+++ b/lib/plugins/html/assets/css/sitespeed.css
@@ -64,6 +64,11 @@ ul.menu {
   text-transform: uppercase;
 }
 
+.errors {
+  margin-bottom: 2em;
+  background: lightpink;
+}
+
 /* Hide/show in coach offending */
 .hideable {
   display: none;

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -29,9 +29,9 @@ class HTMLBuilder {
     this.urlRunPages[url] = [];
   }
 
-  addErrorForUrl(url, data) {
-    const errors = get(this.urlPages[url], 'errors', []);
-    errors.push(data);
+  addErrorForUrl(url, source, data) {
+    const errors = get(this.urlPages[url], 'errors', {});
+    errors[source] = data;
     set(this.urlPages[url], 'errors', errors);
   }
 

--- a/lib/plugins/html/index.js
+++ b/lib/plugins/html/index.js
@@ -24,7 +24,7 @@ module.exports = {
 
       case 'error':
       {
-        return this.HTMLBuilder.addErrorForUrl(message.url, message.data);
+        return this.HTMLBuilder.addErrorForUrl(message.url, message.source, message.data);
       }
 
       case 'browsertime.run':

--- a/lib/plugins/html/templates/url/index.jade
+++ b/lib/plugins/html/templates/url/index.jade
@@ -13,32 +13,33 @@ block content
       a(href='./#{index}.html') #{value}
       if (value !== Object.keys(runPages).length)
         | &nbsp;-&nbsp;
-  p
+
+  if pageInfo.errors
+    h4 Errors
+    .errors= JSON.stringify(pageInfo.errors, null, 2)
+
   - run = 0
   h3 Statistics from run #{run + 1}
-  if pageInfo.errors
-    p Errors
-    .errors= JSON.stringify(pageInfo.errors, null, 2)
-  else
-    - d = pageInfo.data
-    ul
-      if d.coach && d.coach.pageSummary
-        li: a(href='#coach') Coach
-      if d.browsertime && d.browsertime.pageSummary
-        li: a(href='#timings') Timings
-      if d.pagexray && d.pagexray.pageSummary
-        li: a(href='#pagexray') Info
-      if d.webpagetest
-        li: a(href='#webpagetest') WebPageTest
 
+  - const d = pageInfo.data
+  ul
     if d.coach && d.coach.pageSummary
-      include ./coach/index.jade
-
+      li: a(href='#coach') Coach
     if d.browsertime && d.browsertime.pageSummary
-      include ./browsertime/index.jade
-
+      li: a(href='#timings') Timings
     if d.pagexray && d.pagexray.pageSummary
-      include ./pagexray/index.jade
-
+      li: a(href='#pagexray') Info
     if d.webpagetest
-      include ./webpagetest/index.jade
+      li: a(href='#webpagetest') WebPageTest
+
+  if d.coach && d.coach.pageSummary
+    include ./coach/index.jade
+
+  if d.browsertime && d.browsertime.pageSummary
+    include ./browsertime/index.jade
+
+  if d.pagexray && d.pagexray.pageSummary
+    include ./pagexray/index.jade
+
+  if d.webpagetest
+    include ./webpagetest/index.jade


### PR DESCRIPTION
- always show results from plugins that succeed
- provide some context to the error by including the plugin name
- style errors with beautiful pink background

Test by running:
bin/sitespeed.js http://www.expressen.se -n1 -b chrome --webpagetest.key foo