### PR TITLE
Shrink URL on Asset HTML report for any relatively long URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 -------------------------
 ### Fixed
 * The CSS size advice on summary page used the wrong metrics to check the color, meaning 0 bytes made it red :/
+* Shorten long URLs displayed on HTML Asset report #977
 
 ## 4.0.0-alpha5 - 2016-06-30
 -------------------------
@@ -38,7 +39,6 @@
 ### Fixed
 * Enable the coach by default.
 * Fixed broken default plugin loading.
-
 
 ## 4.0.0-alpha2 - 2016-06-07
 -------------------------

--- a/lib/plugins/assets/aggregator.js
+++ b/lib/plugins/assets/aggregator.js
@@ -1,13 +1,17 @@
 'use strict';
 
+const getShortUrl = require('../../support/util').getShortUrl;
+
 const assets = {};
 
 module.exports = {
   addToAggregate(data) {
     data.assets.forEach(function(asset) {
-      const url = asset.url;
+      const url = asset.url,
+      shortUrl = getShortUrl(asset.url);
       const urlInfo = assets[url] || {
           url: url,
+          shortURL: shortUrl,
           type: asset.type,
           lastModification: asset.timeSinceLastModified,
           cacheTime: asset.expires,

--- a/lib/plugins/html/templates/assets.pug
+++ b/lib/plugins/html/templates/assets.pug
@@ -5,7 +5,7 @@ mixin rows(assets)
   each asset in assets
     tr
       td.url.assetsurl(data-title='URL')
-        a(href=asset.url)= asset.url
+        a(href=asset.url)= asset.shortURL
       td(data-title='type')= asset.type
       +durationCell('last modified',asset.lastModification)
       +durationCell('cache time',asset.cacheTime)

--- a/lib/support/util.js
+++ b/lib/support/util.js
@@ -35,5 +35,12 @@ module.exports = {
       domainOrFile = path.basename(domainOrFile).replace(/\./g, '_');
     }
     return domainOrFile;
+  },
+  getShortUrl(url) {
+    if (url.length > 40) {
+        let shortUrl =  url.replace(/\?.*/,'');
+        url = (shortUrl.substr(0, 20) + '...' + shortUrl.substr(-17));
+    }
+    return url
   }
 };


### PR DESCRIPTION
Quick hack to add a shortenURL for HTML output for URLs longer than 30 characters for #874. Code should probably be moved to a function and tests needed.