### PR TITLE
Empty size fixes for tablet view of pages HTML report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * The CSS size advice on summary page used the wrong metrics to check the color, meaning 0 bytes made it red :/
 * Shorten long URLs displayed on HTML Asset report #977
+* Empty size fixes for tablet view of HTML report
 
 ## 4.0.0-alpha5 - 2016-06-30
 -------------------------

--- a/lib/plugins/html/helpers/size.js
+++ b/lib/plugins/html/helpers/size.js
@@ -10,14 +10,14 @@ module.exports = {
   },
   format(bytes) {
     if (!bytes || bytes < 0)
-      return '';
+      return 'N/A';
 
     if (bytes < KB) {
-      return Number(bytes) + ' b';
+      return Number(bytes) + ' B';
     } else if (bytes < MB) {
-      return Number(bytes / KB).toFixed(1) + ' kb';
+      return Number(bytes / KB).toFixed(1) + ' KB';
     } else {
-      return Number(bytes / MB).toFixed(1) + ' Mb';
+      return Number(bytes / MB).toFixed(1) + ' MB';
     }
   }
 };


### PR DESCRIPTION
Returning N/A if nothing to display to fix issue with text overlap on tablet view of 'Requests and sizes per content type' section of pages and switching to captial unit text to clarify that it is in Bytes.

https://xkcd.com/394/