### PR TITLE
Sync'ing up menu text on page summary and run summary

### DIFF
--- a/lib/plugins/html/templates/url/index.pug
+++ b/lib/plugins/html/templates/url/index.pug
@@ -54,24 +54,24 @@ block content
       if (value !== Object.keys(runPages).length)
         | &nbsp;-&nbsp;
 
-  if pageInfo.errors
-    h4 Errors
-    .errors= JSON.stringify(pageInfo.errors, null, 2)
-
   - run = 0
   h3 Statistics from run #{run + 1}
 
-  ul
-    if d.coach && d.coach.pageSummary
-      li: a(href='#coach') Coach
-    if d.browsertime && d.browsertime.pageSummary
-      li: a(href='#timings') Timings
-    if d.browsertime && d.browsertime.har && options.html && options.html.showWaterfallSummary
-      li: a(href='#waterfall') Waterfall
-    if d.pagexray && d.pagexray.pageSummary
-      li: a(href='#pagexray') Info
-    if d.webpagetest
-      li: a(href='#webpagetest') WebPageTest
+  if pageInfo.errors
+    h4 Errors
+    .errors= JSON.stringify(pageInfo.errors, null, 2)
+  else
+    ul.menu
+      if d.coach && d.coach.pageSummary
+        li: a(href='#coach') Coach
+      if d.browsertime && d.browsertime.pageSummary
+        li: a(href='#timings') Timings
+      if d.browsertime && d.browsertime.har && options.html && options.html.showWaterfallSummary
+        li: a(href='#waterfall') Waterfall
+      if d.pagexray && d.pagexray.pageSummary
+        li: a(href='#pagexray') Page summary
+      if d.webpagetest
+        li: a(href='#webpagetest') WebPageTest
 
   if d.coach && d.coach.pageSummary
     include ./coach/index.pug

--- a/lib/plugins/html/templates/url/run.pug
+++ b/lib/plugins/html/templates/url/run.pug
@@ -51,16 +51,16 @@ block content
     .error= pageInfo.error
   else
     ul.menu
-    if d.pagexray && d.pagexray.run
-      li: a(href='#pagexray') Page summary
-    if d.coach && d.coach.run
-      li: a(href='#coach') Advice
-    if d.browsertime && d.browsertime.run
-      li: a(href='#timings') Timing
-      if d.browsertime.run.har
-        li: a(href='#waterfall') Waterfall
-    if d.webpagetest && d.webpagetest.run
-      li: a(href='#webpagetest') WebPageTest
+      if d.pagexray && d.pagexray.run
+        li: a(href='#pagexray') Page summary
+      if d.coach && d.coach.run
+        li: a(href='#coach') Coach
+      if d.browsertime && d.browsertime.run
+        li: a(href='#timings') Timing
+        if d.browsertime.run.har
+          li: a(href='#waterfall') Waterfall
+      if d.webpagetest && d.webpagetest.run
+        li: a(href='#webpagetest') WebPageTest
 
     if d.pagexray && d.pagexray.run
       include ./pagexray/index.pug


### PR DESCRIPTION
@soulgalore may be a good idea before 1.0 we split some of these(menu, screenshot, page summary, etc) out into partials that we can include to avoid duplication of HTML and keep things consistent. Not too important though but would be an easy ticket for someone that wants to contribute to pick up.