### PR TITLE
Update slimerjs to avoid issue with download mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - sitespeed.io
 
+
+version 3.11.6 - 2016-07-10
+------------------------
+### Fixed
+* Updated Browsertime to latest Selenium to work with Firefox 47.0.1
+
+
 version 3.11.5 - 2016-01-30
 ------------------------
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Stars][stars-image]][stars-url]
 
 
-[Website](https://www.sitespeed.io) | [Documentation](https://www.sitespeed.io/documentation/) | [Help us](https://github.com/sitespeedio/sitespeed.io/blob/master/HELP.md) | [Twitter](https://twitter.com/SiteSpeedio)
+[Website](https://www.sitespeed.io) | [Documentation](https://www.sitespeed.io/documentation/) | [Help us](https://github.com/sitespeedio/sitespeed.io/blob/3.x/HELP.md) | [Twitter](https://twitter.com/SiteSpeedio)
 
 Welcome to the wonderful world of web performance!
 
@@ -40,14 +40,14 @@ Do you want to make sitespeed.io even better? Check out the [help us](HELP.md) p
 Example reports
 =============
 Summary:
-<img src="https://raw.githubusercontent.com/sitespeedio/sitespeed.io/master/doc/3.0-summary2.png">
+<img src="https://raw.githubusercontent.com/sitespeedio/sitespeed.io/3.x/doc/3.0-summary2.png">
 Pages summary:
-<img src="https://raw.githubusercontent.com/sitespeedio/sitespeed.io/master/doc/3.0-pages.png">
+<img src="https://raw.githubusercontent.com/sitespeedio/sitespeed.io/3.x/doc/3.0-pages.png">
 Metrics in Graphite:
-<img src="https://raw.githubusercontent.com/sitespeedio/sitespeed.io/master/doc/3.0-grafana-timing-metrics.png">
+<img src="https://raw.githubusercontent.com/sitespeedio/sitespeed.io/3.x/doc/3.0-grafana-timing-metrics.png">
 
-[travis-image]: https://img.shields.io/travis/sitespeedio/sitespeed.io.svg?style=flat-square
-[travis-url]: https://travis-ci.org/sitespeedio/sitespeed.io
+[travis-image]: https://img.shields.io/travis/sitespeedio/sitespeed.io/3.x.svg?style=flat-square
+[travis-url]: https://travis-ci.org/sitespeedio/sitespeed.io/branches
 [stars-url]: https://github.com/sitespeedio/sitespeed.io/stargazers
 [stars-image]: https://img.shields.io/github/stars/sitespeedio/sitespeed.io.svg?style=flat-square
 [downloads-image]: http://img.shields.io/npm/dm/sitespeed.io.svg?style=flat-square

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "async": "1.5.2",
     "brace-expansion": "1.1.2",
-    "browsertime": "0.12.2",
+    "browsertime": "0.12.3",
     "cross-spawn-async": "2.1.6",
     "fast-stats": "0.0.3",
     "fs-extra": "0.26.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitespeed.io",
-  "version": "3.11.5",
+  "version": "3.11.6",
   "bin": "./bin/sitespeed.js",
   "description": "Analyze the web performance of your site",
   "keywords": [


### PR DESCRIPTION
Slimerjs package will download slimerjs on installation. This caused too much load on the server and the author has blocked downloads from aws: https://groups.google.com/forum/#!topic/slimerjs/nIi0ZqSNzBs. This was fixed in the slimerjs npm package by using github as a mirror: https://github.com/graingert/slimerjs/commit/63a82887b941222d714e52d4afdbee5f55028a1e. This PR will use the latest slimerjs version to avoid issues running sitespeedio on aws.

`npm run travis` gives no errors.