### PR TITLE
Upgrade slimerjs to avoid issue with download mirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "phantomjs-prebuilt": "2.1.3",
     "request": "2.69.0",
     "simplehar.sitespeed.io": "0.19.0",
-    "slimerjs": "0.9.2",
+    "slimerjs": "0.906.2",
     "tape": "3.5.0",
     "valid-url": "1.0.9",
     "webpagetest": "0.2.5",


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
Slimerjs package will download slimerjs on installation. This caused too much load on the server and the author has blocked downloads from aws: https://groups.google.com/forum/#!topic/slimerjs/nIi0ZqSNzBs. This was fixed in the slimerjs npm package by using github as a mirror: graingert/slimerjs@63a8288. This PR will use the latest slimerjs version to avoid issues running sitespeedio on aws.