### PR TITLE
Correct way of creating relative urls in html site

### DIFF
--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -27,7 +27,7 @@ class HTMLBuilder {
 
   addUrl(url) {
     this.urlPages[url] = {
-      path: this.storageManager.relativePathFromUrl(url),
+      path: this.storageManager.pathFromRootToPageDir(url),
       data: {}
     };
     this.urlRunPages[url] = [];
@@ -42,7 +42,6 @@ class HTMLBuilder {
   addDataForUrl(url, typePath, data, runIndex) {
     if (runIndex !== undefined) {
       let runData = this.urlRunPages[url][runIndex] || {
-          path: this.storageManager.relativePathFromUrl(url),
           runIndex,
           data: {}
         };
@@ -147,7 +146,7 @@ class HTMLBuilder {
 
   _renderSummaryPage(name, locals) {
     locals = merge({
-      rootPath: '.',
+      rootPath: '',
       menu: name,
       pageTitle: name,
       pageDescription: '',

--- a/lib/plugins/html/templates/header.pug
+++ b/lib/plugins/html/templates/header.pug
@@ -2,13 +2,13 @@ mixin headerLink(id, name)
   if (headers[id])
     li
       - active = menu===id ? 'active' : ''
-      a(href= rootPath + '/' + id + '.html', class=active)= name
+      a(href= rootPath + id + '.html', class=active)= name
 
 .darkblue.nav
   .navgrid
     .logo
         a(href='https://www.sitespeed.io')
-          img.navbar-brand(src= rootPath + '/img/sitespeed.io-logo.png', width='162', height='50', alt='sitespeed.io logo')
+          img.navbar-brand(src= rootPath + 'img/sitespeed.io-logo.png', width='162', height='50', alt='sitespeed.io logo')
     ul
       +headerLink('index', 'Summary')
       +headerLink('detailed', 'Detailed Summary')

--- a/lib/plugins/html/templates/layout.pug
+++ b/lib/plugins/html/templates/layout.pug
@@ -6,13 +6,13 @@ html(lang='en')
         title= pageTitle
         meta(name='description', content=pageDescription)
         meta(name='robots', content='noindex')
-        link(rel='stylesheet', href=rootPath + '/css/index.min.css')
+        link(rel='stylesheet', href=rootPath + 'css/index.min.css')
         block inlineStyles
-        link(rel='apple-touch-icon-precomposed', sizes='144x144', href=rootPath + '/img/ico/sitespeed.io-144.png')
-        link(rel='apple-touch-icon-precomposed', sizes='114x114', href=rootPath + '/img/ico/sitespeed.io-114.png')
-        link(rel='apple-touch-icon-precomposed', sizes='72x72', href=rootPath + '/img/ico/sitespeed.io-72.png')
-        link(rel='apple-touch-icon-precomposed', href=rootPath + '/img/ico/sitespeed.io-57.png')
-        link(rel='shortcut icon', href=rootPath + '/img/ico/sitespeed.io.ico')
+        link(rel='apple-touch-icon-precomposed', sizes='144x144', href=rootPath + 'img/ico/sitespeed.io-144.png')
+        link(rel='apple-touch-icon-precomposed', sizes='114x114', href=rootPath + 'img/ico/sitespeed.io-114.png')
+        link(rel='apple-touch-icon-precomposed', sizes='72x72', href=rootPath + 'img/ico/sitespeed.io-72.png')
+        link(rel='apple-touch-icon-precomposed', href=rootPath + 'img/ico/sitespeed.io-57.png')
+        link(rel='shortcut icon', href=rootPath + 'img/ico/sitespeed.io.ico')
     body
       include ./header.pug
       .container
@@ -20,4 +20,4 @@ html(lang='en')
         block content
 
         include ./footer.pug
-      script(src= rootPath + '/js/sortable.min.js')
+      script(src= rootPath + 'js/sortable.min.js')

--- a/lib/plugins/html/templates/pages.pug
+++ b/lib/plugins/html/templates/pages.pug
@@ -7,7 +7,7 @@ mixin rows(pages)
     - t = p.contentTypes || {javascript: {transferSize: ''}, css: {transferSize: ''}, image: {transferSize: ''}}
     tr
       td.url.pagesurl(data-title='URL')
-        a(href= pageInfo.path + '/index.html')= url
+        a(href= pageInfo.path + 'index.html')= url
       +kbSizeCell('Javascript size', h.get(t.javascript, 'transferSize'))
       +kbSizeCell('CSS size', h.get(t.css, 'transferSize'))
       +kbSizeCell('Image size', h.get(t.image, 'transferSize'))

--- a/lib/plugins/html/templates/url/coach/index.pug
+++ b/lib/plugins/html/templates/url/coach/index.pug
@@ -46,7 +46,7 @@ script(type='text/javascript').
   .column
     .row
       .four.columns
-        img.u-max-full-width(src= rootPath + '/img/coach.png', alt='I am the coach')
+        img.u-max-full-width(src= rootPath + 'img/coach.png', alt='I am the coach')
       .eight.columns
         h3 Coach score
         ul

--- a/lib/sitespeed.js
+++ b/lib/sitespeed.js
@@ -42,13 +42,14 @@ module.exports = {
     let disabledPlugins = options.plugins ? options.plugins.disable : [];
     pullAll(pluginNames,disabledPlugins);
 
+    const url = options._[0];
     const timestamp = moment();
 
     if (options.utc) {
       timestamp.utc();
     }
 
-    const storageManager = new StorageManager(options, timestamp);
+    const storageManager = new StorageManager(url, timestamp, options);
 
     return storageManager.createDataDir('logs').then((logDir) => {
         logging.configure(options, logDir);

--- a/lib/support/storageManager.js
+++ b/lib/support/storageManager.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs-extra'),
   Promise = require('bluebird'),
+  moment = require('moment'),
   path = require('path'),
   crypto = require('crypto'),
   urlParser = require('url'),
@@ -11,6 +12,7 @@ Promise.promisifyAll(fs);
 const mkdirp = Promise.promisify(require('mkdirp'));
 
 const defaultDir = 'sitespeed-result';
+
 function write(dirPath, filename, data) {
   return Promise.join(dirPath, filename, data,
     (dirPath, filename, data) =>
@@ -18,23 +20,28 @@ function write(dirPath, filename, data) {
 }
 
 class StorageManager {
-  constructor(options, timestamp) {
+  constructor(url, timestamp, options) {
+    timestamp = timestamp || moment();
+    options = options || {};
+
+    const domainOrFile = util.getDomainOrFileName(url);
+
     this.timestamp = timestamp.format('YYYY-MM-DD-HH-mm-ss');
-    let domainOrFile = util.getDomainOrFileName(options._[0]);
     this.baseDir = path.resolve(process.cwd(), options.resultBaseDir || defaultDir, domainOrFile, this.timestamp);
   }
 
   rootPathFromUrl(url) {
-    return this.relativePathFromUrl(url)
+    return this.pathFromRootToPageDir(url)
       .split('/')
       .filter(Boolean)
       .map(() => '..')
-      .join('/');
+      .join('/')
+      .concat('/');
   }
 
-  relativePathFromUrl(url) {
+  pathFromRootToPageDir(url) {
     const parsedUrl = urlParser.parse(url),
-      pathSegments = parsedUrl.pathname.split('/');
+      pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
 
     pathSegments.unshift(parsedUrl.hostname);
 
@@ -46,7 +53,8 @@ class StorageManager {
       pathSegments.push('query-' + hash);
     }
 
-    return path.join.apply(null, pathSegments);
+    return pathSegments.join('/')
+      .concat('/');
   }
 
   createDataDir(subDir) {
@@ -80,7 +88,7 @@ class StorageManager {
   createDirForUrl(url, subDir) {
     const pathSegments = [
       this.baseDir,
-      this.relativePathFromUrl(url),
+      this.pathFromRootToPageDir(url),
       subDir
     ].filter(Boolean);
 

--- a/test/storageManagerTests.js
+++ b/test/storageManagerTests.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const StorageManager = require('../lib/support/storageManager'),
+  os = require('os'),
+  moment = require('moment'),
+  expect = require('chai').expect;
+
+function createManager(url) {
+  return new StorageManager(url, moment(), {resultBaseDir: os.tmpdir()});
+}
+
+describe('storageManager', function() {
+  describe('#rootPathFromUrl', function() {
+    it('should create path from url', function() {
+      const storageManager = createManager('http://www.foo.bar');
+      const path = storageManager.rootPathFromUrl('http://www.foo.bar/x/y/z.html');
+      expect(path).to.equal('../../../../../');
+    });
+
+    it('should create path from url with query string', function() {
+      const storageManager = createManager('http://www.foo.bar');
+      const path = storageManager.rootPathFromUrl('http://www.foo.bar/x/y/z?foo=bar');
+      expect(path).to.equal('../../../../../../');
+    });
+  });
+
+  describe('#pathFromRootToPageDir', function() {
+    it('should create path from site root', function() {
+      const storageManager = createManager('http://www.foo.bar');
+      const path = storageManager.pathFromRootToPageDir('http://www.foo.bar');
+      expect(path).to.equal('pages/www.foo.bar/');
+    });
+
+    it('should create path from url', function() {
+      const storageManager = createManager('http://www.foo.bar');
+      const path = storageManager.pathFromRootToPageDir('http://www.foo.bar/x/y/z.html');
+      expect(path).to.equal('pages/www.foo.bar/x/y/z.html/');
+    });
+
+    it('should create path from url with query string', function() {
+      const storageManager = createManager('http://www.foo.bar');
+      const path = storageManager.pathFromRootToPageDir('http://www.foo.bar/x/y/z?foo=bar');
+      expect(path).to.equal('pages/www.foo.bar/x/y/z/query-115ffe20/');
+    });
+
+  });
+});


### PR DESCRIPTION
- rename relativePathFromUrl to pathFromRootToPageDir to make it more obvious what it does.
- join relative url path with / instead of using the path module (should make paths work on all OSes).
- remove path parameter for url run pages, since it wasn't used.
- make StorageManager constructor signature follow node conventions (options last) and add some StorageManager tests.