### PR TITLE
Run custom scripts

### DIFF
--- a/lib/plugins/browsertime/aggregator.js
+++ b/lib/plugins/browsertime/aggregator.js
@@ -20,6 +20,11 @@ module.exports = {
         statsHelpers.pushStats(this.statsPerType, ['navigationTiming', name], value);
     });
 
+    // pick up one level of custom metrics
+    forEach(browsertimeRunData.custom, (value, name) => {
+        statsHelpers.pushStats(this.statsPerType, ['custom', name], value);
+    });
+
     forEach(browsertimeRunData.timings.timings, (value, name) => {
         statsHelpers.pushStats(this.statsPerType, ['timings', name], value);
     });

--- a/lib/plugins/browsertime/analyzer.js
+++ b/lib/plugins/browsertime/analyzer.js
@@ -70,8 +70,8 @@ module.exports = {
     const scriptCategories = browserScripts.allScriptCategories;
     let scriptsByCategory = browserScripts.getScriptsForCategories(scriptCategories);
 
-    if (options.script) {
-      const userScripts = parseUserScripts(options.script);
+    if (options.browsertime.script) {
+      const userScripts = parseUserScripts(options.browsertime.script);
       scriptsByCategory = Promise.join(scriptsByCategory, userScripts,
         (scriptsByCategory, userScripts) => merge(scriptsByCategory, userScripts));
     }

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -38,7 +38,8 @@ const DEFAULT_METRICS_PAGE_SUMMARY = [
   'statistics.timings.userTimings',
   'statistics.visualMetrics.SpeedIndex',
   'statistics.visualMetrics.FirstVisualChange',
-  'statistics.visualMetrics.LastVisualChange'
+  'statistics.visualMetrics.LastVisualChange',
+  'statistics.custom.*'
 ];
 
 const DEFAULT_METRICS_SUMMARY = [
@@ -50,7 +51,8 @@ const DEFAULT_METRICS_SUMMARY = [
   'userTimings.measures',
   'visualMetrics.SpeedIndex',
   'visualMetrics.FirstVisualChange',
-  'visualMetrics.LastVisualChange'
+  'visualMetrics.LastVisualChange',
+  'custom.*'
 ];
 
 module.exports = {

--- a/lib/plugins/html/setup/detailed.js
+++ b/lib/plugins/html/setup/detailed.js
@@ -75,6 +75,12 @@ module.exports = function(data) {
     for (let timing of timings) {
       rows.push(row(summary.timings[timing], timing, timing))
     }
+
+    if (summary.custom) {
+      for (var key of Object.keys(summary.custom)) {
+        rows.push(row(summary.custom[key],key));
+      }
+    }
   }
 
   if (webpagetest) {

--- a/lib/plugins/html/setup/summaryBoxes.js
+++ b/lib/plugins/html/setup/summaryBoxes.js
@@ -124,6 +124,12 @@ module.exports = function(data) {
         infoBox(summary.visualMetrics.SpeedIndex, 'Speed Index'),
         infoBox(summary.visualMetrics.LastVisualChange, 'Last Visual Change', h.time.duration));
     }
+
+    if (summary.custom) {
+      for (var key of Object.keys(summary.custom)) {
+        boxes.push(infoBox(summary.custom[key], key));
+      }
+    }
   }
 
   if (webpagetest) {

--- a/lib/plugins/html/templates/url/browsertime/index.pug
+++ b/lib/plugins/html/templates/url/browsertime/index.pug
@@ -51,3 +51,16 @@ table
       tr
         td #{value.name}
         td.number #{value.startTime.toFixed(1)}
+
+h4 Custom scripts
+if browsertime.custom
+  table
+    tr
+      th name
+      th value
+    each value, name in browsertime.custom
+      tr
+        td #{name}
+        td #{value}
+else
+  p There are no custom configured scripts.

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -66,12 +66,10 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe: 'Supply javascript that decides when a browser run is finished. Use it to fetch timings happening after the loadEventEnd.',
       group: 'Browser'
     })
-    /*
     .option('browsertime.script', {
       describe: 'Add custom Javascript to run on page. If a single js file is specified, it will be included in the category named "custom" in the output json. Pass a folder to include all .js scripts in the folder, and have the folder name be the category. Note that --script can be passed multiple times.',
       group: 'Browser'
     })
-    */
     .option('browsertime.selenium.url', {
       describe: 'Configure the path to the Selenium server when fetching timings using browsers. If not configured the supplied NodeJS/Selenium version is used.',
       group: 'Browser'

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -67,7 +67,8 @@ module.exports.parseCommandLine = function parseCommandLine() {
       group: 'Browser'
     })
     .option('browsertime.script', {
-      describe: 'Add custom Javascript to run on page. If a single js file is specified, it will be included in the category named "custom" in the output json. Pass a folder to include all .js scripts in the folder, and have the folder name be the category. Note that --script can be passed multiple times.',
+      describe: 'Add custom Javascript to run on page (that returns a number). Note that --script can be passed multiple times if you want to collect multiple metrics. The metrics will automatically be pushed to the summary/detailed summary and each individual page + sent to Graphite/InfluxDB.',
+      alias: ['script'],
       group: 'Browser'
     })
     .option('browsertime.selenium.url', {


### PR DESCRIPTION
Made the simplest solution for adding your own script. 

Use <code>--browsertime.script myScript.js</code> to add your script. You can run multiple script by passing the parameter multiple times.

The metrics will automatically turn up on the summary page, detailed page, the summary page of the page and the run page. They will also be sent to Graphite.

We lack support for passing a dir with multiple files (as we have in Browsertime) but I think it's ok to wait with that!
