### PR TITLE
Tag messages with group, based on url or filename.

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -77,7 +77,7 @@ module.exports = {
     filterRegistry.registerFilterForType(DEFAULT_METRICS_SUMMARY, 'browsertime.summary');
   },
   processMessage(message, queue) {
-    function processCrawlOutput(url, results) {
+    function processCrawlOutput(url, group, results) {
       const originalDomain = parseDomain(url);
 
       let depth = message.data.depth || 0;
@@ -96,14 +96,15 @@ module.exports = {
               depth,
               referrer: url
             }, {
-              url: link
+              url: link,
+              group
             }));
           }
         }
       }
     }
 
-    function processCoachOutput(url, results) {
+    function processCoachOutput(url, group, results) {
       return Promise.resolve(results.browserScripts)
         .each((run, runIndex) => {
           const coachAdvice = run.coach.coachAdvice;
@@ -124,6 +125,7 @@ module.exports = {
             .then((harResult) => api.merge(coachAdvice, harResult))
             .then((total) => queue.postMessage(make('coach.run', total, {
               url,
+              group,
               runIndex
             })));
         });
@@ -133,18 +135,19 @@ module.exports = {
       case 'url':
         {
           const url = message.url;
+          const group = message.group;
 
           visitedUrls.add(url);
           return analyzer.analyzeUrl(url, this.options)
             .tap((results) => {
               log.trace('Result from Browsertime for %s with %:2j', url, results);
               if (this.options.browsertime.crawl) {
-                processCrawlOutput(url, results);
+                processCrawlOutput(url, group, results);
               }
             })
             .tap((results) => {
               if (this.options.browsertime.coach) {
-                return processCoachOutput(url, results);
+                return processCoachOutput(url, group, results);
               }
             })
             .tap((results) => {
@@ -169,25 +172,29 @@ module.exports = {
                 }
                 queue.postMessage(make('browsertime.run', run, {
                   url,
+                  group,
                   runIndex
                 }));
                 aggregator.addToAggregate(run);
               });
               queue.postMessage(make('browsertime.pageSummary', results, {
-                url
+                url,
+                group
               }));
             })
             .tap((results) => {
               if (results.har) {
                 queue.postMessage(make('browsertime.har', results.har, {
-                  url
+                  url,
+                  group
                 }));
               }
             })
             .tap((results) => {
               if (results.screenshots) {
                 queue.postMessage(make('browsertime.screenshot', results.screenshots, {
-                  url
+                  url,
+                  group
                 }));
               }
             })

--- a/lib/plugins/coach/index.js
+++ b/lib/plugins/coach/index.js
@@ -33,7 +33,8 @@ module.exports = {
           // For now, choose the first run to represent the whole page.
           // Later we might want to change the median run (based on some metric) similar to the WPT approach.
           const url = message.url;
-          queue.postMessage(make('coach.pageSummary', message.data, {url}));
+          const group = message.group;
+          queue.postMessage(make('coach.pageSummary', message.data, {url, group}));
         }
 
         aggregator.addToAggregate(message.data);
@@ -43,6 +44,7 @@ module.exports = {
       case 'browsertime.har':
       {
         const url = message.url;
+        const group = message.group;
         let config = {
           includeAssets: true,
           firstParty: this.options.firstParty ? this.options.firstParty : undefined
@@ -51,10 +53,10 @@ module.exports = {
 
         pagexrayAggregator.addToAggregate(pageSummary, message.url);
 
-        queue.postMessage(make('pagexray.pageSummary', pageSummary[0], {url}));
+        queue.postMessage(make('pagexray.pageSummary', pageSummary[0], {url, group}));
 
         pageSummary.forEach((run, runIndex) => {
-          queue.postMessage(make('pagexray.run', run, {url, runIndex}));
+          queue.postMessage(make('pagexray.run', run, {url, group, runIndex}));
         });
         break;
       }

--- a/lib/plugins/crawler/index.js
+++ b/lib/plugins/crawler/index.js
@@ -65,7 +65,7 @@ module.exports = {
             log.verbose('Crawler skipping initial URL %s', url);
           } else if (pageMimeType.test(queueItem.stateData.contentType)) {
             log.verbose('Crawler found URL %s', url);
-            queue.postMessage(make('url', {}, {url}));
+            queue.postMessage(make('url', {}, {url, group: message.group}));
             pageCount++;
 
             if (pageCount >= maxPages) {

--- a/lib/plugins/gpsi/index.js
+++ b/lib/plugins/gpsi/index.js
@@ -24,12 +24,14 @@ module.exports = {
       case 'url':
         {
           const url = message.url;
+          const group = message.group;
           return analyzer.analyzeUrl(url, this.options.gpsi)
             .then((result) => {
               log.info('Got ' + url + ' analysed from Google Page Speed Insights');
               log.trace('Result from Google Page Speed Insights:%:2j', result);
               queue.postMessage(make('gpsi.pageSummary', result, {
-                url
+                url,
+                group
               }))
             });
         }

--- a/lib/plugins/webpagetest/index.js
+++ b/lib/plugins/webpagetest/index.js
@@ -44,19 +44,21 @@ module.exports = {
       case 'url':
       {
         const url = message.url;
+        const group = message.group;
         return analyzer.analyzeUrl(url, this.options)
           .tap((result) => {
-            queue.postMessage(make('webpagetest.har', result.har, {url}));
+            queue.postMessage(make('webpagetest.har', result.har, {url, group}));
 
             forEach(result.data.runs, (run, runKey) =>
               queue.postMessage(make('webpagetest.run', run, {
                 url,
+                group,
                 runIndex: (parseInt(runKey) - 1)
               }))
             );
             const location = result.data.location.replace(':', '-').replace(' ', '-').toLowerCase();
             const connectivity = result.data.connectivity.toLowerCase();
-            queue.postMessage(make('webpagetest.pageSummary', result, {url, location, connectivity}));
+            queue.postMessage(make('webpagetest.pageSummary', result, {url, group, location, connectivity}));
             aggregator.addToAggregate(result, connectivity, location);
           })
           .catch((err) => {

--- a/lib/support/url-source.js
+++ b/lib/support/url-source.js
@@ -3,6 +3,8 @@
 const lineReader = require('line-reader'),
   Promise = require('bluebird'),
   log = require('intel'),
+  urlParser = require('url'),
+  path = require('path'),
   messageMaker = require('../support/messageMaker');
 
 const make = messageMaker('url-reader').make;
@@ -27,17 +29,25 @@ module.exports = {
     const urls = this.urls.map((url) => url.trim());
 
     return Promise.reduce(urls, (urls, url) => {
-        if (url.startsWith('http')) {
-          urls.push(url);
-          return urls;
-        } else {
-          return linesFromFile(url)
-            .then((lines) => {
-              log.info('Will analyse %s URLs from %s', lines.length, url);
-              return urls.concat(lines);
-            });
-        }
-      }, [])
-      .each((url) => queue.postMessage(make('url', {}, {url})));
+      if (url.startsWith('http')) {
+        urls.push({url, group: urlParser.parse(url).hostname});
+        return urls;
+      } else {
+        const filePath = url;
+        return linesFromFile(filePath)
+          .then((lines) => {
+            log.info('Will analyse %s URLs from %s', lines.length, filePath);
+
+            for (let line of lines) {
+              urls.push({url: line, group: path.basename(filePath)});
+            }
+
+            return urls;
+          });
+      }
+    }, [])
+      .each((urlData) => {
+        queue.postMessage(make('url', {}, {url: urlData.url, group: urlData.group}))
+      });
   }
 };


### PR DESCRIPTION
Lay the foundation for grouping data from multiple urls. Tag all messages originating from a single url (browsertime.pageSummary, coach.pageSummary etc.) with a group. Aggregations based on group will be a breaking change, so that will follow in a later changeset.

Urls passed directly on the command line will be tagged with a group based on the domain. When passing urls via text files, the group will be generated from the file name.