### PR TITLE
Make it easy to get the result mapped to your local file system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM sitespeedio/webbrowsers
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/
-RUN npm install
 COPY . /usr/src/app
+RUN npm install -g
 
 COPY docker/scripts/start.sh /start.sh
 
 ENTRYPOINT ["/start.sh"]
+
+WORKDIR /sitespeed.io
+VOLUME /sitespeed.io

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -6,6 +6,6 @@ firefox --version
 
 echo 'Starting Xvfb ...'
 export DISPLAY=:99
-Xvfb :99  -ac -nolisten tcp -screen 0 1500x1200x16 &
+2>/dev/null 1>&2 Xvfb :99  -ac -nolisten tcp -screen 0 1500x1200x16 &
 sleep 1
-exec bin/sitespeed.js "$@"
+exec sitespeed.io "$@"


### PR DESCRIPTION
A couple of changes:
* Install sitespeed.io globally, so we can run it from whatever dir
* Set volume & workdir
* Use the same old /sitespeed.io for mapping (we can change that if we have better name)
