### PR TITLE
Added --summary option(s) to get text summary to stdout

### DIFF
--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -21,7 +21,7 @@ const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 class HTMLBuilder {
   constructor(context, options) {
     this.storageManager = context.storageManager;
-    this.timestamp = context.timestamp;
+    this.timestamp = context.timestamp.format(TIME_FORMAT);
     this.options = options;
     this.summaryPages = {};
     this.urlPages = {};
@@ -133,7 +133,7 @@ class HTMLBuilder {
       pageDescription: '',
       headers: this.summaryPages,
       version: packageInfo.version,
-      timestamp: this.timestamp.format(TIME_FORMAT),
+      timestamp: this.timestamp,
       h: helpers
     }, locals);
 
@@ -150,7 +150,7 @@ class HTMLBuilder {
       pageDescription: '',
       headers: this.summaryPages,
       version: packageInfo.version,
-      timestamp: this.timestamp.format(TIME_FORMAT),
+      timestamp: this.timestamp,
       h: helpers
     }, locals);
 
@@ -165,7 +165,7 @@ class HTMLBuilder {
       pageDescription: '',
       headers: this.summaryPages,
       version: packageInfo.version,
-      timestamp: this.timestamp.format(TIME_FORMAT),
+      timestamp: this.timestamp,
       h: helpers
     }, locals);
 

--- a/lib/plugins/html/index.js
+++ b/lib/plugins/html/index.js
@@ -104,6 +104,14 @@ module.exports = {
     }
   },
   close() {
-    return this.HTMLBuilder.renderHTML(this.options);
+    return this.HTMLBuilder.renderHTML(this.options)
+      .tap(this.buildSummary.bind(this));
+  },
+
+  buildSummary() {
+    if (!this.options.summary) return;
+    var textBuilder = require('./textBuilder'),
+      renderer = this.options.summaryDetail ? textBuilder.renderSummary : textBuilder.renderBriefSummary;
+    return renderer(this.HTMLBuilder, this.options);
   }
 };

--- a/lib/plugins/html/textBuilder.js
+++ b/lib/plugins/html/textBuilder.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const table = require('text-table'),
+  flatten = require('lodash.flatten'),
+  color = require('cli-color'),
+  h = require('./helpers'),
+  tableOpts = {
+    stringLength : color.getStrippedLength
+  },
+  drab = color.blackBright;
+
+
+function getMarker(label) {
+  return {ok: '√', warning: '!', error: '✗', info: ''}[label] || '';
+}
+
+function getColor(label) {
+  // ansi = {ok: 150, warning: 230, error: 217, info: ''}[b.label],
+  return {ok: 'green', warning: 'yellow', error: 'red', info: 'blackBright'}[label];
+}
+
+function getHeader(HTMLBuilder, options) {
+  const noPages = Object.keys(HTMLBuilder.urlPages).length;
+  return drab([
+    `${h.plural(noPages,'page')} analyzed for ${h.short(options._[0], 30)} `,
+    `(${h.plural(options.browsertime.iterations, 'run')}, `,
+    `${h.cap(options.browsertime.browser)}/${options.mobile ? 'mobile' : 'desktop'}/${options.connectivity})`
+    ].join(''));
+}
+
+function getBoxes(HTMLBuilder) {
+  return flatten(HTMLBuilder.summaryPages['index'].boxes);
+}
+
+// foo bar -> fb
+function abbr(str) {
+  if (/total|overall/i.test(str)) return str.trim();
+  return str.replace(/\w+\s?/g, (a) => a[0]);
+}
+
+function noop(a) {
+  return a;
+}
+
+module.exports = {
+  renderSummary(HTMLBuilder, options) {
+    let out = getHeader(HTMLBuilder, options);
+    let rows = getBoxes(HTMLBuilder).map((b) => {
+      var marker = getMarker(b.label),
+        c = getColor(b.label);
+      // color.xterm(ansi)(label),
+      return [ color[c](marker), color[c](b.name), color.bold(b.median) ];
+    });
+    rows.unshift(['', 'Score / Metric', 'Median'],['', '-------------', '------']);
+    options.summary = {out : `${out}\n` + table(rows, tableOpts)};
+  },
+
+  renderBriefSummary(HTMLBuilder, options) {
+    let out = getHeader(HTMLBuilder, options);
+    var lines = [],
+      scores = [],
+      size = '', reqs = '', rum = '';
+    getBoxes(HTMLBuilder).map((b) => {
+      var c =  getColor(b.label),
+        val = b.median,
+        name;
+      c = color[c] || noop;
+      if (/score$/i.test(b.url)) {
+        name = abbr(b.name.replace('score',''));
+        scores.push(c(`${name}:${val}`));
+      }
+      else if ('pageSize' === b.url) {
+        val = val.replace(' ',''); // 10 KB -> 10KB
+        size = `${val}`;
+      }
+      else if (/total requests/i.test(b.name)) {
+        reqs = `${val} reqs`;
+      }
+      else if (b.url === 'rumSpeedIndex') {
+        name = abbr(b.name);
+        rum = color.bold(`${name}: ${val}`);
+      }
+    });
+    lines.push(drab('Score: ') + scores.reverse().join(', '));
+    lines.push(size);
+    lines.push(reqs);
+    lines.push(rum);
+    options.summary = { out: `${out}\n` + lines.join(' / ') };
+  }
+};

--- a/lib/sitespeed.js
+++ b/lib/sitespeed.js
@@ -101,6 +101,7 @@ module.exports = {
       })
       .then((errors) => {
         log.info('Finished analysing %s', options._);
+        if (options.summary && options.summary.out) console.log(options.summary.out); // eslint-disable-line no-console
         return errors;
       })
       .catch((err) => {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -317,7 +317,18 @@ module.exports.parseCommandLine = function parseCommandLine() {
           group: 'HTML'
         })
     */
-
+  .option('summary', {
+    describe: 'Show brief text summary to stdout',
+    default: false,
+    type: 'boolean',
+    group: 'TEXT'
+  })
+  .option('summary-detail', {
+    describe: 'Show longer text summary to stdout',
+    default: false,
+    type: 'boolean',
+    group: 'TEXT'
+  })
   .option('mobile', {
       describe: 'Access pages as mobile a fake mobile device. Set UA and width/height. For Chrome it will use device Apple iPhone 6.',
       default: false,
@@ -384,6 +395,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
   if (argv.webpagetest.script) {
     argv.webpagetest.script= fs.readFileSync(path.resolve(argv.webpagetest.script), { encoding:'utf8' });
   }
+  if (argv.summaryDetail) argv.summary = true;
 
   return {
     url: argv._[0],

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "bluebird": "3.4.6",
     "browsertime": "1.0.0-beta.4",
+    "cli-color": "1.1.0",
     "concurrent-queue": "7.0.1",
     "fast-stats": "0.0.3",
     "fs-extra": "0.30.0",
@@ -78,6 +79,7 @@
     "lodash.chunk": "4.2.0",
     "lodash.clonedeep": "4.5.0",
     "lodash.difference": "4.5.0",
+    "lodash.flatten": "4.4.0",
     "lodash.foreach": "4.5.0",
     "lodash.get": "4.4.2",
     "lodash.merge": "4.6.0",
@@ -93,6 +95,7 @@
     "png-crop": "0.0.1",
     "pug": "2.0.0-beta6",
     "simplecrawler": "1.0.1",
+    "text-table": "0.2.0",
     "webcoach": "0.26.0",
     "webpagetest": "0.3.4",
     "yargs": "5.0.0"


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I'm making a ~~big~~ small change or adding functionality so ~~I've already~~ haven't opened an issue proposing the change to other contributors, so I ~~got~~ hope to get feedback on the idea ~~before~~ even though I took the time to write precious code :)
- [ ] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
This is a fairly small change to get summary results right on the cli console - useful for a quick look or when run as part of larger build process.  It is based on the main summary data in the HTML report.

--summary option:
![sitespeed-summary](https://cloud.githubusercontent.com/assets/233047/18705435/17513f7a-7fa3-11e6-8640-92d20b6438bc.JPG)

--summary-detail option:
![sitespeed-summary-detail](https://cloud.githubusercontent.com/assets/233047/18705439/1ae9adf2-7fa3-11e6-9dfa-b5d94d209b87.JPG)
