### PR TITLE
Process pug synchronously for better memory management - fixes #1219

### DIFF
--- a/lib/plugins/html/renderer.js
+++ b/lib/plugins/html/renderer.js
@@ -1,11 +1,7 @@
 'use strict';
 
 const pug = require('pug'),
-  fs = require('fs'),
-  Promise = require('bluebird'),
   path = require('path');
-
-Promise.promisifyAll(fs);
 
 const basePath = path.resolve(__dirname, 'templates');
 
@@ -16,23 +12,19 @@ function getTemplate(templateName) {
     templateName = templateName + '.pug';
 
   const template = templateCache[templateName];
-
   if (template) {
-    return Promise.resolve(template);
+    return template;
   }
 
   const filename = path.resolve(basePath, templateName);
-  return fs.readFileAsync(filename, 'utf-8')
-    .then((source) => {
-      const renderedTemplate = pug.compile(source, {'filename': filename});
-      templateCache[templateName] = renderedTemplate;
-      return renderedTemplate;
-    });
+  const renderedTemplate = pug.compileFile(filename);
+
+  templateCache[templateName] = renderedTemplate;
+  return renderedTemplate;
 }
 
 module.exports = {
   renderTemplate(templateName, locals) {
-    return getTemplate(templateName)
-      .then((template) => template(locals));
+    return getTemplate(templateName)(locals);
   }
 };


### PR DESCRIPTION
- [x] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [x] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`

Fixes #1219 and #1218.

There is no clear benefit in rendering async as each process is roughly of equal time -- so I don't think we losing anything going sync -- and gaining much better memory management.