### PR TITLE
Reuse exposed browsertime CLI options -- #1068

### DIFF
--- a/bin/sitespeed.js
+++ b/bin/sitespeed.js
@@ -7,7 +7,14 @@
 const cli = require('../lib/support/cli'),
   sitespeed = require('../lib/sitespeed'),
   Promise = require('bluebird'),
-  loader = require('../lib/support/pluginLoader');
+  loader = require('../lib/support/pluginLoader'),
+  browsertimeCli = require('browsertime').cli;
+
+let browsertimeOptions = browsertimeCli.getOptions({
+  group: 'Browser',
+  prefix: 'browsertime.',
+  forceGroup: true
+});
 
 require('longjohn');
 Promise.config({
@@ -17,7 +24,7 @@ Promise.config({
 
 process.exitCode = 1;
 
-let parsed = cli.parseCommandLine();
+let parsed = cli.parseCommandLine(browsertimeOptions);
 
 loader.parsePluginNames(parsed.explicitOptions)
   .then((pluginNames) => {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -8,7 +8,15 @@ let yargs = require('yargs'),
   fs = require('fs'),
   set = require('lodash.set');
 
-module.exports.parseCommandLine = function parseCommandLine() {
+
+function getBrowsertimeOptions(opts) {
+  if (!opts) return {};
+  let removeOptions = ['output', 'silent', 'har', 'skipHar', 'resultDir', 'config'];
+  removeOptions.forEach(p => delete opts['browsertime.' + p]);
+  return opts;
+}
+
+module.exports.parseCommandLine = function parseCommandLine(opts) {
   let parsed = yargs
     .usage('$0 [options] <url>/<file>')
     .require(1, 'urlOrFile')
@@ -25,92 +33,18 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'count'
     })
     /*
-     Browsertime cli options
+     Browsertime options
      */
-    .option('browsertime.browser', {
-      alias: ['b', 'browser'],
-      default: 'chrome',
-      describe: 'Choose which Browser to use when you test.',
-      choices: ['chrome', 'firefox'],
-      group: 'Browser'
-    })
-    .option('browsertime.iterations', {
-      alias: 'n',
-      default: 3,
-      describe: 'How many times you want to test each page',
-      group: 'Browser'
-    })
-    .option('browsertime.delay', {
-      describe: 'Delay between runs, in milliseconds',
-      group: 'Browser'
-    })
-    .option('browsertime.connectivity.profile', {
-      alias: ['c', 'connectivity'],
-      default: 'native',
-      choices: ['3g', '3gfast', '3gslow', '2g', 'cable', 'native', 'custom'],
-      describe: 'The connectivity profile. Default connectivity engine is tsproxy',
-      group: 'Browser'
-    })
-    .option('browsertime.connectivity.config', {
-      default: undefined,
-      describe: 'This option requires --connectivity.profile be set to "custom". Takes a JSON object with the keys downstreamKbps, upstreamKbps and latency. \"{\\\"downstreamKbps\\\":6000, \\\"upstreamKbps\\\": 6000, \\\"latency\\\": 200}\"',
-      group: 'Browser'
-    })
-    .option('browsertime.connectivity.tsproxy.port', {
-      default: 1080,
-      describe: 'The port used for ts proxy',
-      group: 'Browser'
-    })
-  .option('browsertime.connectivity.engine', {
-      default: 'tsproxy',
-      choices: ['tc', 'tsproxy'],
-      describe: 'The engine for connectivity. Tsproxy needs Python 2.7. TC needs tc, modprobe and ip installed to work. Running tc inside Docker needs modprobe to run outside the container.',
-      group: 'Browser'
-    })
-    .option('browsertime.pageCompleteCheck', {
-      describe: 'Supply javascript that decides when a browser run is finished. Use it to fetch timings happening after the loadEventEnd.',
-      group: 'Browser'
-    })
-    .option('browsertime.script', {
-      describe: 'Add custom Javascript to run on page (that returns a number). Note that --script can be passed multiple times if you want to collect multiple metrics. The metrics will automatically be pushed to the summary/detailed summary and each individual page + sent to Graphite/InfluxDB.',
-      alias: ['script'],
-      group: 'Browser'
-    })
-    .option('browsertime.selenium.url', {
-      describe: 'Configure the path to the Selenium server when fetching timings using browsers. If not configured the supplied NodeJS/Selenium version is used.',
-      group: 'Browser'
-    })
-    .option('browsertime.viewPort', {
-      default: '1366x708',
-      describe: 'The view port, the page viewport size WidthxHeight like 400x300',
-      group: 'Browser'
-    })
-    .option('browsertime.userAgent', {
-      describe: 'The full User Agent string, defaults to the user agent used by the browsertime.browser option.',
-      group: 'Browser'
-    })
-    .option('browsertime.preScript', {
-      alias: 'preScript',
-      describe: 'Task(s) to run before you test your URL (use it for login etc). Note that --preScript can be passed multiple times.',
-      group: 'Browser'
-    })
-    .option('browsertime.postScript', {
-      alias: 'postScript',
-      describe: 'Path to JS file for any postTasks that need to be executed.',
-      group: 'Browser'
-    })
-    .option('browsertime.delay', {
-      type: 'number',
-      default: 0,
-      describe: 'Delay between runs, in milliseconds'
-    })
-    .option('browsertime.pageCompleteCheck', {
-      describe: 'Javascript snippet is repeatedly queried to see if page has completed loading (indicated by the script returning true)'
-    })
-
-  /*
-   Crawler options
-   */
+    .options(getBrowsertimeOptions(opts))
+    .alias('browsertime.browser', 'browser')
+    .alias('browsertime.preScript', 'preScript')
+    .alias('browsertime.script', 'script')
+    .alias('browsertime.postScript', 'postScript')
+    .alias('browsertime.connectivity.profile', 'connectivity')
+    .default('browsertime.viewPort', '1366x708')
+    /*
+     Crawler options
+     */
   .option('crawler.depth', {
       alias: 'd',
       describe: 'How deep to crawl (1=only one page, 2=include links from first page, etc.)',


### PR DESCRIPTION
- [x] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [x] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`

Addresses #1068.  Please note this PR depends on [browsertime PR-191](https://github.com/sitespeedio/browsertime/pull/191).

Double check the 'removeOptions' and alises list.
