### PR TITLE
Change toplist data structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # CHANGELOG - sitespeed.io
 
+## Unreleased
+-------------------------
+### Changed
+* The data structure (internally) for toplists is changed so they can be sent to Graphite and used in a budget. Messages for largest assets was renamed from assets.aggregateSizePerContentType to assets.largest. Also send the largest individual size of an image to Graphite by default.
+
 ## 4.0.0-beta.4 2016-09-29
 -------------------------
 ### Fixed
-* Pug templates never was a cache hit, so generating the HTML took a lot of extra memory #1218 #1219 thank @moos for the PR #1220 
-* Fix crash for pages that didn't set the last-modified http header #1221 
+* Pug templates never was a cache hit, so generating the HTML took a lot of extra memory #1218 #1219 thank @moos for the PR #1220
+* Fix crash for pages that didn't set the last-modified http header #1221
 * WebPageTest data rendering was broken since 4.0.0-beta.1.
 
 ### Added

--- a/lib/plugins/assets/index.js
+++ b/lib/plugins/assets/index.js
@@ -3,9 +3,14 @@
 let messageMaker = require('../../support/messageMaker'),
   path = require('path'),
   isEmpty = require('lodash.isempty'),
+  filterRegistry = require('../../support/filterRegistry'),
   aggregator = require('./aggregator');
 
 const make = messageMaker('assets').make;
+
+const DEFAULT_METRICS_LARGEST_ASSETS = [
+  'total.image.0.transferSize'
+];
 
 module.exports = {
   name() {
@@ -13,6 +18,7 @@ module.exports = {
   },
   open(context) {
     this.context = context;
+    filterRegistry.registerFilterForType(DEFAULT_METRICS_LARGEST_ASSETS, 'assets.largest');
   },
   processMessage(message, queue) {
     switch (message.type) {
@@ -35,7 +41,7 @@ module.exports = {
               const d = {};
               d[group] = {};
               d[group][contentType] = summary.size[group][contentType];
-              queue.postMessage(make('assets.aggregateSizePerContentType', d));
+              queue.postMessage(make('assets.largest', d));
             }
             const slow = {};
             slow[group] = summary.timing[group];
@@ -45,7 +51,7 @@ module.exports = {
           for (let contentType of Object.keys(summary.size.total)) {
             const data = {};
             data[contentType] = summary.size.total[contentType];
-            queue.postMessage(make('assets.aggregateSizePerContentType', contentType));
+            queue.postMessage(make('assets.largest', contentType));
           }
 
           queue.postMessage(make('assets.slowest', summary.timing.total));

--- a/lib/plugins/assets/index.js
+++ b/lib/plugins/assets/index.js
@@ -27,17 +27,25 @@ module.exports = {
         const summary = aggregator.summarize();
         if (!isEmpty(summary)) {
           for (let group of Object.keys(summary.groups)) {
-            queue.postMessage(make('assets.aggregate', summary.groups[group], {group}));
+            const data = {};
+            data[group] = summary.groups[group];
+            queue.postMessage(make('assets.aggregate', data));
 
             for (let contentType of Object.keys(summary.size[group])) {
-              queue.postMessage(make('assets.aggregateSizePerContentType', summary.size[group][contentType], {group, contentType}));
+              const d = {};
+              d[group] = {};
+              d[group][contentType] = summary.size[group][contentType];
+              queue.postMessage(make('assets.aggregateSizePerContentType', d));
             }
-
-            queue.postMessage(make('assets.slowest', summary.timing[group], {group}));
+            const slow = {};
+            slow[group] = summary.timing[group];
+            queue.postMessage(make('assets.slowest', slow));
           }
 
           for (let contentType of Object.keys(summary.size.total)) {
-            queue.postMessage(make('assets.aggregateSizePerContentType', summary.size.total[contentType], {contentType}));
+            const data = {};
+            data[contentType] = summary.size.total[contentType];
+            queue.postMessage(make('assets.aggregateSizePerContentType', contentType));
           }
 
           queue.postMessage(make('assets.slowest', summary.timing.total));

--- a/lib/plugins/datacollector/index.js
+++ b/lib/plugins/datacollector/index.js
@@ -65,7 +65,7 @@ module.exports = {
         } else return;
       }
 
-      case 'assets.aggregateSizePerContentType':
+      case 'assets.largest':
       {
         if (message.data.total) {
           const assetsBySize= {};

--- a/lib/plugins/datacollector/index.js
+++ b/lib/plugins/datacollector/index.js
@@ -46,24 +46,31 @@ module.exports = {
 
       case 'assets.aggregate':
       {
-        const assetList = reduce(message.data, (assetList, asset) => {
-          assetList.push(asset);
-          return assetList;
-        }, []);
+        if (message.data.total) {
+          const assetList = reduce(message.data.total, (assetList, asset) => {
+            assetList.push(asset);
+            return assetList;
+          }, []);
 
-        const count = 20,
-          fullCount = Object.keys(assetList).length,
-          topAssets = assetList
+          const count = 20,
+            fullCount = Object.keys(assetList).length,
+            topAssets = assetList
             .sort((a, b) => b.requestCount - a.requestCount)
             .splice(0, count);
-        return dataCollector.addDataForSummaryPage('assets', {topAssets, count, fullCount});
+          return dataCollector.addDataForSummaryPage('assets', {
+            topAssets,
+            count,
+            fullCount
+          });
+        } else return;
       }
 
       case 'assets.aggregateSizePerContentType':
       {
-        if (!message.group) {
+        if (message.data.total) {
           const assetsBySize= {};
-          assetsBySize[message.contentType] = message.data;
+          const contentType = Object.keys(message.data.total)[0];
+          assetsBySize[contentType] = message.data.total[contentType];
           return dataCollector.addDataForSummaryPage('toplist', {assetsBySize});
         }
         else return;
@@ -71,8 +78,8 @@ module.exports = {
 
       case 'assets.slowest':
       {
-        if (!message.group) {
-          const slowestAssets = message.data;
+        if (message.data.total) {
+          const slowestAssets = message.data.total;
           return dataCollector.addDataForSummaryPage('toplist', {slowestAssets});
         }
         else return;

--- a/lib/plugins/metrics/index.js
+++ b/lib/plugins/metrics/index.js
@@ -54,7 +54,7 @@ module.exports = {
   },
   processMessage(message) {
     if (this.options.metrics && this.options.metrics.list) {
-      if (!(message.type.endsWith('.summary') || message.type.endsWith('.pageSummary')))
+      if (!(message.type.endsWith('.summary') || message.type.endsWith('.pageSummary') || message.type.endsWith('assets.largest')))
         return;
       let flattenMess = flatten.flattenMessageData(message);
       for (let key of Object.keys(flattenMess)) {


### PR DESCRIPTION
The old structure was made in a hurry and only usable for HTML output. The new structure opens up so we can send the toplist to Graphite or use in a budget. You can now graph the largest size for an asset content type or make budget that's breaks if we have one image larger than X.