### PR TITLE
WIP: Inital take on adding a plugin for Elasticsearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .vscode
 sitespeed-result
 configs
+.idea

--- a/lib/plugins/elasticsearch/datagenerator.js
+++ b/lib/plugins/elasticsearch/datagenerator.js
@@ -1,0 +1,18 @@
+const log = require('intel');
+
+module.exports = dataGenerator;
+
+function dataGenerator(type) {
+  const filters = {
+  };
+
+  if (type in filters) {
+    return filters[type];
+  }
+
+  return (sender, timestamp, message) => {
+    log.debug(`No custom data generator is available for ${type}`);
+    sender.send(message);
+  }
+}
+

--- a/lib/plugins/elasticsearch/index.js
+++ b/lib/plugins/elasticsearch/index.js
@@ -1,0 +1,39 @@
+const path = require('path');
+const Sender = require('./sender');
+const filterRegistry = require('../../support/filterRegistry');
+const isEmpty = require('lodash.isempty');
+const log = require('intel');
+const throwIfMissing = require('../../support/util').throwIfMissing;
+const dataGenerator = require('./datagenerator');
+
+module.exports = {
+  name() {
+    return path.basename(__dirname);
+  },
+  open(context, options) {
+    throwIfMissing(options.elasticsearch, ['host', 'port'], 'elasticsearch');
+
+    const opts = options.elasticsearch || {};
+    this.sender = new Sender(opts.host, opts.port, context.timestamp);
+  },
+  processMessage(message) {
+    if (!(message.type.endsWith('.summary') || message.type.endsWith('.pageSummary')))
+      return;
+
+    // we only sends individual groups to Elastic
+    // NOTE: this is ported straight from the Graphite plugin
+    if (message.group === 'total')  {
+      return;
+    }
+
+    const filteredMessage = filterRegistry.filterMessage(message);
+
+    if (isEmpty(filteredMessage.data)) {
+      log.info(`Removed ${filteredMessage.type} since data is empty after filtering.`);
+      return;
+    }
+
+    return dataGenerator(filteredMessage.type)(this.sender, this.timestamp, filteredMessage);
+  }
+};
+

--- a/lib/plugins/elasticsearch/sender.js
+++ b/lib/plugins/elasticsearch/sender.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const elasticsearch = require('elasticsearch');
+
+class ElasticsearchSender {
+  constructor(host, port, timestamp) {
+    this.timestamp = timestamp;
+    this.client = new elasticsearch.Client({
+      host: `${host}:${port}`,
+      log: 'info'
+    });
+  }
+
+  send(message) {
+    return this.client.create({
+      index: `sitespeed-${this.timestamp.format("YYYY.MM.DD")}-${message.type.toLowerCase()}`,
+      type: message.type.toLowerCase(),
+      id: message.uuid,
+      timestamp: this.timestamp.toDate(),
+      body: message
+    });
+  }
+}
+
+module.exports = ElasticsearchSender;

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -137,6 +137,16 @@ module.exports.parseCommandLine = function parseCommandLine() {
     /**
      Graphite cli option
      */
+    .option('elasticsearch.host', {
+      default: 'localhost',
+      describe: 'The Elasticsearch host to store captured metrics',
+      group: 'Elasticsearch'
+    })
+    .option('elasticsearch.port', {
+      default: 9200,
+      describe: 'The Elasticsearch port to store captured metrics',
+      group: 'Elasticsearch'
+    })
     .option('graphite.host', {
       describe: 'The Graphite host used to store captured metrics.',
       group: 'Graphite'

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "browsertime": "1.0.0-beta.6",
     "cli-color": "1.1.0",
     "concurrent-queue": "7.0.1",
+    "elasticsearch": "^11.0.1",
     "fast-stats": "0.0.3",
     "fs-extra": "0.30.0",
     "gpagespeed": "3.0.0",

--- a/tools/elasticsearch/docker-compose.yml
+++ b/tools/elasticsearch/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+    kibana:
+        image: kibana:5.0.0-alpha5
+        depends_on:
+            - elasticsearch
+        links:
+            - elasticsearch
+        ports:
+            - "5601:5601"
+    elasticsearch:
+        image: elasticsearch:5.0.0-alpha5
+        ports:
+            - "9200:9200"
+            - "9300:9300"
+        environment:
+            ES_JAVA_OPTS: -Xms2g -Xmx2g


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.
- [x] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code: #1062 
- [ ] Check that your change/fix has corresponding unit tests (if applicable)
  This pull request is not intended to merge in its current state, but more to gather requirements how to write a proper Eleasticsearch plugin.
- [x] Squash commits so it looks sane
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`
### Description

This pull request is just about to get a feeling about what it would require to write a proper plugin for sending data to Elasticsearch. The Eleasticsearch plugin is ported straight from the Graphite plugin and some questions has emerged that I think can be valuable before trying implement a proper plugin that might be used as requirements for #1062.
1. Removal of data
   In the Graphite plugin we're removing lots of data, with:

```
    if (message.group === 'total')  {
      return;
    }

    const filteredMessage = filterRegistry.filterMessage(message);
    if (isEmpty(filteredMessage.data)) {
      log.info(`Removed ${filteredMessage.type} since data is empty after filtering.`);
      return;
    }
```

Will this hold true for the Elasticsearch plugin as well?
1. Destructing of messages
   At the moment I've just saved the messages as they are in separate indices but this can be problematic for aggregation of keys e.g. listing all advices together over time. Destructing of message will be even more important if we're not removing data in 1. There are also some fields in the messages that's a bit redundant e.g. `_type` and `type` and all data is prefixed with `data`, that might be a good thing but needs clarification.
2. Indices and Type
   Elasticsearch is a little bit different to Graphite/Influx with indices and types and different data types cannot overlap within the same index. In this PR I've just used a specific index per elastic and sitespeed data type.
3. Default pattern for index names
   I've just applied index name pattern similar to the one for logstash to enable search over time, retention and searching over all data types, but this needs to be able to be configured and possible evaluated depending on 2 and 3 above.  

```
`sitespeed-${this.timestamp.format("YYYY.MM.DD")}-${message.type.toLowerCase()}`
```
1. Mappings
   If we should add support we should probably add a dynamic template as a sensible default, to make sure that the indices are mapped correctly.

If you are interested and if we can find answers to the questions above I'm willing to continue the work and add tests for the implementation!
### How to run

First of all we'll need to start Elasticsearch and Kibana

```
cd tools/elasticsearch
docker-compose up
```

Then we'll need to activate the elasticsearch plugin and execute sitespeed.

```
bin/sitespeed.js --plugins.load elasticsearch --elk -n 2 -d 1 https://www.sitespeed.io/
```

Spiked implementation of #1062 
