### PR TITLE
Should only check the slack channel prefix if the channel is defined.

### DIFF
--- a/lib/plugins/slack/index.js
+++ b/lib/plugins/slack/index.js
@@ -29,7 +29,7 @@ module.exports = {
     const slack = new Slack(this.options.hookUrl);
     let logo = "https://www.sitespeed.io/img/slack/sitespeed-logo-slack.png";
 
-    if (!this.options.channel.startsWith('#')) {
+    if (typeof this.options.channel !== 'undefined' && !this.options.channel.startsWith('#')) {
       this.options.channel = '#' + this.options.channel;
     }
 


### PR DESCRIPTION
### Description
Since the default channel has been removed we cannot directly check if the channel starts with `#`, we'll need to make sure that the channel is defined before.

#1234
