### PR TITLE
Remove additional slash to rootPath in pugs

### DIFF
--- a/lib/plugins/html/templates/url/browsertime/index.pug
+++ b/lib/plugins/html/templates/url/browsertime/index.pug
@@ -4,7 +4,7 @@ p.small Collect timing metrics from your browser.
 - var browsertime = pageInfo.data.browsertime.run || pageInfo.data.browsertime.pageSummary.browserScripts[run]
 - var timings = browsertime.timings;
 - var visualMetrics = browsertime.visualMetrics;
-- baseHelpURL = rootPath + '/help.html#';
+- baseHelpURL = rootPath + 'help.html#';
 table
   tr
     th name

--- a/lib/plugins/html/templates/url/tabs.pug
+++ b/lib/plugins/html/templates/url/tabs.pug
@@ -1,25 +1,25 @@
 a#summary(href='#summary', data-name='tabs', onclick='return selectTab(this)', if-not-selected)
-  img(src= rootPath + '/img/summary64.png', height=32, alt='Summary')
+  img(src= rootPath + 'img/summary64.png', height=32, alt='Summary')
   | Summary
 if d.coach && (d.coach.pageSummary || d.coach.run)
   a#coach(href='#coach', data-name='tabs', onclick='return selectTab(this)')
-    img(src= rootPath + '/img/coach64.png', height=32, alt='Coach')
+    img(src= rootPath + 'img/coach64.png', height=32, alt='Coach')
     | Coach
 if d.browsertime && (d.browsertime.pageSummary || d.browsertime.run)
   a#browsertime(href='#browsertime', data-name='tabs', onclick='return selectTab(this)')
-    img(src= rootPath + '/img/browsertime64.png', height=32, alt='Browsertime')
+    img(src= rootPath + 'img/browsertime64.png', height=32, alt='Browsertime')
     | Browsertime
 if d.pagexray && (d.pagexray.pageSummary || d.pagexray.run)
   a#pagexray(href='#pagexray', data-name='tabs', onclick='return selectTab(this)')
-    img(src= rootPath + '/img/xray64.png', height=32, alt='PageXray')
+    img(src= rootPath + 'img/xray64.png', height=32, alt='PageXray')
     | PageXray
 if d.webpagetest || (d.webpagetest && d.webpagetest.run)
   a#webpagetest(href='#webpagetest', data-name='tabs', onclick='return selectTab(this)')
-    img(src= rootPath + '/img/webpagetest64.png', height=32, alt='WebPageTest')
+    img(src= rootPath + 'img/webpagetest64.png', height=32, alt='WebPageTest')
     | WebPageTest
 if d.gpsi
   a#gpsi(href='#gpsi', data-name='tabs', onclick='return selectTab(this)')
-    img(src= rootPath + '/img/gpsi64.png', height=32, alt='Google Page Speed Insights')
+    img(src= rootPath + 'img/gpsi64.png', height=32, alt='Google Page Speed Insights')
     | GPSI
 
 script(type='text/javascript').

--- a/lib/plugins/html/templates/url/waterfall/index.pug
+++ b/lib/plugins/html/templates/url/waterfall/index.pug
@@ -16,7 +16,7 @@ else
   a(href='data/browsertime.har') Download
   |  the HAR file.
 #output
-script(src= rootPath + '/js/perf-cascade.min.js')
+script(src= rootPath + 'js/perf-cascade.min.js')
 script(type='text/javascript').
   var outputHolderEl = document.getElementById("output");
   var pageSelectorEl = document.getElementById("page-selector");


### PR DESCRIPTION
### Description
The rootPath ends with a trailing slash and adding an extra slash in the pugs will create an invalid url for some web servers e.g. S3

There's a unit test that asserts that the rootUrl should end with a slash and I'm assuming that it's correct. I've removed the appending slash from the locations that I can find.

<img width="734" alt="screen shot 2016-10-13 at 19 23 00" src="https://cloud.githubusercontent.com/assets/124032/19364265/bef3418c-918d-11e6-922e-d6342e18703c.png">
