### PR TITLE
Don't run as root inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
 FROM sitespeedio/webbrowsers:firefox-49.0-chrome-54.0
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+RUN useradd --user-group --create-home --shell /bin/false app
 
-COPY package.json /usr/src/app/
+ENV HOME=/home/app
+
+COPY package.json $HOME
+RUN chown -R app:app $HOME/*
+
+USER app
+WORKDIR $HOME
 RUN npm install --production
-COPY . /usr/src/app
+
+USER root
+COPY . $HOME
+
+RUN chown -R app:app $HOME/*
+USER app
 
 COPY docker/scripts/start.sh /start.sh
 

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -10,4 +10,4 @@ echo 'Starting Xvfb ...'
 export DISPLAY=:99
 2>/dev/null 1>&2 Xvfb :99  -ac -nolisten tcp -screen 0 1500x1200x16 &
 sleep 1
-exec node --max-old-space-size=$MAX_OLD_SPACE_SIZE /usr/src/app/bin/sitespeed.js "$@"
+exec node --max-old-space-size=$MAX_OLD_SPACE_SIZE /home/app/bin/sitespeed.js "$@"


### PR DESCRIPTION
Been following http://jdlm.info/articles/2016/03/06/lessons-building-node-app-docker.html  to not run as root inside the container.  I've seen when I run on Ubuntu not as root, that the owner of the files in sitespeed-result is ... root!  I've tested this locally on my Mac but not on Ubuntu, could you try it out @beenanner ?

