### PR TITLE
Fix header level for 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG - sitespeed.io
-# 4.0.0 2016-10-27
+## 4.0.0 2016-10-27
 Version 4.0 is a ground up rewrite for Node.js 6.9.1 and newer. It builds on all our experience since shipping 3.0 in December 2014, the first version to use Node.js.
 
 * We support HTTP/2! In 3.X we used PhantomJS and a modified version of YSlow to analyze best practice rules. We also had BrowserMobProxy in front of our browsers that made it impossible to collect metrics using H2. We now use the coach and Firefox/Chrome without a proxy. That makes it easier for us to adapt to browser changes and changes in best practices.


### PR DESCRIPTION
This way it will not break automatic parsers like https://allmychanges.com/p/javascript/sitespeed.io/