### PR TITLE
Fix link in CI section

### DIFF
--- a/docs/documentation/sitespeed.io/continuous-integration/index.md
+++ b/docs/documentation/sitespeed.io/continuous-integration/index.md
@@ -19,7 +19,7 @@ twitterdescription: Use sitespeed.io in your Continuous Integration setup.
 
 Use sitespeed.io to keep track of what is happening with your site making sure that you don’t break the performance best practice rules before your change make it to production. You can even leverage budgets to break your build if your page has too many assets, they are too big or too slow. If you use WebPageTest you can even use those metrics to break a build.
 
-You can define your own [budget file](({{site.baseurl}}/documentation/sitespeed.io/performance-budget/)) with rules on when to break your build. This budget will return an error code status after the run or you can choose to output JUnit XML and TAP.
+You can define your own [budget file](../performance-budget/#the-budget-file) with rules on when to break your build. This budget will return an error code status after the run or you can choose to output JUnit XML and TAP.
 
 ## Jenkins
 The easiest way to run in Jenkins is to use the pre built Docker containers. You can run an installed npm version too, but then you will need to setup browsers and use the [Xvfb plugin](https://wiki.jenkins-ci.org/display/JENKINS/Xvfb+Plugin) to make the browsers run in headless mode.


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [ ] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs
- [ ] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
Fix a small typo in documentation for continuous integration. Currently the link points to `https://www.sitespeed.io/documentation/sitespeed.io/continuous-integration/(/documentation/sitespeed.io/performance-budget/)`

I'm not sure if the relative path is preferred but i saw this in other places so trying to stick to that.


Thank you for making sitespeed.io even better!
_Thank you for building an amazing tool!_
