### PR TITLE
Fix spelling error in The Coach link

### DIFF
--- a/docs/_includes/index/box3.md
+++ b/docs/_includes/index/box3.md
@@ -2,4 +2,4 @@
 * * *
 [<img src="{{site.baseurl}}/img/logos/coach.png" class="pull-left img-big" alt="I'm the coach" width="155" height="180">]({{site.baseurl}}/documentation/coach)
 
-The Godfather of web performance tools [YSlow is dead](http://4.bp.blogspot.com/-gEqiZsYvoV4/T2FM-E7UvcI/AAAAAAAAIeE/Sg0GxV2hVLE/s1600/PDVD_138.BMP). It died a couple of years after the first release and finally there's something new that can guide you in the web performance jungle: [The Coach]({{site.baseurl}}/documentaion/coach/) gives you advice on how you can make your web page more performant.
+The Godfather of web performance tools [YSlow is dead](http://4.bp.blogspot.com/-gEqiZsYvoV4/T2FM-E7UvcI/AAAAAAAAIeE/Sg0GxV2hVLE/s1600/PDVD_138.BMP). It died a couple of years after the first release and finally there's something new that can guide you in the web performance jungle: [The Coach]({{site.baseurl}}/documentation/coach/) gives you advice on how you can make your web page more performant.


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io

- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
The Coach-href on the startpage was misspelled. It links to /documentaion/coach/ instead of /documentation/coach/
