### PR TITLE
Fixing issue with disabling browsertime plugin #1398

### DIFF
--- a/lib/plugins/html/templates/url/index.pug
+++ b/lib/plugins/html/templates/url/index.pug
@@ -68,7 +68,7 @@ block content
                 td #{d.browsertime.pageSummary.statistics.timings.rumSpeedIndex.median}
 
         .one-half.column
-            if d.browsertime.pageSummary.screenshots
+            if d.browsertime && d.browsertime.pageSummary.screenshots
               - var width = options.mobile ? 150 : '100%';
               a(href='data/screenshots/0.png')
                 img.screenshot(src='data/screenshots/0.png', width=width, alt='Screenshot of run 0')

--- a/lib/plugins/html/templates/url/webpagetest/index.pug
+++ b/lib/plugins/html/templates/url/webpagetest/index.pug
@@ -1,3 +1,5 @@
+include ../../_tableMixins
+
 a
 h2 WebPageTest
 p.small Metrics & data collected using WebPageTest.org (or your private instance).


### PR DESCRIPTION
#Minor bug fixes for webpagetest table mixin and making sure browsertime is enabled before using it in the html output. Fixes #1398 

Tested with: `bin/sitespeed.js https://www.sitespeed.io/ -n 1 --plugins.disable browsertime  <insert all the private webpagetest options>` 