### PR TITLE
usage of --shm-size requires at least docker 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Video (if you use the Docker version):
 Version 4.0 is a ground-up rewrite for node.js 6.9.1 and newer. It builds on all our experience since shipping 3.0 in December 2014,
 the first version to use node.js.
 
-Using Docker:
+Using Docker (requires 1.10+):
 
 ```bash
 $ docker run --privileged --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io --video --speedIndex https://www.sitespeed.io/


### PR DESCRIPTION
the --shm-size option was added with docker 1.10. mention the min docker version in the readme.

see https://github.com/docker/docker/pull/16168