### PR TITLE
#1422 Make it possible to insert a direct string with a wpt script into webpagetest.script

### DIFF
--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -283,7 +283,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
       group: 'WebPageTest'
     })
     .option('webpagetest.script', {
-      describe: 'Path to a script file',
+      describe: 'Path to a script file or an already parsed string with the script',
       group: 'WebPageTest'
     })
     /** Google Page Speed Insights */
@@ -374,6 +374,17 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .coerce('budget', function(arg) {
       return JSON.parse(fs.readFileSync(arg, 'utf8'))
     })
+    .coerce('webpagetest', function(arg) {
+      if (fs.existsSync(path.resolve(arg.script))) {
+        arg.script = fs.readFileSync(path.resolve(arg.script), 'utf8');
+      } else {
+        // because the escaped characters are passed re-escaped from the console
+        arg.script = arg.script.split('\\t').join('\t');
+        arg.script = arg.script.split('\\n').join('\n');
+      }
+
+      return arg;
+    })
     //     .describe('browser', 'Specify browser')
     .wrap(yargs.terminalWidth())
     //  .check(validateInput)
@@ -406,11 +417,6 @@ module.exports.parseCommandLine = function parseCommandLine() {
 
   if (argv.webpagetest.custom) {
     argv.webpagetest.custom = fs.readFileSync(path.resolve(argv.webpagetest.custom), {
-      encoding: 'utf8'
-    });
-  }
-  if (argv.webpagetest.script) {
-    argv.webpagetest.script = fs.readFileSync(path.resolve(argv.webpagetest.script), {
       encoding: 'utf8'
     });
   }

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -375,6 +375,10 @@ module.exports.parseCommandLine = function parseCommandLine() {
       return JSON.parse(fs.readFileSync(arg, 'utf8'))
     })
     .coerce('webpagetest', function(arg) {
+      if (!arg.hasOwnProperty('script')) {
+        return arg;
+      }
+
       if (fs.existsSync(path.resolve(arg.script))) {
         arg.script = fs.readFileSync(path.resolve(arg.script), 'utf8');
       } else {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
     "uuid": "^3.0.0",
     "webcoach": "0.30.4",
     "webpagetest": "0.3.4",
-    "yargs": "5.0.0"
+    "yargs": "6.6.0"
   }
 }


### PR DESCRIPTION
This enables using a direct WebPageTest script string as the input for the `--webpagetest.script`  flag.

Example:
```
// NEW
./bin/sitespeed.js --webpagetest.key <key> --webpagetest.script "logData\t0\nnavigate\thttp://www.jeroenvdb.be\nlogData\t1\nnavigate\thttp://www.demorgen.be" http://www.jeroenvdb.be

// NEW
./bin/sitespeed.js --webpagetest.key <key> --webpagetest.script  "logData\t0\nnavigate\thttp://www.demorgen.be\nlogData\t1\nnavigate\t{{{URL}}}" http://www.jeroenvdb.be

// still possible to use a script from path
./bin/sitespeed.js --webpagetest.key <key> --webpagetest.script ./wpt-script.txt
```

