### PR TITLE
Making key and secret optional parameters

### DIFF
--- a/lib/plugins/s3/index.js
+++ b/lib/plugins/s3/index.js
@@ -11,17 +11,17 @@ Promise.promisifyAll(fs);
 
 
 function getClient(options) {
-  return s3.createClient({
-    maxAsyncS3: 20, // this is the default
-    s3RetryCount: 3, // this is the default
-    s3RetryDelay: 1000, // this is the default
-    multipartUploadThreshold: 20971520, // this is the default (20 MB)
-    multipartUploadSize: 15728640, // this is the default (15 MB)
-    s3Options: {
-      accessKeyId: options.s3.key,
-      secretAccessKey: options.s3.secret
-    }
-  });
+  let $client = s3.createClient();
+  if (options.s3.key && options.s3.secret) {
+    $client = s3.createClient({
+      s3Options: {
+        accessKeyId: options.s3.key,
+        secretAccessKey: options.s3.secret
+      }
+    });
+  }
+
+  return $client
 }
 
 module.exports = {
@@ -29,7 +29,10 @@ module.exports = {
     return path.basename(__dirname);
   },
   open(context, options) {
-    throwIfMissing(options.s3, ['secret', 'key', 'bucketname'], 's3');
+    throwIfMissing(options.s3, ['bucketname'], 's3');
+    if (options.s3.key || options.s3.secret) {
+      throwIfMissing(options.s3, ['key', 'secret'], 's3');
+    }
     this.storageManager = context.storageManager;
   },
 


### PR DESCRIPTION
This is so a user can take advantage of CredentialProviderChain as mentioned in #1349

Example:
```
export AWS_ACCESS_KEY_ID=xxxxx
export AWS_SECRET_ACCESS_KEY=xxxx
bin/sitespeed.js -n 1 --s3.bucketname somebucket https://www.sitespeed.io

```