### PR TITLE
Allow budget to be specified inline on cli.

### DIFF
--- a/lib/plugins/budget/index.js
+++ b/lib/plugins/budget/index.js
@@ -25,7 +25,7 @@ module.exports = {
       case 'pagexray.pageSummary':
       case 'coach.pageSummary':
         {
-          verify(message, this.result, this.options);
+          verify(message, this.result, this.options.budget.file);
           return;
         }
     }

--- a/lib/plugins/budget/index.js
+++ b/lib/plugins/budget/index.js
@@ -25,7 +25,7 @@ module.exports = {
       case 'pagexray.pageSummary':
       case 'coach.pageSummary':
         {
-          verify(message, this.result, this.options.budget.file);
+          verify(message, this.result, this.options.budget.config);
           return;
         }
     }

--- a/lib/plugins/budget/verify.js
+++ b/lib/plugins/budget/verify.js
@@ -27,8 +27,7 @@ function getHelperFunction(metric) {
 }
 
 module.exports = {
-  verify(message, result, options) {
-    const budgets = options.budget;
+  verify(message, result, budgets) {
     const failing = [];
     const working = [];
     // do we have an etry in the budget for this kind of message?

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -190,8 +190,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       group: 'Plugins'
     })
     /** Budget */
-    .option('budget.file', {
+    .option('budget.configPath', {
       describe: 'Path to the JSON budget file.',
+      group: 'Budget'
+    })
+    .option('budget.config', {
+      describe: 'The JSON budget config as a string.',
       group: 'Budget'
     })
     .option('budget.output', {
@@ -394,10 +398,13 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .alias('help', 'h')
     .config('config')
     .alias('version', 'V')
+    .conflicts('budget.config', 'budget.configPath')
     .coerce('budget', function(arg) {
-      if (arg === Object(arg) && !Array.isArray(arg)) {
-        if (arg.hasOwnProperty('file')) {
-          arg.file = JSON.parse(fs.readFileSync(arg.file, 'utf8'))
+      if (typeof arg === 'object' && !Array.isArray(arg)) {
+        if (arg.configPath) {
+          arg.config = JSON.parse(fs.readFileSync(arg.configPath, 'utf8'));
+        } else if (arg.config){
+          arg.config = JSON.parse(arg.config);
         }
         return arg;
       } else {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -190,7 +190,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
       group: 'Plugins'
     })
     /** Budget */
-    .option('budget', {
+    .option('budget.file', {
       describe: 'Path to the JSON budget file.',
       group: 'Budget'
     })
@@ -395,7 +395,14 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .config('config')
     .alias('version', 'V')
     .coerce('budget', function(arg) {
-      return JSON.parse(fs.readFileSync(arg, 'utf8'))
+      if (arg === Object(arg) && !Array.isArray(arg)) {
+        if (arg.hasOwnProperty('file')) {
+          arg.file = JSON.parse(fs.readFileSync(arg.file, 'utf8'))
+        }
+        return arg;
+      } else {
+        throw new Error('Something looks wrong with your budget configuration. Since sitespeed.io 4.4 you should pass the path to your budget file through the --budget.file flag instead of directly through the --budget flag.');
+      }
     })
     //     .describe('browser', 'Specify browser')
     .wrap(yargs.terminalWidth())

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -398,7 +398,6 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .alias('help', 'h')
     .config('config')
     .alias('version', 'V')
-    .conflicts('budget.config', 'budget.configPath')
     .coerce('budget', function(arg) {
       if (typeof arg === 'object' && !Array.isArray(arg)) {
         if (arg.configPath) {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "uuid": "^3.0.0",
     "webcoach": "0.30.4",
     "webpagetest": "0.3.4",
-    "yargs": "6.4.0"
+    "yargs": "6.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "uuid": "^3.0.0",
     "webcoach": "0.30.4",
     "webpagetest": "0.3.4",
-    "yargs": "5.0.0"
+    "yargs": "6.4.0"
   }
 }


### PR DESCRIPTION
I've updates the yargs (cli options library) to version 6.
We reverted this update in #1399 because if caused a conflict between the --budget and --budget.output flags (was automagically fixed in 5 but not anymore in 6).

Using the new version seemed logical for #1431 and because we don't want to be pinned down on an old version of yargs.