### PR TITLE
Fix for Template error with meta data aliases when not using the CLI #1444

### DIFF
--- a/lib/plugins/graphite/util.js
+++ b/lib/plugins/graphite/util.js
@@ -17,7 +17,7 @@ module.exports = {
     }
   },
   getURLAndGroup(options, group, url, includeQueryParams) {
-    if(group && options.urlsMetaData[url]) {
+    if(group && options.urlsMetaData && options.urlsMetaData[url] && options.urlsMetaData[url].alias) {
       let alias = options.urlsMetaData[url].alias;
        return this.toSafeKey(group) + "." + this.toSafeKey(alias);
     } else {

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -116,7 +116,7 @@ class HTMLBuilder {
         let summaryPageHAR =  options.html.showAllWaterfallSummary ? get(pageInfo, 'data.browsertime.har') : get(runPages[0], 'data.browsertime.run.har');
 
         let daurlAlias;
-        if (options.urlsMetaData[url]) {
+        if (options.urlsMetaData[url] && options.urlsMetaData[url].alias) {
           daurlAlias = options.urlsMetaData[url].alias
         }
 

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -116,7 +116,7 @@ class HTMLBuilder {
         let summaryPageHAR =  options.html.showAllWaterfallSummary ? get(pageInfo, 'data.browsertime.har') : get(runPages[0], 'data.browsertime.run.har');
 
         let daurlAlias;
-        if (options.urlsMetaData[url] && options.urlsMetaData[url].alias) {
+        if (options.urlsMetaData && options.urlsMetaData[url] && options.urlsMetaData[url].alias) {
           daurlAlias = options.urlsMetaData[url].alias
         }
 

--- a/lib/plugins/html/templates/pages.pug
+++ b/lib/plugins/html/templates/pages.pug
@@ -5,7 +5,7 @@ mixin rows(pages)
   each pageInfo, url in pages
     - p = pageInfo.data.pagexray ? pageInfo.data.pagexray.pageSummary : {}
     - t = p.contentTypes || {javascript: {transferSize: ''}, css: {transferSize: ''}, image: {transferSize: ''}}
-    - display = (options.urlsMetaData[url] && options.urlsMetaData[url].alias) ? options.urlsMetaData[url].alias : url
+    - display = (options.urlsMetaData && options.urlsMetaData[url] && options.urlsMetaData[url].alias) ? options.urlsMetaData[url].alias : url
     tr
       td.url.pagesurl(data-title='URL')
         a(href= pageInfo.path + 'index.html')= decodeURIComponent(display)

--- a/lib/plugins/html/templates/pages.pug
+++ b/lib/plugins/html/templates/pages.pug
@@ -5,7 +5,7 @@ mixin rows(pages)
   each pageInfo, url in pages
     - p = pageInfo.data.pagexray ? pageInfo.data.pagexray.pageSummary : {}
     - t = p.contentTypes || {javascript: {transferSize: ''}, css: {transferSize: ''}, image: {transferSize: ''}}
-    - display = options.urlsMetaData[url] ? options.urlsMetaData[url].alias : url
+    - display = (options.urlsMetaData[url] && options.urlsMetaData[url].alias) ? options.urlsMetaData[url].alias : url
     tr
       td.url.pagesurl(data-title='URL')
         a(href= pageInfo.path + 'index.html')= decodeURIComponent(display)


### PR DESCRIPTION
Fixes #1444. Simple script to reproduce issue and verify fix. @soulgalore where should we keep this to run in travis? 

```
const sitespeed = require('../lib/sitespeed');
const urls = ['https://www.sitespeed.io/'];

function run() {

  sitespeed.run({ urls })
    .then((results) => {
      if (results.error) {
        throw new Error(results.error);
      }
    })
    .catch((err) => {
      console.error(err);
      process.exit(1);
    });
}

run();
```