### PR TITLE
Minor cleanup and tweaks to S3 plugin.

### DIFF
--- a/lib/plugins/s3/index.js
+++ b/lib/plugins/s3/index.js
@@ -5,78 +5,75 @@ const s3 = require('s3');
 const Promise = require('bluebird');
 const throwIfMissing = require('../../support/util').throwIfMissing;
 const fs = require('fs-extra');
+const pick = require('lodash.pick');
 
 Promise.promisifyAll(fs);
 
-function getClient(options) {
-  if (options.s3.key && options.s3.secret) {
-    const settings = {
-      maxAsyncS3: options.s3.maxAsyncS3 || 20,
-      s3RetryCount: options.s3.s3RetryCount || 3,
-      s3RetryDelay: options.s3.s3RetryDelay || 1000,
-      multipartUploadThreshold: options.s3.multipartUploadThreshold ||  20971520,
-      multipartUploadSize: options.s3.multipartUploadSize || 15728640,
-      s3Options: {
-        accessKeyId: options.s3.key,
-        secretAccessKey: options.s3.secret
-      }
-    };
-    if (options.s3.region) {
-      settings.s3Options.region = options.s3.region;
-    }
+function createS3Client(s3Options) {
+  const clientOptions = pick(s3Options,
+    ['maxAsyncS3', 's3RetryCount', 's3RetryDelay', 'multipartUploadThreshold', 'multipartUploadSize']);
 
-    const client = s3.createClient(settings);
+  clientOptions.s3Options = {
+    accessKeyId: s3Options.key,
+    secretAccessKey: s3Options.secret,
+    region: s3Options.region
+  };
 
-    return client;
-  } else {
-    return s3.createClient();
-  }
+  return s3.createClient(clientOptions);
 }
 
 module.exports = {
   open(context, options) {
-    throwIfMissing(options.s3, ['bucketname'], 's3');
+    const s3Options = options.s3;
+
+    throwIfMissing(s3Options, ['bucketname'], 's3');
     if (options.outputFolder) {
       throw new Error('The current version does\'t support S3 together with a configured outputFolder.');
     }
-    if (options.s3.key || options.s3.secret) {
-      throwIfMissing(options.s3, ['key', 'secret'], 's3');
+    if (s3Options.key || s3Options.secret) {
+      throwIfMissing(s3Options, ['key', 'secret'], 's3');
     }
     this.storageManager = context.storageManager;
   },
 
   postClose(options) {
-    const client = getClient(options);
+    const s3Options = options.s3;
+    const client = createS3Client(s3Options);
+
+    const baseDir = this.storageManager.getBaseDir();
 
     const params = {
-      localDir: this.storageManager.getBaseDir(),
-      deleteRemoved: false,
+      localDir: baseDir,
       s3Params: {
-        Bucket: options.s3.bucketname,
+        Bucket: s3Options.bucketname,
         // maybe just skipr default sitespeed-result?
         Prefix: this.storageManager.getRelativeBaseDir()
-          // other options supported by putObject, except Body and ContentLength.
-          // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
-      },
+        // other options supported by putObject, except Body and ContentLength.
+        // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
+      }
     };
+
     return new Promise((resolve, reject) => {
-      log.info('Uploading %s to S3 bucket %s, this can take a while ...', this.storageManager.getBaseDir(), options.s3.bucketname);
+      log.info(`Uploading ${baseDir} to S3 bucket ${s3Options.bucketname}, this can take a while ...`);
+
       const uploader = client.uploadDir(params);
-      const storageManager = this.storageManager;
-      uploader.on('error', function(err) {
+
+      uploader.on('error', err => {
         log.error('Could not upload to S3', err);
         reject(err);
       });
-      uploader.on('progress', function() {
-        log.trace("S3 upload progress", uploader.progressMd5Amount,
+      uploader.on('progress', () => {
+        log.verbose("S3 upload progress", uploader.progressMd5Amount,
           uploader.progressAmount, uploader.progressTotal);
       });
-      uploader.on('end', function() {
-        if (options.s3.removeLocalResult) {
-          fs.removeAsync(storageManager.getBaseDir()).then(() => {
-            log.info('Removed local files and directory %s', storageManager.getBaseDir());
-            resolve();
-          });
+      uploader.on('end', () => {
+        if (s3Options.removeLocalResult) {
+          fs.removeAsync(baseDir)
+            .then(() => {
+              log.info(`Removed local files and directory ${baseDir}`);
+              resolve();
+            })
+            .catch((e) => reject(e));
         } else {
           resolve();
         }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lodash.get": "4.4.2",
     "lodash.isempty": "4.4.0",
     "lodash.merge": "4.6.0",
+    "lodash.pick": "4.4.0",
     "lodash.pullall": "4.2.0",
     "lodash.reduce": "4.6.0",
     "lodash.set": "4.3.2",


### PR DESCRIPTION
* Avoid hang if fs.remove fails.
* Use defaults from s3 module for maxAsyncS3, s3RetryCount etc.
* Always set whichever of region, accessKeyId and secretAccessKey that are passed as options. That allows for an arbitrary mix of options and env. variables.
* Allow configuration of  S3 (such as s3RetryDelay) even when credentials aren’t passed as options.
* Use verbose logging instead of trace (since trace prints a stack trace).