### PR TITLE
Use map and concurrency to make sure we don't overload the WPT server

### DIFF
--- a/lib/plugins/webpagetest/analyzer.js
+++ b/lib/plugins/webpagetest/analyzer.js
@@ -30,7 +30,8 @@ module.exports = {
         log.verbose('Got JSON from WebPageTest :%:2j', data);
 
         const promises = [];
-        promises.push(wptClient.getHARDataAsync(id, {}));
+        let har;
+        promises.push(wptClient.getHARDataAsync(id, {}).then((theHar) => har = theHar));
 
         const traces = {};
         const views = ['firstView'];
@@ -93,10 +94,12 @@ module.exports = {
 
           }
         })
-        return Promise.all(promises).then((result) => {
+
+        // set a low concurrency to not overload the WebPageTest server
+        return Promise.map(promises, function(){}, {concurrency: 2}).then(() => {
           const myResult = {
             data: data.data,
-            har: result[0]
+            har
           }
           myResult.trace = traces;
           return myResult;


### PR DESCRIPTION
To fix these errors https://www.sitespeed.io/img/slack-alert-error.png