### PR TITLE
Don't try to display unexistant screenshot

### DIFF
--- a/lib/plugins/html/templates/url/index.pug
+++ b/lib/plugins/html/templates/url/index.pug
@@ -86,7 +86,7 @@ block content
               td #{d.webpagetest.pageSummary.data.median.firstView.requestsFull}
 
       .one-half.column
-          if d.browsertime && d.browsertime.pageSummary && d.browsertime.pageSummary.screenshots
+          if d.browsertime && options.browsertime.screenshot && d.browsertime.pageSummary && d.browsertime.pageSummary.screenshots
             - var width = options.mobile ? 150 : '100%';
             a(href='data/screenshots/0.png')
               img.screenshot(src='data/screenshots/0.png', width=width, alt='Screenshot of run 1')

--- a/lib/plugins/html/templates/url/run.pug
+++ b/lib/plugins/html/templates/url/run.pug
@@ -90,7 +90,7 @@ block content
 
       .one-half.column
           //- No good way to detect if we have screenshots or not right now for a run
-          if d.browsertime
+          if d.browsertime && options.browsertime.screenshot
             - screenshotName = 'data/screenshots/' + runIndex + '.png'
             - var width = options.mobile ? 150 : '100%';
             a(href=screenshotName)


### PR DESCRIPTION
Removed broken image when screenshot plugin is disabled, aka `--plugins.disable screenshot`

Related to #1570 