### PR TITLE
Save metrics to disk when generating HTML

### DIFF
--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -22,6 +22,7 @@ class HTMLBuilder {
     this.storageManager = context.storageManager;
     this.timestamp = context.timestamp.format(TIME_FORMAT);
     this.options = options;
+    this.htmlOptions = options.html || {};
     this.dataCollection = context.dataCollection;
     this.summary = {};
     this.budget = context.budget;
@@ -181,7 +182,12 @@ class HTMLBuilder {
       context: this.context
     }, locals);
 
-    return this.storageManager.writeHtmlForUrl(renderer.renderTemplate('url/' + name, locals), name + '.html', url);
+    const work = [];
+    if (this.htmlOptions.debug) {
+      work.push(this.storageManager.writeDataForUrl(JSON.stringify(locals), name + '.json', url));
+    }
+    work.push(this.storageManager.writeHtmlForUrl(renderer.renderTemplate('url/' + name, locals), name + '.html', url));
+    return Promise.all(work);
   }
 
   _renderUrlRunPage(url, name, locals) {
@@ -200,7 +206,12 @@ class HTMLBuilder {
       context: this.context
     }, locals);
 
-    return this.storageManager.writeHtmlForUrl(renderer.renderTemplate('url/run', locals), name + '.html', url);
+    const work = [];
+    if (this.htmlOptions.debug) {
+      work.push(this.storageManager.writeDataForUrl(JSON.stringify(locals), name + '.json', url));
+    }
+    work.push(this.storageManager.writeHtmlForUrl(renderer.renderTemplate('url/run', locals), name + '.html', url));
+    return Promise.all(work);
   }
 
   _renderSummaryPage(name, locals) {
@@ -216,7 +227,12 @@ class HTMLBuilder {
       context: this.context
     }, locals);
 
-    return this.storageManager.writeHtml(name + '.html', renderer.renderTemplate(name, locals));
+    const work = [];
+    if (this.htmlOptions.debug) {
+      work.push(this.storageManager.writeData(name + '.json', JSON.stringify(locals)));
+    }
+    work.push(this.storageManager.writeHtml(name + '.html', renderer.renderTemplate(name, locals)));
+    return Promise.all(work);
   }
 }
 

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -486,6 +486,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean',
       group: 'HTML'
     })
+    .option('html.debug', {
+      describe: 'Save the JSON structure to disk that is used to render the HTML. Use it with Pug to make it easy to change the HTML.',
+      default: false,
+      type: 'boolean',
+      group: 'HTML'
+    })
     .option('summary', {
       describe: 'Show brief text summary to stdout',
       default: false,


### PR DESCRIPTION
If we store the raw JSON to disk that is used to generate the HTML, you can just run Pug command line and match the raw JSON with the pug template and debug/change the HTML on the fly, instead of having to run sitespeed.io over and over.