### PR TITLE
Update docs with docker details to remove data volumes

### DIFF
--- a/development/index.md
+++ b/development/index.md
@@ -22,6 +22,12 @@ run the following to push the updated dashboards to Grafana.
 docker-compose up --build grafana-setup
 ```
 
+## Shutdown and remove containers
+
+When you are done you can shutdown and remove all the docker containers by running `docker-compose stop && docker-compose rm`
+
+NOTE: This will close and remove all containers but the data will not be removed. To remove the Graphite and Grafana data volumes and start from scratch you need to run `docker volume rm performancedashboard_graphite performancedashboard_grafana`.
+
 ## Run Sitespeed.io
 The local Sitespeed.io container with Linux making it easy to record videos.
 

--- a/docs/documentation/sitespeed.io/performance-dashboard/index.md
+++ b/docs/documentation/sitespeed.io/performance-dashboard/index.md
@@ -27,7 +27,8 @@ You need [Docker](https://docs.docker.com/engine/installation/) and [Docker Comp
 2. Run: <code>docker-compose up -d</code> (make sure you run the latest [Docker compose](https://docs.docker.com/compose/install/) version)
 3. Run sitespeed to get some metrics: <code> docker-compose run sitespeed.io https://www.sitespeed.io/ --graphite.host=graphite</code>
 4. Access the dashboard: http://127.0.0.1:3000
-5. When you are done you can shutdown and remove all the docker containers by running <code>docker-compose stop && docker-compose rm</code>
+5. When you are done you can shutdown and remove all the docker containers by running <code>docker-compose stop && docker-compose rm</code>. Container data will be kept.
+6. To start from scratch, also remove the Graphite and Grafana data volumes by running `docker volume rm performancedashboard_graphite performancedashboard_grafana`.
 
 
 If you want to play with the dashboards the default login is sitespeedio and password is ...well checkout the docker-compose.yml file.


### PR DESCRIPTION
If we close and remove the docker containers use for performance dashboard the data will be kept.

So on the next run it will persists with the new containers. To start from scratch we need to remove the volumes also.

This fixes #1589 