### PR TITLE
support budget config path in non cli version

### DIFF
--- a/lib/plugins/budget/index.js
+++ b/lib/plugins/budget/index.js
@@ -4,6 +4,7 @@ const verify = require('./verify').verify;
 const tap = require('./tap');
 const junit = require('./junit');
 const log = require('intel').getLogger('sitespeedio.plugin.budget');
+const fs = require('fs');
 
 module.exports = {
   open(context, options) {
@@ -15,13 +16,14 @@ module.exports = {
     if (!this.options.budget) {
       return;
     }
+    let config = this.options.budget.configPath ? JSON.parse(fs.readFileSync(this.options.budget.configPath, 'utf8')) : this.options.budget.config;
     switch (message.type) {
       case 'browsertime.pageSummary':
       case 'webpagetest.pageSummary':
       case 'pagexray.pageSummary':
       case 'coach.pageSummary':
         {
-          verify(message, this.result, this.options.budget.config);
+          verify(message, this.result, config);
           return;
         }
     }

--- a/test/runBudgetWithoutCli.js
+++ b/test/runBudgetWithoutCli.js
@@ -1,0 +1,47 @@
+const sitespeed = require('../lib/sitespeed');
+const expect = require('chai').expect;
+
+describe("Sitespeed run without CLI", function(){
+  it("should capture the budget plugin correctly when budget config is passed", function(done){
+    const options = {
+      "urls": ["http://www.google.com"],
+      "browsertime": {
+        "iterations": 1
+      },
+
+      "budget": {
+        "config": {
+          "browsertime.pageSummary": [{
+            "metric": "statistics.timings.firstPaint.median",
+            "max": 10
+          }, {
+            "metric": "statistics.visualMetrics.FirstVisualChange.median",
+            "max": 10
+          }]
+        }
+      }
+
+    };
+    sitespeed.run(options).then(function(results){
+      expect(results.budgetResult.failing).to.include.keys('http://www.google.com');
+      done();
+    });
+  }).timeout(15000);
+  it("should capture the budget plugin correctly when budget configPath is passed", function(done){
+    const options = {
+      "urls": ["http://www.google.com"],
+      "browsertime": {
+        "iterations": 1
+      },
+
+      "budget": {
+        "configPath": __dirname + '/budget.json'
+      }
+
+    };
+    sitespeed.run(options).then(function(results){
+      expect(results.budgetResult.failing).to.include.keys('http://www.google.com');
+      done();
+    });
+  }).timeout(15000);
+})


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [ ] Check that your change/fix has corresponding unit tests (if applicable)
- [ ] Squash commits so it looks sane
- [ ] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs
- [ ] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
Please describe your pull request and tell us the fix #1601 

Thank you for making sitespeed.io even better!
========================================================================
This PR will support the `budget.config ` and `budget.configPath` when sitespeed runs as a node module instead of CLI version.
Test case added