### PR TITLE
Added support for --s3.storageClass option for user to be able to spe…

### DIFF
--- a/lib/plugins/s3/index.js
+++ b/lib/plugins/s3/index.js
@@ -43,7 +43,12 @@ module.exports = {
       localDir: baseDir,
       s3Params: {
         Bucket: s3Options.bucketname,
-        Prefix: s3Options.path || this.storageManager.getStoragePrefix()
+        Prefix: s3Options.path || this.storageManager.getStoragePrefix(),
+
+        // Allow user to set default StorageClass on objects and default to STANDARD if not set
+        // Possible options [STANDARD | REDUCED_REDUNDANCY | STANDARD_IA] 
+        StorageClass: s3Options.storageClass || 'STANDARD' 
+
         // other options supported by putObject, except Body and ContentLength.
         // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
       }


### PR DESCRIPTION
Added support for --s3.storageClass option for user to be able to specify the default storage class of the objects getting put into s3. Valid options are STANDARD | REDUCED_REDUNDANCY | STANDARD_IA

Really simple change. I was looking for a way to default the storage to reduced redundancy in s3 to lower costs. Let me know your thoughts.

Thanks
