### PR TITLE
Fixes #1647 where URL key doesn't exist due to filter setting

### DIFF
--- a/lib/support/flattenMessage.js
+++ b/lib/support/flattenMessage.js
@@ -80,7 +80,7 @@ module.exports = {
             // use the url to generate the key
 
             if (type === 'pagexray.pageSummary' && keyPrefix === 'assets') {
-                recursiveFlatten(target, joinNonEmpty([keyPrefix, toSafeKey(value[key].url?value[key].url:key)], '.'), value[key]);
+                recursiveFlatten(target, joinNonEmpty([keyPrefix, toSafeKey(value[key].url || key)], '.'), value[key]);
             }
             else {
               recursiveFlatten(target, joinNonEmpty([keyPrefix, toSafeKey(key)], '.'), value[key]);

--- a/lib/support/flattenMessage.js
+++ b/lib/support/flattenMessage.js
@@ -80,7 +80,7 @@ module.exports = {
             // use the url to generate the key
 
             if (type === 'pagexray.pageSummary' && keyPrefix === 'assets') {
-                recursiveFlatten(target, joinNonEmpty([keyPrefix, toSafeKey(value[key].url)], '.'), value[key]);
+                recursiveFlatten(target, joinNonEmpty([keyPrefix, toSafeKey(value[key].url?value[key].url:key)], '.'), value[key]);
             }
             else {
               recursiveFlatten(target, joinNonEmpty([keyPrefix, toSafeKey(key)], '.'), value[key]);


### PR DESCRIPTION
Fixes #1647 

If the URL key doesn't exist due to customized filtering use the index instead when sending out to TSDBs