### PR TITLE
More meta data for the HAR

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -144,9 +144,8 @@ module.exports = {
                 // sometimes Firefox can't create the HAR + in the future
                 // we may wanna use Safari (without HAR)
                 if (results.har) {
-                  const pageTimings = results.har.log.pages[runIndex].pageTimings;
 
-                  // add more meta data to be used in the future
+                  // Add meta data to be used when we compare multiple HARs
                   results.har.log.pages[runIndex]._meta = {};
                   const _meta = results.har.log.pages[runIndex]._meta;
                   _meta._connectivity = this.options.connectivity.profile;
@@ -160,12 +159,23 @@ module.exports = {
                     }
                   }
 
-                  // if we have first and last visual change add it to the HAR file
-                  // so we can see it in the waterfall graph
+                  // Setup visual metrics to use when we compare hars
+                  results.har.log.pages[runIndex]._visualMetrics = {};
+                  const _visualMetrics = results.har.log.pages[runIndex]._visualMetrics;
+
+                  const pageTimings = results.har.log.pages[runIndex].pageTimings;
+
+                  // if we have first, complete85 and last visual change add it to the HAR file
+                  // so we can see it in the waterfall graph (PerfCascade automatically picks it up)
                   if (results.visualMetrics && results.visualMetrics[runIndex]) {
                     pageTimings._firstVisualChange = results.visualMetrics[runIndex].FirstVisualChange;
                     pageTimings._lastVisualChange = results.visualMetrics[runIndex].LastVisualChange;
                     pageTimings._visualComplete85 = results.visualMetrics[runIndex].VisualComplete85;
+                    _visualMetrics._FirstVisualChange = results.visualMetrics[runIndex].FirstVisualChange;
+                    _visualMetrics._SpeedIndex = results.visualMetrics[runIndex].SpeedIndex;
+                    _visualMetrics._VisualComplete85 = results.visualMetrics[runIndex].VisualComplete85;
+                    _visualMetrics._LastVisualChange = results.visualMetrics[runIndex].LastVisualChange;
+                    _visualMetrics._VisualProgress = results.visualMetrics[runIndex].VisualProgress;
                   }
                   // only add first paint if we don't have visual metrics
                   else if (run.timings.firstPaint) {

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -72,6 +72,7 @@ module.exports = {
     this.options = merge({}, defaultConfig, options.browsertime);
     this.options.mobile = options.mobile;
     this.storageManager = context.storageManager;
+    this.resultUrls = context.resultUrls;
 
     browsertime.logging.configure(options);
 
@@ -144,6 +145,20 @@ module.exports = {
                 // we may wanna use Safari (without HAR)
                 if (results.har) {
                   const pageTimings = results.har.log.pages[runIndex].pageTimings;
+
+                  // add more meta data to be used in the future
+                  results.har.log.pages[runIndex]._meta = {};
+                  const _meta = results.har.log.pages[runIndex]._meta;
+                  _meta._connectivity = this.options.connectivity.profile;
+
+                  if (this.resultUrls.hasBaseUrl()) {
+                    _meta._screenshot =  this.resultUrls.absoluteSummaryPageUrl(url) + 'data/screenshots/' + runIndex + '.png';
+                    // TODO this should be to that exact run instead
+                    _meta._result =  this.resultUrls.absoluteSummaryPageUrl(url);
+                    if (this.options.video) {
+                        _meta._video =  this.resultUrls.absoluteSummaryPageUrl(url) + 'data/video/' + runIndex + '.mp4';
+                    }
+                  }
 
                   // if we have first and last visual change add it to the HAR file
                   // so we can see it in the waterfall graph

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -152,11 +152,11 @@ module.exports = {
                   _meta._connectivity = this.options.connectivity.profile;
 
                   if (this.resultUrls.hasBaseUrl()) {
-                    _meta._screenshot =  this.resultUrls.absoluteSummaryPageUrl(url) + 'data/screenshots/' + runIndex + '.png';
-                    // TODO this should be to that exact run instead
-                    _meta._result =  this.resultUrls.absoluteSummaryPageUrl(url);
+                    const base = this.resultUrls.absoluteSummaryPageUrl(url);
+                    _meta._screenshot =  `${base}data/screenshots/${runIndex}.png`;
+                    _meta._result =  `${base}${runIndex}.html`;
                     if (this.options.video) {
-                        _meta._video =  this.resultUrls.absoluteSummaryPageUrl(url) + 'data/video/' + runIndex + '.mp4';
+                        _meta._video =  `${base}data/video/${runIndex}.mp4`;
                     }
                   }
 


### PR DESCRIPTION
We want to include more meta data of the run in the HAR to make it easier to show extra info when we compare HARs.

This adds the possibility to: show screenshots, video, visualMetrics, link back to the result page  and know about the connectivity. 

This will be used when we compare multiple HAR files.

This should be mergeable asap, we can include it now and start use it in 6.0.