### PR TITLE
add extra S3 settings

### DIFF
--- a/docs/documentation/sitespeed.io/configuration/index.md
+++ b/docs/documentation/sitespeed.io/configuration/index.md
@@ -150,7 +150,9 @@ s3
   --s3.path               Override the default folder path in the bucket where the results are uploaded. By default it's "DOMAIN_OR_FILENAME/TIMESTAMP", or the name of the
                           folder if --outputFolder is specified.
   --s3.region             The S3 region. Optional depending on your settings.
-  --s3.removeLocalResult  Remove all the local result files after they have been uploaded to S3                                                     [boolean] [default: false]
+  --s3.clientSettings     Extra settings to pass to the s3 client, see: https://github.com/andrewrk/node-s3-client#create-a-client                                             [string] [default: "{}"]
+  --s3.uploadSettings     Extra settings to pass when uploading files to s3, see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property            [string] [default: "{}"]
+  --s3.removeLocalResult  Remove all the local result files after they have been uploaded to S3                                                                                                                      [boolean] [default: false]
 
 HTML
   --html.showAllWaterfallSummary  Set to true to show all waterfalls on page summary HTML report                                                    [boolean] [default: false]

--- a/lib/plugins/s3/index.js
+++ b/lib/plugins/s3/index.js
@@ -18,11 +18,14 @@ function createS3Client(s3Options) {
     'multipartUploadSize'
   ]);
 
-  clientOptions.s3Options = {
-    accessKeyId: s3Options.key,
-    secretAccessKey: s3Options.secret,
-    region: s3Options.region
-  };
+  clientOptions.s3Options = Object.assign(
+    {
+      accessKeyId: s3Options.key,
+      secretAccessKey: s3Options.secret,
+      region: s3Options.region
+    },
+    s3Options.clientSettings
+  );
 
   return s3.createClient(clientOptions);
 }
@@ -46,17 +49,20 @@ module.exports = {
 
     const params = {
       localDir: baseDir,
-      s3Params: {
-        Bucket: s3Options.bucketname,
-        Prefix: s3Options.path || this.storageManager.getStoragePrefix(),
+      s3Params: Object.assign(
+        {
+          Bucket: s3Options.bucketname,
+          Prefix: s3Options.path || this.storageManager.getStoragePrefix(),
 
-        // Allow user to set default StorageClass on objects and default to STANDARD if not set
-        // Possible options [STANDARD | REDUCED_REDUNDANCY | STANDARD_IA]
-        StorageClass: s3Options.storageClass || 'STANDARD'
+          // Allow user to set default StorageClass on objects and default to STANDARD if not set
+          // Possible options [STANDARD | REDUCED_REDUNDANCY | STANDARD_IA]
+          StorageClass: s3Options.storageClass || 'STANDARD'
 
-        // other options supported by putObject, except Body and ContentLength.
-        // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
-      }
+          // other options supported by putObject, except Body and ContentLength.
+          // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
+        },
+        s3Options.uploadSettings
+      )
     };
 
     return new Promise((resolve, reject) => {

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -514,6 +514,20 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe: 'The S3 region. Optional depending on your settings.',
       group: 's3'
     })
+    .option('s3.clientSettings', {
+      describe:
+        'Extra settings to pass to the s3 client, see: https://github.com/andrewrk/node-s3-client#create-a-client',
+      group: 's3',
+      type: 'string',
+      default: '{}'
+    })
+    .option('s3.uploadSettings', {
+      describe:
+        'Extra settings to pass when uploading files to s3, see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property',
+      group: 's3',
+      type: 'string',
+      default: '{}'
+    })
     .option('s3.removeLocalResult', {
       describe:
         'Remove all the local result files after they have been uploaded to S3',
@@ -627,6 +641,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
         arg.script = arg.script.split('\\n').join('\n');
       }
       return arg;
+    })
+    .coerce('s3', function(s3Options) {
+      s3Options.clientSettings = JSON.parse(s3Options.clientSettings);
+      s3Options.uploadSettings = JSON.parse(s3Options.uploadSettings);
+      return s3Options;
     })
     //     .describe('browser', 'Specify browser')
     .wrap(yargs.terminalWidth())


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [X] Check that your change/fix has corresponding unit tests (if applicable)
- [X] Squash commits so it looks sane
- [X] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs
- [X] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description

Greetings,

This is a small pull request to add more settings to the S3 Upload plugin, I needed to have the possibility to update the AWS endpoint (I'm using Ceph instead), disable the SSL and set the ACL when uploading.

Let me know if you need more documentation updated or if there's a question.
