### PR TITLE
Add note about unaffiliated `sitespeed` pkg on NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Or install using npm:
 $ npm i -g sitespeed.io
 ```
 
+_Don't forget the `.io`! There's another package out there named just `sitespeed`, which we don't maintain._
+
 Or clone the repo and test the latest changes:
 
 ```bash


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
- [X] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs

### Description
This is a small update to the main README: I've added a note about the other, unaffiliated NPM package named `sitespeed`.

As a newcomer, I accidentally installed this package when I meant to install `sitespeed.io`, so this is an attempt to help future newcomers avoid this pitfall!

Fixes #1696. Thanks @soulgalore!