### PR TITLE
More useful logging for WPT issues.

### DIFF
--- a/lib/plugins/webpagetest/analyzer.js
+++ b/lib/plugins/webpagetest/analyzer.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var fs = require('fs'),
-  Promise = require('bluebird'),
-  log = require('intel').getLogger('sitespeedio.plugin.webpagetest'),
-  clone = require('lodash.clonedeep'),
-  get = require('lodash.get'),
-  WebPageTest = require('webpagetest'),
-  WPTAPIError = require('webpagetest/lib/helper').WPTAPIError;
+const fs = require('fs');
+const Promise = require('bluebird');
+const log = require('intel').getLogger('sitespeedio.plugin.webpagetest');
+const clone = require('lodash.clonedeep');
+const get = require('lodash.get');
+const WebPageTest = require('webpagetest');
+const WPTAPIError = require('webpagetest/lib/helper').WPTAPIError;
 
 Promise.promisifyAll(fs);
 Promise.promisifyAll(WebPageTest.prototype);
@@ -46,7 +46,9 @@ module.exports = {
           .getHARDataAsync(id, {})
           .then(theHar => (har = theHar))
           .catch(WPTAPIError, error =>
-            log.error('Couldnt get HAR data fir id %s %s', id, error)
+            log.warn(
+              `Couldn't get HAR for id ${id} ${error.message} (url = ${url})`
+            )
           )
       );
 
@@ -93,7 +95,9 @@ module.exports = {
                   'screenshots'
                 )
             ).catch(WPTAPIError, error =>
-              log.error('Couldnt get screenshot for id %s %s', id, error)
+              log.warn(
+                `Couldn't get screenshot for id ${id} ${error.message} (url = ${url})`
+              )
             )
           );
 
@@ -111,7 +115,9 @@ module.exports = {
                     'waterfall'
                   )
                   .catch(WPTAPIError, error =>
-                    log.error('Couldnt get waterfall %s %s', id, error)
+                    log.warn(
+                      `Couldn't get waterfall for id ${id} ${error.message} (url = ${url})`
+                    )
                   );
               }
             )
@@ -130,10 +136,8 @@ module.exports = {
                   'waterfall'
                 )
             ).catch(WPTAPIError, error =>
-              log.error(
-                'Couldnt get watetfall connection for id %s %s',
-                id,
-                error
+              log.warn(
+                `Couldn't get connection waterfall for id ${id} ${error.message} (url = ${url})`
               )
             )
           );
@@ -147,7 +151,9 @@ module.exports = {
                   traces['trace-' + index + '-wpt-' + view] = result;
                 }
               ).catch(WPTAPIError, error =>
-                log.error('Couldnt get chrome trace for id %s %s', id, error)
+                log.warn(
+                  `Couldn't get chrome trace for id ${id} ${error.message} (url = ${url})`
+                )
               )
             );
           }


### PR DESCRIPTION
Log on warning level instead of error level for issues retrieving data from WPT. It’s not an error in sitespeed, so error is to severe. Additionally make the logging more useful by:
* not adding a stack trace to each log statement
* including the page url for each log statement
* fix some spelling errors in logging.