### PR TITLE
Collect run/pageSummary from all plugins

### DIFF
--- a/lib/plugins/datacollector/index.js
+++ b/lib/plugins/datacollector/index.js
@@ -13,133 +13,128 @@ module.exports = {
 
   processMessage(message) {
     const dataCollector = this.dataCollector;
-
-    switch (message.type) {
-      case 'error': {
-        dataCollector.addErrorForUrl(message.url, message.source, message.data);
-        break;
-      }
-
-      case 'browsertime.run':
-      case 'browsertime.pageSummary':
-      case 'browsertime.har':
-      case 'webpagetest.run':
-      case 'webpagetest.pageSummary':
-      case 'gpsi.data':
-      case 'gpsi.pageSummary':
-      case 'pagexray.run':
-      case 'pagexray.pageSummary':
-      case 'coach.run':
-      case 'coach.pageSummary': {
-        dataCollector.addDataForUrl(
-          message.url,
-          message.type,
-          message.data,
-          message.runIndex
-        );
-        break;
-      }
-
-      case 'aggregateassets.summary': {
-        if (message.group === 'total') {
-          const assetList = reduce(
-            message.data,
-            (assetList, asset) => {
-              assetList.push(asset);
-              return assetList;
-            },
-            []
+    if (
+      message.type.endsWith('.run') ||
+      message.type.endsWith('.pageSummary')
+    ) {
+      dataCollector.addDataForUrl(
+        message.url,
+        message.type,
+        message.data,
+        message.runIndex
+      );
+    } else {
+      switch (message.type) {
+        case 'error': {
+          dataCollector.addErrorForUrl(
+            message.url,
+            message.source,
+            message.data
           );
-
-          const count = this.maxAssets,
-            fullCount = Object.keys(assetList).length,
-            topAssets = assetList
-              .sort((a, b) => b.requestCount - a.requestCount)
-              .splice(0, count);
-          dataCollector.addDataForSummaryPage('assets', {
-            topAssets,
-            count,
-            fullCount
-          });
+          break;
         }
-        break;
-      }
 
-      case 'largestassets.summary': {
-        if (message.group === 'total') {
-          const assetsBySize = {};
-          for (const contentType of Object.keys(message.data)) {
-            assetsBySize[contentType] = message.data[contentType];
-            dataCollector.addDataForSummaryPage('toplist', {
-              assetsBySize
+        case 'aggregateassets.summary': {
+          if (message.group === 'total') {
+            const assetList = reduce(
+              message.data,
+              (assetList, asset) => {
+                assetList.push(asset);
+                return assetList;
+              },
+              []
+            );
+
+            const count = this.maxAssets,
+              fullCount = Object.keys(assetList).length,
+              topAssets = assetList
+                .sort((a, b) => b.requestCount - a.requestCount)
+                .splice(0, count);
+            dataCollector.addDataForSummaryPage('assets', {
+              topAssets,
+              count,
+              fullCount
             });
           }
+          break;
         }
-        break;
-      }
-      case 'largestthirdpartyassets.summary': {
-        if (message.group === 'total') {
-          dataCollector.addDataForSummaryPage('toplist', {
-            thirdPartyAssetsBySize: message.data
-          });
-        }
-        break;
-      }
-      case 'slowestassets.summary': {
-        if (message.group === 'total') {
-          const slowestAssets = message.data;
-          dataCollector.addDataForSummaryPage('toplist', {
-            slowestAssets
-          });
-        }
-        break;
-      }
 
-      case 'slowestthirdpartyassets.summary': {
-        if (message.group === 'total') {
-          dataCollector.addDataForSummaryPage('toplist', {
-            thirdPartySlowestAssets: message.data
-          });
+        case 'largestassets.summary': {
+          if (message.group === 'total') {
+            const assetsBySize = {};
+            for (const contentType of Object.keys(message.data)) {
+              assetsBySize[contentType] = message.data[contentType];
+              dataCollector.addDataForSummaryPage('toplist', {
+                assetsBySize
+              });
+            }
+          }
+          break;
         }
-        break;
-      }
+        case 'largestthirdpartyassets.summary': {
+          if (message.group === 'total') {
+            dataCollector.addDataForSummaryPage('toplist', {
+              thirdPartyAssetsBySize: message.data
+            });
+          }
+          break;
+        }
+        case 'slowestassets.summary': {
+          if (message.group === 'total') {
+            const slowestAssets = message.data;
+            dataCollector.addDataForSummaryPage('toplist', {
+              slowestAssets
+            });
+          }
+          break;
+        }
 
-      case 'domains.summary': {
-        if (message.group === 'total') {
-          const domainList = reduce(
-            message.data,
-            (domainList, domainStats) => {
-              domainList.push(domainStats);
-              return domainList;
-            },
-            []
-          );
+        case 'slowestthirdpartyassets.summary': {
+          if (message.group === 'total') {
+            dataCollector.addDataForSummaryPage('toplist', {
+              thirdPartySlowestAssets: message.data
+            });
+          }
+          break;
+        }
 
-          const count = 200,
-            fullCount = domainList.length,
-            topDomains = domainList
-              .sort((a, b) => b.requestCount - a.requestCount)
-              .splice(0, count);
-          dataCollector.addDataForSummaryPage('domains', {
-            topDomains,
-            count,
-            fullCount
-          });
+        case 'domains.summary': {
+          if (message.group === 'total') {
+            const domainList = reduce(
+              message.data,
+              (domainList, domainStats) => {
+                domainList.push(domainStats);
+                return domainList;
+              },
+              []
+            );
+
+            const count = 200,
+              fullCount = domainList.length,
+              topDomains = domainList
+                .sort((a, b) => b.requestCount - a.requestCount)
+                .splice(0, count);
+            dataCollector.addDataForSummaryPage('domains', {
+              topDomains,
+              count,
+              fullCount
+            });
+          }
+          break;
         }
-        break;
-      }
-      case 'webpagetest.summary':
-      case 'coach.summary':
-      case 'pagexray.summary':
-      case 'browsertime.summary':
-      case 'gpsi.summary': {
-        if (message.group === 'total') {
-          const data = {};
-          set(data, message.type, message.data);
-          dataCollector.addDataForSummaryPage('index', data);
-          dataCollector.addDataForSummaryPage('detailed', data);
+        case 'webpagetest.summary':
+        case 'coach.summary':
+        case 'pagexray.summary':
+        case 'browsertime.summary':
+        case 'gpsi.summary': {
+          if (message.group === 'total') {
+            const data = {};
+            set(data, message.type, message.data);
+            dataCollector.addDataForSummaryPage('index', data);
+            dataCollector.addDataForSummaryPage('detailed', data);
+          }
+          break;
         }
-        break;
       }
     }
   },


### PR DESCRIPTION
The current version has hardcoded plugins that reports run/pageSummaries but it's better to keep it open, it will make it much easier for plugins to get metrics into the HTML.

Let this be one of the first steps in 6.0.

