### PR TITLE
Added new LH plugin - plots_configs only

### DIFF
--- a/lib/plugins/lighthouse/aggregator.js
+++ b/lib/plugins/lighthouse/aggregator.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const statsHelpers = require('../../support/statsHelpers');
+const METRIC_NAMES = [
+  'critical-request-chains',
+  'first-meaningful-paint',
+  'speed-index-metric',
+  'estimated-input-latency',
+  'first-interactive',
+  'consistently-interactive'
+];
+
+function replaceAll(str, search, replacement) {
+  return str.replace(new RegExp(search, 'g'), replacement);
+}
+
+module.exports = {
+  stats: {},
+  groups: {},
+  addToAggregate(data, group) {
+    if (this.groups[group] === undefined) {
+      this.groups[group] = {};
+    }
+    let stats = this.stats;
+    let groups = this.groups;
+
+    METRIC_NAMES.forEach(function(metric) {
+      if (metric == 'critical-request-chains') {
+        statsHelpers.pushGroupStats(
+          stats,
+          groups[group],
+          metric,
+          parseInt(data[metric].displayValue)
+        );
+      } else {
+        statsHelpers.pushGroupStats(
+          stats,
+          groups[group],
+          metric,
+          parseInt(data[metric].rawValue)
+        );
+      }
+    });
+  },
+  summarize() {
+    if (
+      Object.keys(this.stats).length === 0 ||
+      Object.keys(this.groups).length === 0
+    )
+      return undefined;
+
+    const summary = {
+      groups: {}
+    };
+    const tmp = {};
+    for (let group of Object.keys(this.groups)) {
+      for (let stat of Object.keys(this.stats)) {
+        statsHelpers.setStatsSummary(
+          tmp,
+          replaceAll(stat, '-', ''),
+          this.stats[stat]
+        );
+      }
+      summary.groups[group] = tmp;
+    }
+
+    return summary;
+  }
+};

--- a/lib/plugins/lighthouse/index.js
+++ b/lib/plugins/lighthouse/index.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const log = require('intel').getLogger('sitespeedio.plugin.lighthouse');
+const lighthouse = require('lighthouse');
+const chromeLauncher = require('chrome-launcher');
+const messageMaker = require('../../support/messageMaker');
+const filterRegistry = require('../../support/filterRegistry');
+const make = messageMaker('lighthouse').make;
+const aggregator = require('./aggregator');
+
+const DEFAULT_SUMMARY_METRICS = [
+  'criticalrequestchains',
+  'firstmeaningfulpaint',
+  'speedindexmetric',
+  'estimatedinputlatency',
+  'firstinteractive',
+  'consistentlyinteractive'
+];
+const PORT = '9222';
+const flags = {
+  port: PORT,
+  chromeFlags: [
+    `--remote-debugging-port=${PORT}`,
+    //‘--disable-web-security’,
+    //‘--disable-device-discovery-notifications’,
+    //‘--acceptSslCerts’,
+    '--no-sandbox',
+    //‘--ignore-certificate-errors’,
+    '--headless',
+    '--disable-gpu'
+  ]
+};
+
+function launchChromeAndRunLighthouse(url, flags = {}, config = null) {
+  return chromeLauncher.launch(flags).then(chrome => {
+    return lighthouse(url, flags, config).then(results =>
+      chrome.kill().then(() => results)
+    );
+  });
+}
+
+module.exports = {
+  open() {
+    filterRegistry.registerFilterForType(
+      DEFAULT_SUMMARY_METRICS,
+      'lighthouse.summary'
+    );
+  },
+  processMessage(message, queue) {
+    switch (message.type) {
+      case 'url': {
+        const config = {
+          passes: [
+            {
+              recordTrace: true,
+              pauseAfterLoadMs: 5250,
+              networkQuietThresholdMs: 5250,
+              cpuQuietThresholdMs: 5250,
+              useThrottling: true,
+              gatherers: []
+            }
+          ],
+          audits: [
+            'critical-request-chains',
+            'first-meaningful-paint',
+            'speed-index-metric',
+            'estimated-input-latency',
+            'first-interactive',
+            'consistently-interactive'
+          ]
+        };
+
+        const url = message.url;
+        const group = message.group;
+        log.info('Collecting Lighthouse result');
+        return launchChromeAndRunLighthouse(url, flags, config)
+          .then(results => {
+            aggregator.addToAggregate(results.audits, group);
+            log.info('Finished collecting Lighthouse result');
+          })
+          .catch(err => {
+            log.error('Error creating Lighthouse result ', err);
+            queue.postMessage(
+              make('error', err, {
+                url
+              })
+            );
+          });
+      }
+      case 'summarize': {
+        const summary = aggregator.summarize();
+        if (summary) {
+          for (let group of Object.keys(summary.groups)) {
+            queue.postMessage(
+              make('lighthouse.summary', summary.groups[group], { group })
+            );
+          }
+        }
+      }
+    }
+  }
+};

--- a/lib/support/setup/summaryBoxes.js
+++ b/lib/support/setup/summaryBoxes.js
@@ -51,6 +51,7 @@ module.exports = function(data) {
   const browsertime = data.browsertime;
   const webpagetest = data.webpagetest;
   const gpsi = data.gpsi;
+  const lighthouse = data.lighthouse;
 
   // coach
   if (coach) {
@@ -265,6 +266,30 @@ module.exports = function(data) {
 
   if (gpsi) {
     boxes.push(infoBox(gpsi.summary.SPEED.score, 'GPSI Speed Score'));
+  }
+
+  //lighthouse
+  if (lighthouse) {
+    boxes.push(
+      infoBox(
+        lighthouse.summary['criticalrequestchains'],
+        'Critical Request Chains'
+      ),
+      infoBox(
+        lighthouse.summary['firstmeaningfulpaint'],
+        'First meaningful paint'
+      ),
+      infoBox(lighthouse.summary['speedindexmetric'], 'SpeedIndex metric'),
+      infoBox(
+        lighthouse.summary['estimatedinputlatency'],
+        'Estimated input latency'
+      ),
+      infoBox(lighthouse.summary['firstinteractive'], 'First interactive'),
+      infoBox(
+        lighthouse.summary['consistentlyinteractive'],
+        'Consistently interactive'
+      )
+    );
   }
 
   return boxes;


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [x] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`

### Description
This is an initial PR for #1681 . 
It contains a simple optional LH plugin (plots-config audits only for now  https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/config/plots-config.js). 

### Todo
- Expand the LH run to include at least all the Performance audits
- Store the json report in files
- Add few key score boxes in the html summary report
- Create a whole new LH html page

Thank you for making sitespeed.io even better!
