### PR TITLE
Pass additional BT config from plugins via message

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -159,6 +159,10 @@ module.exports = {
     }
 
     switch (message.type) {
+      case 'browsertime.config': {
+        merge(this.options, message.data);
+        break;
+      }
       case 'url': {
         const url = message.url;
         const group = message.group;

--- a/lib/plugins/coach/index.js
+++ b/lib/plugins/coach/index.js
@@ -73,6 +73,10 @@ module.exports = {
   processMessage(message, queue) {
     const make = this.make;
     switch (message.type) {
+      case 'sitespeedio.setup': {
+        queue.postMessage(make('browsertime.config', { coach: true }));
+        break;
+      }
       case 'coach.run': {
         if (message.runIndex === 0) {
           // For now, choose the first run to represent the whole page.

--- a/lib/plugins/screenshot/index.js
+++ b/lib/plugins/screenshot/index.js
@@ -25,10 +25,16 @@ function storeScreenshots(url, imagesAndName, storageManager) {
 module.exports = {
   open(context, options) {
     this.storageManager = context.storageManager;
+    this.make = context.messageMaker('screenshot').make;
     this.options = options;
   },
-  processMessage(message) {
+  processMessage(message, queue) {
+    const make = this.make;
     switch (message.type) {
+      case 'sitespeedio.setup': {
+        queue.postMessage(make('browsertime.config', { screenshot: true }));
+        break;
+      }
       case 'browsertime.screenshot':
         return storeScreenshots(
           message.url,

--- a/lib/sitespeed.js
+++ b/lib/sitespeed.js
@@ -7,8 +7,6 @@ const Promise = require('bluebird'),
   process = require('process'),
   logging = require('./core/logging'),
   toArray = require('./support/util').toArray,
-  difference = require('lodash.difference'),
-  merge = require('lodash.merge'),
   pullAll = require('lodash.pullall'),
   union = require('lodash.union'),
   messageMaker = require('./support/messageMaker'),
@@ -27,10 +25,6 @@ const budgetResult = {
 
 function hasFunctionFilter(functionName) {
   return obj => typeof obj[functionName] === 'function';
-}
-
-function allInArray(sampleArray, referenceArray) {
-  return difference(sampleArray, referenceArray).length === 0;
 }
 
 function runOptionalFunction(objects, fN) {
@@ -104,16 +98,6 @@ module.exports = {
               pluginNames.join(', ')
             );
           }
-        }
-        if (allInArray(['browsertime', 'coach'], pluginNames)) {
-          options.browsertime = merge({}, options.browsertime, {
-            coach: true
-          });
-        }
-        if (allInArray(['browsertime', 'screenshot'], pluginNames)) {
-          options.browsertime = merge({}, options.browsertime, {
-            screenshot: true
-          });
         }
         return pluginNames;
       })

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "junit-report-builder": "1.2.0",
     "lodash.chunk": "4.2.0",
     "lodash.clonedeep": "4.5.0",
-    "lodash.difference": "4.5.0",
     "lodash.flatten": "4.4.0",
     "lodash.foreach": "4.5.0",
     "lodash.get": "4.4.2",


### PR DESCRIPTION
Push knowledge about config dependencies between plugins out to the plugins themselves. This reduces centralized knowledge.

This is not a way to specify dependencies on plugins that have to be loaded. We’ll see when (and if) we’ll tackle that.