### PR TITLE
Make the WebPageTest plugin independent on sitespeed.io requires

### DIFF
--- a/lib/plugins/webpagetest/aggregator.js
+++ b/lib/plugins/webpagetest/aggregator.js
@@ -1,21 +1,26 @@
 'use strict';
 
-const forEach = require('lodash.foreach'),
-  log = require('intel').getLogger('sitespeedio.plugin.webpagetest'),
-  statsHelpers = require('../../support/statsHelpers');
+const forEach = require('lodash.foreach');
 
 const metrics = ['TTFB', 'render', 'fullyLoaded', 'SpeedIndex'];
 
-module.exports = {
-  timingStats: {},
-  assetStats: {},
-  customStats: {},
-  assetGroups: {},
-  timingGroups: {},
-  customGroups: {},
-  connectivity: undefined,
-  location: undefined,
+class Aggregator {
+  constructor(statsHelpers, log) {
+    this.statsHelpers = statsHelpers;
+    this.log = log;
+    this.timingStats = {};
+    this.assetStats = {};
+    this.customStats = {};
+    this.assetGroups = {};
+    this.timingGroups = {};
+    this.customGroups = {};
+    this.connectivity;
+    this.location;
+  }
+
   addToAggregate(group, wptData, connectivity, location, wptOptions) {
+    const log = this.log;
+    const statsHelpers = this.statsHelpers;
     // TODO this will break if we run multiple locations/connectivity per run
     this.location = location;
     this.connectivity = connectivity;
@@ -81,7 +86,8 @@ module.exports = {
         });
       });
     });
-  },
+  }
+
   summarize() {
     const summary = {
       groups: {
@@ -114,8 +120,10 @@ module.exports = {
       }
     }
     return summary;
-  },
+  }
+
   summarizePerAssetType(type) {
+    const statsHelpers = this.statsHelpers;
     const summary = {};
     forEach(type, (view, viewName) =>
       forEach(view, (contentType, contentTypeName) =>
@@ -129,8 +137,10 @@ module.exports = {
       )
     );
     return summary;
-  },
+  }
+
   summarizePerTimingType(type) {
+    const statsHelpers = this.statsHelpers;
     const summary = {};
     forEach(type, (view, viewName) =>
       forEach(view, (stats, name) =>
@@ -138,8 +148,10 @@ module.exports = {
       )
     );
     return summary;
-  },
+  }
+
   summarizePerCustomType(type) {
+    const statsHelpers = this.statsHelpers;
     const summary = {};
     forEach(type, (view, viewName) =>
       forEach(view, (metricName, name) =>
@@ -154,4 +166,6 @@ module.exports = {
     );
     return summary;
   }
-};
+}
+
+module.exports = Aggregator;

--- a/lib/plugins/webpagetest/analyzer.js
+++ b/lib/plugins/webpagetest/analyzer.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Promise = require('bluebird');
-const log = require('intel').getLogger('sitespeedio.plugin.webpagetest');
 const clone = require('lodash.clonedeep');
 const get = require('lodash.get');
 const WebPageTest = require('webpagetest');
@@ -10,7 +9,7 @@ const WPTAPIError = require('webpagetest/lib/helper').WPTAPIError;
 Promise.promisifyAll(WebPageTest.prototype);
 
 module.exports = {
-  analyzeUrl(url, storageManager, wptOptions) {
+  analyzeUrl(url, storageManager, log, wptOptions) {
     const wptClient = new WebPageTest(wptOptions.host, wptOptions.key);
     wptOptions.firstViewOnly = !wptOptions.includeRepeatView;
     let urlOrScript = url;

--- a/lib/plugins/webpagetest/index.js
+++ b/lib/plugins/webpagetest/index.js
@@ -2,15 +2,16 @@
 
 const urlParser = require('url');
 const analyzer = require('./analyzer');
-const aggregator = require('./aggregator');
+const Aggregator = require('./aggregator');
 const forEach = require('lodash.foreach');
 const merge = require('lodash.merge');
 const get = require('lodash.get');
 const path = require('path');
-const log = require('intel').getLogger('sitespeedio.plugin.webpagetest');
 const WebPageTest = require('webpagetest');
 const fs = require('fs');
 
+// These are the metrics we want to save in
+// the time series database per pageSummary
 const DEFAULT_PAGE_SUMMARY_METRICS = [
   'data.median.*.SpeedIndex',
   'data.median.*.render',
@@ -25,6 +26,8 @@ const DEFAULT_PAGE_SUMMARY_METRICS = [
   'data.median.*.requestsFull'
 ];
 
+// These are the metrics we want to save in
+// the time series database per summary (per domain/test/group)
 const DEFAULT_SUMMARY_METRICS = [
   'timing.*.SpeedIndex',
   'timing.*.render',
@@ -67,21 +70,32 @@ function isPublicWptHost(address) {
 
 module.exports = {
   open(context, options) {
+    // The context holds help methods to setup what we need in plugin
+    // Get a log specificfor this plugin
+    this.log = context.intel.getLogger('sitespeedio.plugin.webpagetest');
+    // Make will help you create messages that you will send on the queue
     this.make = context.messageMaker('webpagetest').make;
-    this.options = merge({}, defaultConfig, options.webpagetest);
+    // The aggregator helps you aggregate metrics per URL and/or domain
+    this.aggregator = new Aggregator(context.statsHelpers, this.log);
+    // The storagemanager helps you save file to disk
     this.storageManager = context.storageManager;
+    // The filter registry decides which metrics that will be stored in the time/series db
     this.filterRegistry = context.filterRegistry;
+
+    this.options = merge({}, defaultConfig, options.webpagetest);
+
     if (!this.options.key && isPublicWptHost(this.options.host)) {
       throw new Error(
         'webpagetest.key needs to be specified when using the public WebPageTest server.'
       );
     }
 
-    context.filterRegistry.registerFilterForType(
+    // Register the type of metrics we want to have in the db
+    this.filterRegistry.registerFilterForType(
       DEFAULT_PAGE_SUMMARY_METRICS,
       'webpagetest.pageSummary'
     );
-    context.filterRegistry.registerFilterForType(
+    this.filterRegistry.registerFilterForType(
       DEFAULT_SUMMARY_METRICS,
       'webpagetest.summary'
     );
@@ -96,6 +110,9 @@ module.exports = {
     const make = this.make;
     const wptOptions = this.options;
     switch (message.type) {
+      // In the setup phase, register our pug file(s) in the HTML plugin
+      // by sending a message. This plugin uses the same pug for data
+      // per run and per page summary.
       case 'sitespeedio.setup': {
         queue.postMessage(
           make('html.pug', {
@@ -116,11 +133,12 @@ module.exports = {
         break;
       }
 
+      // We got a URL that we should test
       case 'url': {
         const url = message.url;
         const group = message.group;
         return analyzer
-          .analyzeUrl(url, this.storageManager, wptOptions)
+          .analyzeUrl(url, this.storageManager, this.log, wptOptions)
           .tap(result => {
             addCustomMetric(result, filterRegistry);
             if (result.trace) {
@@ -165,7 +183,7 @@ module.exports = {
                 connectivity
               })
             );
-            aggregator.addToAggregate(
+            this.aggregator.addToAggregate(
               group,
               result,
               connectivity,
@@ -174,7 +192,7 @@ module.exports = {
             );
           })
           .catch(err => {
-            log.error('Error creating WebPageTest result ', err);
+            this.log.error('Error creating WebPageTest result ', err);
             queue.postMessage(
               make('error', err, {
                 url
@@ -183,14 +201,15 @@ module.exports = {
           });
       }
 
+      // All URLs are tested, now create summaries per page and domain/group
       case 'sitespeedio.summarize': {
-        let summary = aggregator.summarize();
+        let summary = this.aggregator.summarize();
         if (summary && Object.keys(summary.groups).length > 0) {
           for (let group of Object.keys(summary.groups)) {
             queue.postMessage(
               make('webpagetest.summary', summary.groups[group], {
-                connectivity: aggregator.connectivity,
-                location: aggregator.location,
+                connectivity: this.aggregator.connectivity,
+                location: this.aggregator.location,
                 group
               })
             );

--- a/test/webpagetestTests.js
+++ b/test/webpagetestTests.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const plugin = require('../lib/plugins/webpagetest');
-const aggregator = require('../lib/plugins/webpagetest/aggregator');
+const Aggregator = require('../lib/plugins/webpagetest/aggregator');
 const fs = require('fs');
 const path = require('path');
 const expect = require('chai').expect;
+const intel = require('intel');
 const messageMaker = require('../lib/support/messageMaker');
 const filterRegistry = require('../lib/support/filterRegistry');
+const statsHelpers = require('../lib/support/statsHelpers');
 
 const wptResultPath = path.resolve(
   __dirname,
@@ -16,7 +18,7 @@ const wptResultPath = path.resolve(
 const wptResult = JSON.parse(fs.readFileSync(wptResultPath, 'utf8'));
 
 describe('webpagetest', () => {
-  const context = { messageMaker, filterRegistry };
+  const context = { messageMaker, filterRegistry, intel, statsHelpers };
 
   describe('plugin', () => {
     it('should require key for default server', () => {
@@ -34,6 +36,10 @@ describe('webpagetest', () => {
     });
   });
 
+  const aggregator = new Aggregator(
+    statsHelpers,
+    intel.getLogger('sitespeedio.plugin.webpagetest')
+  );
   describe('aggregator', () => {
     it('should summarize data', () => {
       aggregator.addToAggregate(


### PR DESCRIPTION
Let the WPT plugin be an example for plugin developers so more or less can copy/paste some code (fixing requires for sitespeed.io code).