### PR TITLE
Notify plugins that Browsertime and WebPageTest will run

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -160,7 +160,7 @@ module.exports = {
     switch (message.type) {
       case 'sitespeedio.setup': {
         // Let other plugins know that the browsertime plugin is alive
-        queue.postMessage(make('browsertime.setup', {}, {}));
+        queue.postMessage(make('browsertime.setup'));
         break;
       }
       case 'browsertime.config': {

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -158,6 +158,11 @@ module.exports = {
     }
 
     switch (message.type) {
+      case 'sitespeedio.setup': {
+        // Let other plugins know that the browsertime plugin is alive
+        queue.postMessage(make('browsertime.setup', {}, {}));
+        break;
+      }
       case 'browsertime.config': {
         merge(this.options, message.data);
         break;

--- a/lib/plugins/coach/index.js
+++ b/lib/plugins/coach/index.js
@@ -73,7 +73,7 @@ module.exports = {
   processMessage(message, queue) {
     const make = this.make;
     switch (message.type) {
-      case 'sitespeedio.setup': {
+      case 'browsertime.setup': {
         queue.postMessage(make('browsertime.config', { coach: true }));
         break;
       }

--- a/lib/plugins/screenshot/index.js
+++ b/lib/plugins/screenshot/index.js
@@ -66,7 +66,7 @@ module.exports = {
   },
   processMessage(message, queue) {
     switch (message.type) {
-      case 'sitespeedio.setup': {
+      case 'browsertime.setup': {
         queue.postMessage(
           this.make('browsertime.config', {
             screenshot: true,

--- a/lib/plugins/webpagetest/index.js
+++ b/lib/plugins/webpagetest/index.js
@@ -144,6 +144,9 @@ module.exports = {
       // by sending a message. This plugin uses the same pug for data
       // per run and per page summary.
       case 'sitespeedio.setup': {
+        // Tell other plugins that webpagetest will run
+        queue.postMessage(make('webpagetest.setup', {}, {}));
+        // Add the HTML pugs
         queue.postMessage(
           make('html.pug', {
             id: 'webpagetest',

--- a/lib/plugins/webpagetest/index.js
+++ b/lib/plugins/webpagetest/index.js
@@ -145,7 +145,7 @@ module.exports = {
       // per run and per page summary.
       case 'sitespeedio.setup': {
         // Tell other plugins that webpagetest will run
-        queue.postMessage(make('webpagetest.setup', {}, {}));
+        queue.postMessage(make('webpagetest.setup'));
         // Add the HTML pugs
         queue.postMessage(
           make('html.pug', {


### PR DESCRIPTION
Add message in the queue that Browsertime and WebPageTest are
read for getting configuration messages. This will make it possible
for other plugins to know if Browsertime or/and WebPageTest is
running.

