### PR TITLE
Fixed some problems with selenium-docker failing + set browsertime aggregator options

### DIFF
--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-set -e
+
+trap "exit" INT TERM ERR
+trap "kill 0" EXIT
 
 google-chrome --version
 firefox --version
 
 BROWSERTIME=/usr/src/app/bin/browsertimeWebPageReplay.js
 SITESPEEDIO=/usr/src/app/bin/sitespeed.js
+export DBUS_SESSION_BUS_ADDRESS=/dev/null
 
 MAX_OLD_SPACE_SIZE="${MAX_OLD_SPACE_SIZE:-2048}"
 
@@ -28,6 +31,17 @@ fi
 # Here's a hack for fixing the problem with Chrome not starting in time
 # See https://github.com/SeleniumHQ/docker-selenium/issues/87#issuecomment-250475864
 function chromeSetup() {
+
+  # Kill process by command
+  function killProcessByCommand() {
+    list=$(ps aux | grep ${1} | awk '{ print $2 }' ORS=' ')
+    if [ "${list}" != "" ]; then
+      killall ${1} > /dev/null 2>/dev/null
+    fi
+  }
+  service dbus stop > /dev/null
+  killProcessByCommand /usr/bin/dbus-daemon
+  killProcessByCommand /usr/lib/at-spi2-core/at-spi-bus-launcher
   sudo rm -f /var/lib/dbus/machine-id
   sudo mkdir -p /var/run/dbus
   sudo service dbus restart > /dev/null

--- a/lib/plugins/browsertime/aggregator.js
+++ b/lib/plugins/browsertime/aggregator.js
@@ -8,6 +8,7 @@ const timings = ['firstPaint', 'fullyLoaded', 'rumSpeedIndex'];
 module.exports = {
   statsPerType: {},
   groups: {},
+  options: {},
 
   addToAggregate(browsertimeRunData, group) {
     if (this.groups[group] === undefined) {
@@ -102,7 +103,7 @@ module.exports = {
   summarizePerObject(obj) {
     return Object.keys(obj).reduce((summary, name) => {
       if (timings.indexOf(name) > -1) {
-        statsHelpers.setStatsSummary(summary, name, obj[name]);
+        statsHelpers.setStatsSummary(summary, name, obj[name], this.options);
       } else if ('userTimings'.indexOf(name) > -1) {
         summary.userTimings = {};
         const marksData = {},

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -79,6 +79,7 @@ module.exports = {
     this.resultUrls = context.resultUrls;
     this.pluginScripts = [];
     this.pluginAsyncScripts = [];
+    aggregator.options = options.browsertime.aggregator.options;
     browsertime.logging.configure(options);
     this.screenshotType = get(
       options,

--- a/lib/support/statsHelpers.js
+++ b/lib/support/statsHelpers.js
@@ -39,8 +39,8 @@ module.exports = {
   /**
    * Summarize stats and put result in target at path
    */
-  setStatsSummary(target, path, stats) {
-    set(target, path, this.summarizeStats(stats));
+  setStatsSummary(target, path, stats, options) {
+    set(target, path, this.summarizeStats(stats, options));
   },
 
   summarizeStats(stats, options) {
@@ -50,6 +50,9 @@ module.exports = {
 
     options = options || {};
     let percentiles = options.percentiles || [0, 90, 100];
+    if (typeof percentiles === 'string') {
+      percentiles = percentiles.split(',');
+    }
     let decimals = options.decimals || 0;
     let data = {
       median: parseInt(stats.median().toFixed(decimals)),


### PR DESCRIPTION
Fixed some problems with selenium-docker failing in case for a lot off scenarios in one docker contained without rebutting container

- add ability to set browsertime aggregator options like "--browsertime.aggregator.options.percentiles 0,90,95,99,100"

### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [ ] Check that your change/fix has corresponding unit tests (if applicable)
- [ ] Squash commits so it looks sane
- [ ] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR
- [ ] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
Please describe your pull request and tell us the fix #

Thank you for making sitespeed.io even better!
