### PR TITLE
Add option to S3 plugin for ACL settings on put objects, this setting…

### DIFF
--- a/docs/documentation/sitespeed.io/configuration/config.md
+++ b/docs/documentation/sitespeed.io/configuration/config.md
@@ -111,6 +111,7 @@ s3
   --s3.bucketname         Name of the S3 bucket
   --s3.path               Override the default folder path in the bucket where the results are uploaded. By default it's "DOMAIN_OR_FILENAME/TIMESTAMP", or the name of the folder if --outputFolder is specified.
   --s3.region             The S3 region. Optional depending on your settings.
+  --s3.acl                The S3 canned ACL to set, optional depending on your settings.
   --s3.removeLocalResult  Remove all the local result files after they have been uploaded to S3  [boolean] [default: false]
 
 HTML

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -559,6 +559,11 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe: 'The S3 region. Optional depending on your settings.',
       group: 's3'
     })
+    .option('s3.acl', {
+      describe:
+        'The S3 canned ACL to set. Optional depending on your settings .',
+      group: 's3'
+    })
     .option('s3.removeLocalResult', {
       describe:
         'Remove all the local result files after they have been uploaded to S3',

--- a/lib/plugins/s3/index.js
+++ b/lib/plugins/s3/index.js
@@ -70,7 +70,10 @@ module.exports = {
           // See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
         }
       };
-
+      //preserve back compatability rather than set undefined
+      if (s3Options.acl) {
+        params.s3Params.ACL = s3Options.acl;
+      }
       return new Promise((resolve, reject) => {
         log.info(
           `Uploading ${baseDir} to S3 bucket ${


### PR DESCRIPTION
This option currently isn't provided by the s3 plugin.
The option `s3.acl` allows adding one of the canned ACL's for S3 buckets rather than letting a default setting. See #1935  

Closes #1935 

### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [x] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
Please describe your pull request and tell us the fix #

Thank you for making sitespeed.io even better!
