### PR TITLE
quick-fix for case of no-succesful wpt runs, undefined error not handled

### DIFF
--- a/lib/plugins/webpagetest/analyzer.js
+++ b/lib/plugins/webpagetest/analyzer.js
@@ -27,6 +27,7 @@ module.exports = {
       log.verbose('Got JSON from WebPageTest :%:2j', data);
 
       // Something failed with WebPageTest but how should we handle that?
+      // Also, this doesn't contain every failure case e.g. successfulFV/RVRuns=0 we should include it
       if (data.statusCode !== 200) {
         log.error(
           'The test got status code %s from WebPageTest with %s. Checkout %s to try to find the original reason.',
@@ -40,6 +41,7 @@ module.exports = {
       // /!\ this mutates data
       if (
         data.statusCode === 200 &&
+        data.data.median.firstView &&
         'chromeUserTiming' in data.data.median.firstView
       ) {
         let chromeUserTiming = {};


### PR DESCRIPTION
- [x] I'm not making a big change or adding functionality so I haven't opened an issue proposing the change to other contributors
- [x] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
As mentioned on slack this morning to Peter had a wpt run returning:
```
        "fvonly": false,
        "successfulFVRuns": 0,
        "successfulRVRuns": 0,
        ....
        "median": []
```
as the test location specified was valid, as i got no api request failure but invalid, http://52.208.139.70/results.php?test=180312_HX_40edf20ba14266c6d4d33a03c83164ef

and as we are not checking if the property firstView exists in the median block an undefined error is throw and not catched.

ERROR: [sitespeedio.plugin.webpagetest] Error creating WebPageTest result  TypeError: Cannot use 'in' operator to search for 'chromeUserTiming' in undefined
    at /usr/src/app/lib/plugins/webpagetest/analyzer.js:43:28 

