### PR TITLE
make outputFolder as string type

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -720,7 +720,8 @@ module.exports.parseCommandLine = function parseCommandLine() {
       type: 'boolean'
     })
     .option('outputFolder', {
-      describe: 'The folder where the result will be stored.'
+      describe: 'The folder where the result will be stored.',
+      type: 'string'
     })
     .option('firstParty', {
       describe:


### PR DESCRIPTION

PR to make outputFolder as `string` type.  Issues are thrown from the container if the outputfolder is named in a numeric form.

```
docker run -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io --outputFolder "1234" https://www.sitespeed.io/ -n 1
Google Chrome 63.0.3239.132 
Mozilla Firefox 54.0.1
TypeError: Path must be a string. Received 1234
    at assertPath (path.js:28:11)
    at Object.basename (path.js:1390:5)
    at module.exports (/usr/src/app/lib/core/resultsStorage/index.js:25:33)
    at Object.run (/usr/src/app/lib/sitespeed.js:52:44)
    at Object.<anonymous> (/usr/src/app/bin/sitespeed.js:30:4)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Function.Module.runMain (module.js:684:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
```