### PR TITLE
📖 Update docs: Browsertime's percentile and decimal options

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -347,6 +347,18 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe:
         'Run the browser in headless mode. This is the browser internal headless mode, meaning you cannot collect visual metrics or in Chrome run any WebExtension.'
     })
+    .option('browsertime.percentiles', {
+      type: 'array',
+      default: [0, 10, 90, 99, 100],
+      describe:
+        'The percentile values within the data browsertime will calculate and report.'
+    })
+    .option('browsertime.decimals', {
+      type: 'number',
+      default: 0,
+      describe:
+        'The decimal points browsertime statistics round to.'
+    })
     /*
    Crawler options
    */


### PR DESCRIPTION
When I needed to reduce the number of metrics sending to Graphite, I've seen the option to apply by own set of percentiles for browsertime that was not documented. This is the documentation for it.