### PR TITLE
FIX statsd timer

### DIFF
--- a/lib/plugins/graphite/helpers/format-entry.js
+++ b/lib/plugins/graphite/helpers/format-entry.js
@@ -6,7 +6,7 @@
 module.exports = type => {
   switch (type) {
     case 'statsd':
-      return '%s:%s|t';
+      return '%s:%s|ms';
     case 'graphite':
     default:
       return '%s %s %s';

--- a/test/graphiteTests.js
+++ b/test/graphiteTests.js
@@ -98,8 +98,9 @@ describe('graphite', function() {
         graphite: { statsd: true }
       });
       var data = generator.dataFromMessage(message, moment());
+
       expect(data).to.match(
-        /ns.summary.sub_domain_com.chrome.cable.domains.www.sitespeed.io.dns.median:[\d]{1,}\|t/
+        /ns.summary.sub_domain_com.chrome.cable.domains.www.sitespeed.io.dns.median:[\d]{1,}\|ms/
       );
     });
   });
@@ -161,7 +162,7 @@ describe('graphite', function() {
     const formatEntry = require('../lib/plugins/graphite/helpers/format-entry');
 
     it('Should retrieve the format of statsd', function() {
-      expect(formatEntry('statsd')).to.equal('%s:%s|t');
+      expect(formatEntry('statsd')).to.equal('%s:%s|ms');
     });
 
     it('Should retrieve the default format of graphite', function() {


### PR DESCRIPTION
Apply fix from https://github.com/sitespeedio/sitespeed.io/pull/2014

> My implementation was error
> StatsD supports the types:
> 
> * counter `c` (default)
> * timer `ms`
> * set `s`
> * gauge `g`
> * histogram `h`
> 
> So `t` defaulted to counter