### PR TITLE
Fix tab spacing for configuration as JSON example

### DIFF
--- a/docs/documentation/sitespeed.io/configuration/index.md
+++ b/docs/documentation/sitespeed.io/configuration/index.md
@@ -159,9 +159,9 @@ Create a config file and call it config.json:
     "host": "my.graphite.host",
     "namespace": "sitespeed_io.desktopFirstView"
   },
-"plugins": {
-	"disable": ["html"]
-	},
+  "plugins": {
+    "disable": ["html"]
+  },
   "utc": true
 }
 ~~~


### PR DESCRIPTION
Replace tabs with spaces in the example for the configuration as JSON