### PR TITLE
[FIX] StatsD entry format

### DIFF
--- a/lib/plugins/graphite/data-generator.js
+++ b/lib/plugins/graphite/data-generator.js
@@ -7,6 +7,9 @@ const flatten = require('../../support/flattenMessage'),
   formatEntry = require('./helpers/format-entry'),
   isStatsd = require('./helpers/is-statsd');
 
+const STATSD = 'statsd';
+const GRAPHITE = 'graphite';
+
 function keyPathFromMessage(message, options, includeQueryParams) {
   let typeParts = message.type.split('.');
   typeParts.push(typeParts.shift());
@@ -55,7 +58,7 @@ class GraphiteDataGenerator {
     this.namespace = namespace;
     this.includeQueryParams = !!includeQueryParams;
     this.options = options;
-    this.entryFormat = isStatsd(options.graphite) ? 'statsd' : 'graphite';
+    this.entryFormat = isStatsd(options.graphite) ? STATSD : GRAPHITE;
   }
 
   dataFromMessage(message, time) {
@@ -71,9 +74,10 @@ class GraphiteDataGenerator {
       flatten.flattenMessageData(message),
       (entries, value, key) => {
         const fullKey = util.format('%s.%s.%s', this.namespace, keypath, key);
-        entries.push(
-          util.format(formatEntry(this.entryFormat), fullKey, value, timestamp)
-        );
+        const args = [formatEntry(this.entryFormat), fullKey, value];
+        this.entryFormat === GRAPHITE && args.push(timestamp);
+
+        entries.push(util.format.apply(util, args));
         return entries;
       },
       []

--- a/test/graphiteTests.js
+++ b/test/graphiteTests.js
@@ -99,9 +99,11 @@ describe('graphite', function() {
       });
       var data = generator.dataFromMessage(message, moment());
 
-      expect(data).to.match(
-        /ns.summary.sub_domain_com.chrome.cable.domains.www.sitespeed.io.dns.median:[\d]{1,}\|ms/
-      );
+      data.forEach(function(line) {
+        expect(line).to.match(
+          /ns.summary.sub_domain_com.chrome.cable.domains.www.sitespeed.io.dns.(median|mean|min|p10|p90|p99|max):[\d]{1,}\|ms/
+        );
+      });
     });
   });
 

--- a/test/graphiteTests.js
+++ b/test/graphiteTests.js
@@ -101,7 +101,7 @@ describe('graphite', function() {
 
       data.forEach(function(line) {
         expect(line).to.match(
-          /ns.summary.sub_domain_com.chrome.cable.domains.www.sitespeed.io.dns.(median|mean|min|p10|p90|p99|max):[\d]{1,}\|ms/
+          /ns.summary.sub_domain_com.chrome.cable.domains.www.sitespeed.io.dns.(median|mean|min|p10|p90|p99|max):[\d]{1,}\|ms$/
         );
       });
     });


### PR DESCRIPTION
Addressing issue https://github.com/sitespeedio/sitespeed.io/issues/2106 : StatsD formatting with excess of timestamp at end of line
```
sitespeed_io.default.pageSummary.hey_car._.chrome.3gfast.browsertime.statistics.cpu.events.XHRReadyStateChange.p90:1|ms 1532331394
```

Some implementations of StatsD will allow this excess while other do noe. None of them use it.
`util`'s string formatter places any "extra" arguments at the end of the string - and this is why this string was included while not needed by the format.
I have changed the number of arguments to exclude this string from every line. This should fix the issue