### PR TITLE
Make it easy for people that uses # in the URL and want to keep it.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -806,6 +806,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
       default: false,
       type: 'boolean'
     })
+    .option('useHash', {
+      describe:
+        'If your site uses # for URLs and # give you unique URLs you need to turn on useHash. By default is it turned off, meaning URLs with hash and without hash are treated as the same URL',
+      default: false,
+      type: 'boolean'
+    })
     .help('h')
     .alias('help', 'h')
     .config('config')

--- a/lib/core/resultsStorage/index.js
+++ b/lib/core/resultsStorage/index.js
@@ -15,7 +15,13 @@ function getDomainOrFileName(input) {
   return domainOrFile;
 }
 
-module.exports = function(input, timestamp, outputFolder, resultBaseURL) {
+module.exports = function(
+  input,
+  timestamp,
+  outputFolder,
+  resultBaseURL,
+  useHash
+) {
   const resultsSubFolders = [];
   let storageBasePath;
   let storagePathPrefix;
@@ -42,7 +48,7 @@ module.exports = function(input, timestamp, outputFolder, resultBaseURL) {
   }
 
   return {
-    storageManager: storageManager(storageBasePath, storagePathPrefix),
-    resultUrls: resultUrls(resultUrl)
+    storageManager: storageManager(storageBasePath, storagePathPrefix, useHash),
+    resultUrls: resultUrls(resultUrl, useHash)
   };
 };

--- a/lib/core/resultsStorage/pathToFolder.js
+++ b/lib/core/resultsStorage/pathToFolder.js
@@ -4,10 +4,13 @@ const isEmpty = require('lodash.isempty'),
   crypto = require('crypto'),
   urlParser = require('url');
 
-module.exports = function pathFromRootToPageDir(url) {
+module.exports = function pathFromRootToPageDir(url, useHash) {
   const parsedUrl = urlParser.parse(decodeURIComponent(url)),
     pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
 
+  if (useHash && parsedUrl.hash) {
+    pathSegments.unshift(parsedUrl.hash);
+  }
   pathSegments.unshift(parsedUrl.hostname);
 
   pathSegments.unshift('pages');

--- a/lib/core/resultsStorage/resultUrls.js
+++ b/lib/core/resultsStorage/resultUrls.js
@@ -3,7 +3,7 @@
 const urlParser = require('url');
 const pathToFolder = require('./pathToFolder');
 
-module.exports = function resultUrls(resultBaseUrl) {
+module.exports = function resultUrls(resultBaseUrl, useHash) {
   return {
     hasBaseUrl() {
       return !!resultBaseUrl;
@@ -13,11 +13,13 @@ module.exports = function resultUrls(resultBaseUrl) {
     },
     absoluteSummaryPageUrl(url) {
       const pageUrl = urlParser.parse(resultBaseUrl);
-      pageUrl.pathname = [pageUrl.pathname, pathToFolder(url)].join('/');
+      pageUrl.pathname = [pageUrl.pathname, pathToFolder(url, useHash)].join(
+        '/'
+      );
       return urlParser.format(pageUrl);
     },
     relativeSummaryPageUrl(url) {
-      return pathToFolder(url);
+      return pathToFolder(url, useHash);
     }
   };
 };

--- a/lib/core/resultsStorage/storageManager.js
+++ b/lib/core/resultsStorage/storageManager.js
@@ -16,10 +16,10 @@ function isValidDirectoryName(name) {
   return name !== undefined && name !== '';
 }
 
-module.exports = function storageManager(baseDir, storagePathPrefix) {
+module.exports = function storageManager(baseDir, storagePathPrefix, useHash) {
   return {
     rootPathFromUrl(url) {
-      return pathToFolder(url)
+      return pathToFolder(url, useHash)
         .split('/')
         .filter(isValidDirectoryName)
         .map(() => '..')
@@ -50,12 +50,14 @@ module.exports = function storageManager(baseDir, storagePathPrefix) {
       return this.createDirectory().then(dir => fs.copy(filename, dir));
     },
     createDirForUrl(url, subDir) {
-      return this.createDirectory(pathToFolder(url), subDir);
+      return this.createDirectory(pathToFolder(url, useHash), subDir);
     },
     writeDataForUrl(data, filename, url, subDir) {
-      return this.createDirectory(pathToFolder(url), 'data', subDir).then(dir =>
-        write(dir, filename, data)
-      );
+      return this.createDirectory(
+        pathToFolder(url, useHash),
+        'data',
+        subDir
+      ).then(dir => write(dir, filename, data));
     },
     writeHtmlForUrl(html, filename, url) {
       return this.createDirForUrl(url).then(dir => write(dir, filename, html));

--- a/lib/sitespeed.js
+++ b/lib/sitespeed.js
@@ -53,7 +53,8 @@ module.exports = {
       url,
       timestamp,
       options.outputFolder,
-      options.resultBaseURL
+      options.resultBaseURL,
+      options.useHash
     );
 
     return storageManager

--- a/lib/support/flattenMessage.js
+++ b/lib/support/flattenMessage.js
@@ -8,11 +8,11 @@ function joinNonEmpty(strings, delimeter) {
 }
 
 function toSafeKey(key) {
-  return key.replace(/[.~ /+|,:?&%]|%7C/g, '_');
+  return key.replace(/[.~ /+#|,:?&%]|%7C/g, '_');
 }
 
 module.exports = {
-  keypathFromUrl(url, includeQueryParams) {
+  keypathFromUrl(url, includeQueryParams, useHash) {
     function flattenQueryParams(params) {
       return Object.keys(params).reduce(
         (result, key) => joinNonEmpty([result, key, params[key]], '_'),
@@ -29,6 +29,9 @@ module.exports = {
         [path, toSafeKey(flattenQueryParams(url.query))],
         '_'
       );
+    }
+    if (useHash && url.hash) {
+      path = joinNonEmpty([path, toSafeKey(url.hash)], '_');
     }
 
     const keys = [toSafeKey(url.hostname), path];

--- a/lib/support/tsdbUtil.js
+++ b/lib/support/tsdbUtil.js
@@ -26,7 +26,7 @@ module.exports = {
       let alias = options.urlsMetaData[url].alias;
       return this.toSafeKey(group) + '.' + this.toSafeKey(alias);
     } else {
-      return flatten.keypathFromUrl(url, includeQueryParams);
+      return flatten.keypathFromUrl(url, includeQueryParams, options.useHash);
     }
   }
 };


### PR DESCRIPTION
We have been old and conservative in how we use # when creating URLs:
From the beginning (5+ years ago) we always left out # from URLs when
we decided if a URL is unique or not. Now you can choose yourself
with --useHash (is there a better name out there?).