### PR TITLE
Use path so we in the future can add full URL including index.html

### DIFF
--- a/lib/core/resultsStorage/resultUrls.js
+++ b/lib/core/resultsStorage/resultUrls.js
@@ -11,7 +11,13 @@ module.exports = function resultUrls(resultBaseUrl) {
     reportSummaryUrl() {
       return resultBaseUrl;
     },
+    // In the future this one shoudl include the full URL including /index.html
     absoluteSummaryPageUrl(url) {
+      const pageUrl = urlParser.parse(resultBaseUrl);
+      pageUrl.pathname = [pageUrl.pathname, pathToFolder(url)].join('/');
+      return urlParser.format(pageUrl);
+    },
+    absoluteSummaryPagePath(url) {
       const pageUrl = urlParser.parse(resultBaseUrl);
       pageUrl.pathname = [pageUrl.pathname, pathToFolder(url)].join('/');
       return urlParser.format(pageUrl);

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -141,7 +141,7 @@ module.exports = {
               _meta.firstParty = this.firstParty;
             }
             if (this.resultUrls.hasBaseUrl()) {
-              const base = this.resultUrls.absoluteSummaryPageUrl(url);
+              const base = this.resultUrls.absoluteSummaryPagePath(url);
               _meta.screenshot = `${base}data/screenshots/${runIndex + 1}.${
                 this.screenshotType
               }`;

--- a/lib/plugins/graphite/index.js
+++ b/lib/plugins/graphite/index.js
@@ -91,7 +91,7 @@ module.exports = {
           message.type === this.annotationType &&
           this.resultUrls.hasBaseUrl()
         ) {
-          const resultPageUrl = this.resultUrls.absoluteSummaryPageUrl(
+          const resultPageUrl = this.resultUrls.absoluteSummaryPagePath(
             message.url
           );
           let screenshotPath;

--- a/lib/plugins/influxdb/index.js
+++ b/lib/plugins/influxdb/index.js
@@ -83,7 +83,7 @@ module.exports = {
           message.type === this.annotationType &&
           this.resultUrls.hasBaseUrl()
         ) {
-          const resultPageUrl = this.resultUrls.absoluteSummaryPageUrl(
+          const resultPageUrl = this.resultUrls.absoluteSummaryPagePath(
             message.url
           );
           let screenshotPath;

--- a/lib/plugins/slack/attachements.js
+++ b/lib/plugins/slack/attachements.js
@@ -140,7 +140,9 @@ module.exports = function(
     let text = url;
 
     if (resultUrls.hasBaseUrl()) {
-      text += ` (<${resultUrls.absoluteSummaryPageUrl(url)}|result>)`;
+      text += ` (<${resultUrls.absoluteSummaryPagePath(
+        url
+      )}index.html |result>)`;
     }
     const attachement = {
       color,
@@ -150,7 +152,7 @@ module.exports = function(
 
     if (resultUrls.hasBaseUrl()) {
       attachement['image_url'] =
-        resultUrls.absoluteSummaryPageUrl(url) +
+        resultUrls.absoluteSummaryPagePath(url) +
         'data/screenshots/0.' +
         screenshotType;
     }


### PR DESCRIPTION
This is not perfect but I think it could be the first step. We need to link directly to /index.html instead of just / so that we can use Digital Ocean and others who don't support / solving to index.html.

