### PR TITLE
Nav-bar video-page z

### DIFF
--- a/docs/_includes/css/navigation.css
+++ b/docs/_includes/css/navigation.css
@@ -87,7 +87,6 @@ max-width: 250px;
   }
 
   .nav {
-    z-index: 10;
     top: 0;
     background-color: #0095d2;
   }


### PR DESCRIPTION
### Description

This removes a CSS rule cascade which makes z-index issue for visual users wishing to use the navbar when on the video's page.

#### Steps to reproduce original problem

- visit https://www.sitespeed.io/video/ in a browser
- play any video
- scroll to a place where the video is at the top of the screen
- observe the video covering the nav, and an inability to read or interact with the nav menu

#### Before

![before: an image of sitespeed.io video content blocking visual nav access](https://user-images.githubusercontent.com/2605791/49325838-e300e980-f540-11e8-95a0-8231df076bef.png)

#### After

![after: an image of sitespeed.io video content not blocking visual nav access](https://user-images.githubusercontent.com/2605791/49325839-e300e980-f540-11e8-805b-272015b4ed91.png)
