### PR TITLE
By default use the supplied URL instead of final URL

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -129,8 +129,15 @@ module.exports = {
         );
         log.verbose('Result from Browsertime for %s with %:2j', url, result);
         for (let resultIndex = 0; resultIndex < result.length; resultIndex++) {
-          url = result[resultIndex].info.url;
-          group = urlParser.parse(url).hostname;
+          // If we use scripts or multiple, use the URL from the tested page
+          // so that we can handle click on links etc
+          // see https://github.com/sitespeedio/sitespeed.io/issues/2260
+          // we could change the plugins but since they do not work with
+          // multiple/scripting lets do it like this for now
+          if (this.scriptOrMultiple) {
+            url = result[resultIndex].info.url;
+            group = urlParser.parse(url).hostname;
+          }
           let runIndex = 0;
           // Browsertime supports alias for URLS in a script
           const alias = result[resultIndex].info.alias;

--- a/lib/plugins/pagexray/index.js
+++ b/lib/plugins/pagexray/index.js
@@ -46,6 +46,7 @@ module.exports = {
 
     this.usingWebpagetest = false;
     this.usingBrowsertime = false;
+    this.multi = options.multi;
   },
   processMessage(message, queue) {
     const make = this.make;
@@ -74,29 +75,50 @@ module.exports = {
           const pageSummary = pagexray.convert(message.data, config);
           pagexrayAggregator.addToAggregate(pageSummary, group);
 
-          // The HAR file can have multiple URLs
-          const sentURL = {};
-          for (let summary of pageSummary) {
-            if (!sentURL[summary.url]) {
-              sentURL[summary.url] = 1;
+          if (this.multi) {
+            // The HAR file can have multiple URLs
+            const sentURL = {};
+            for (let summary of pageSummary) {
+              if (!sentURL[summary.url]) {
+                sentURL[summary.url] = 1;
+                queue.postMessage(
+                  make('pagexray.pageSummary', summary, {
+                    url: summary.url,
+                    group // TODO get the group from the URL?
+                  })
+                );
+              } else {
+                sentURL[summary.url] += 1;
+              }
+              // Send each individual run too
               queue.postMessage(
-                make('pagexray.pageSummary', summary, {
+                make('pagexray.run', summary, {
                   url: summary.url,
-                  group // TODO get the group from the URL?
+                  group,
+                  runIndex: sentURL[summary.url] - 1,
+                  iteration: sentURL[summary.url]
                 })
               );
-            } else {
-              sentURL[summary.url] += 1;
             }
-            // Send each individual run too
+          } else {
             queue.postMessage(
-              make('pagexray.run', summary, {
-                url: summary.url,
-                group,
-                runIndex: sentURL[summary.url] - 1,
-                iteration: sentURL[summary.url]
+              make('pagexray.pageSummary', pageSummary[0], {
+                url: message.url,
+                group // TODO get the group from the URL?
               })
             );
+            let iteration = 1;
+            for (let summary of pageSummary) {
+              queue.postMessage(
+                make('pagexray.run', summary, {
+                  url: message.url,
+                  group,
+                  runIndex: iteration - 1,
+                  iteration
+                })
+              );
+              iteration++;
+            }
           }
         }
         break;


### PR DESCRIPTION
This works fine with the current WebPageTest, GPSI and Lighthouse.
https://github.com/sitespeedio/sitespeed.io/issues/2260

