### PR TITLE
cpu throttle to run inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN sudo apt-get update && sudo apt-get install libnss3-tools \
  mkdir -p $HOME/.pki/nssdb && \
  certutil -d $HOME/.pki/nssdb -N
 
+# For cpu throttling
+RUN sudo apt-get install cpulimit
+
 ENV PATH="/usr/local/bin:${PATH}"
 
 RUN wpr installroot --https_cert_file /webpagereplay/certs/wpr_cert.pem --https_key_file /webpagereplay/certs/wpr_key.pem
@@ -30,6 +33,9 @@ RUN npm install --production
 COPY . /usr/src/app
 
 COPY docker/scripts/start.sh /start.sh
+
+# Script for cpu throttling
+COPY docker/scripts/cpu-throttle.sh /cpu-throttle.sh
 
 ## This is to avoid click the OK button
 RUN mkdir -m 0750 /root/.android

--- a/docker/scripts/cpu-throttle.sh
+++ b/docker/scripts/cpu-throttle.sh
@@ -1,0 +1,10 @@
+while true; do
+    if ps -ef | grep driver | grep use-mock-keychain > /dev/null
+    then
+        PROCESS_PID=$(ps -ef | grep driver | grep use-mock-keychain | awk '{print $2}')
+        echo "Running"
+        echo $PROCESS_PID
+        cpulimit -p $PROCESS_PID -l $1
+    fi
+    sleep 1
+done

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -118,6 +118,25 @@ function runSitespeedio(){
 
 setupADB
 
+# Calling CPU throttle
+while getopts ":t:" opt; do
+case $opt in
+    t) arg_1="$OPTARG"
+    ;;
+    *) echo "Invalid argument."
+    ;;
+esac
+done
+
+printf "CPU throttled value is %s\n" "$arg_1"
+if [ -n "$arg_1" ]; then
+    echo "Starting cpu throttling..."
+    sh /cpu-throttle.sh $arg_1 & >> /cpu-throttle.out
+else
+    echo "No throttling. CPU runs at full capacity..."
+fi
+# End of cpu throttle
+
 if [ $REPLAY ]
 then
   runWebPageReplay "$@"

--- a/docs/documentation/sitespeed.io/docker/index.md
+++ b/docs/documentation/sitespeed.io/docker/index.md
@@ -95,6 +95,15 @@ If you run a server local on your machine and want to access it with sitespeed.i
 docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://host.docker.internal:4000/
 ~~~
 
+## CPU throttling
+
+If you want to limit the cpu usage for the running sitespeed tests, you can do that by adding <code>-t (number in percentage)</code> 
+
+Full example:
+~~~bash
+docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io https://www.sitespeed.io/ -t 100
+~~~
+
 ## Troubleshooting
 
 If something doesn't work, it's hard to guess what't wrong. Then hook up x11vnc with xvfb so that you can see what happens on your screen.


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [x] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
This change is for cpu throttling inside docker containers. Reference for cpulimit functionality is in "http://cpulimit.sourceforge.net". 

Usage :- "docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io https://www.sitespeed.io/ -t 100"
CPU throttle number behaves exactly as given in the cpulimit instruction documentation
