### PR TITLE
Send timeToContentfulPaint and timeToFirstInteractive by default to Graphite/InfluxDB

### DIFF
--- a/lib/plugins/browsertime/default/metricsPageSummary.js
+++ b/lib/plugins/browsertime/default/metricsPageSummary.js
@@ -6,6 +6,8 @@ module.exports = [
   'statistics.timings.fullyLoaded',
   'statistics.timings.firstPaint',
   'statistics.timings.timeToDomContentFlushed',
+  'statistics.timings.timeToContentfulPaint',
+  'statistics.timings.timeToFirstInteractive',
   'statistics.timings.userTimings',
   'statistics.timings.paintTiming',
   'statistics.visualMetrics.*',


### PR DESCRIPTION
Firefox only metrics.