### PR TITLE
Improve use of browsertime.connectivity.alias option

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -125,6 +125,10 @@ module.exports.parseCommandLine = function parseCommandLine() {
         'The connectivity profile. To actually set the connectivity you can choose between Docker networks or Throttle, read https://www.sitespeed.io/documentation/sitespeed.io/connectivity/',
       group: 'Browser'
     })
+    .option('browsertime.connectivity.alias', {
+      describe: 'Give your connectivity profile a custom name',
+      group: 'Browser'
+    })
     .option('browsertime.connectivity.downstreamKbps', {
       default: browsertimeConfig.connectivity.downstreamKbps,
       alias: ['downstreamKbps'],

--- a/lib/plugins/html/templates/runInfo.pug
+++ b/lib/plugins/html/templates/runInfo.pug
@@ -1,10 +1,11 @@
 
 - const profile = options.mobile ? 'mobile' : 'desktop'
+- const connectivity = options.browsertime.connectivity.alias || options.browsertime.connectivity.profile
   h2.url #{h.plural(noPages,'page')} analyzed for #{options.name ? options.name : h.short(context.name, 30)}
   p.small Tested #{timestamp} using #{h.cap(options.browsertime.browser)} for
     | #{ h.get(options, 'browsertime.chrome.android.package') ?  h.get(options, 'browsertime.chrome.android.package') + ' ': ''}
     | #{options.preURL ? 'preURL ' + h.short(options.preURL, 60) + ' ' : ''}
-    | #{h.plural(options.browsertime.iterations, 'run')} with #{profile} profile and connectivity #{options.browsertime.connectivity.profile}.#{ options.replay ? ' Using WebPageReplay.' : ''}#{ options.multi ? ' Using multi mode ' : ''}
+    | #{h.plural(options.browsertime.iterations, 'run')} with #{profile} profile and connectivity #{connectivity}.#{ options.replay ? ' Using WebPageReplay.' : ''}#{ options.multi ? ' Using multi mode ' : ''}
     if options.multi && options.html.showScript
         | (
         a(href= rootPath + 'scripts.html')= 'script'

--- a/lib/plugins/html/templates/url/includes/pageRunInfo.pug
+++ b/lib/plugins/html/templates/url/includes/pageRunInfo.pug
@@ -1,9 +1,10 @@
 - const profile = options.mobile ? 'mobile' : 'desktop'
 - const runTime = h.get(pageInfo, 'pageInfo.data.browsertime.run.timestamp', timestamp)
+- const connectivity = options.browsertime.connectivity.alias || options.browsertime.connectivity.profile
 p.small Tested #{runTime} using #{h.cap(options.browsertime.browser)} #{browser.version} for
   | #{ h.get(options, 'browsertime.chrome.android.package') ?  ' ' + h.get(options, 'browsertime.chrome.android.package') + ' ': ''}
   | #{options.preURL ? 'preURL ' + h.short(options.preURL, 60) + ' ': ''}
-  | #{h.plural(options.browsertime.iterations, 'run')} with #{profile} profile and connectivity #{options.browsertime.connectivity.profile}.#{ options.replay ? ' Using WebPageReplay.' : ''}#{ options.multi ? ' Using multi mode ' : ''}
+  | #{h.plural(options.browsertime.iterations, 'run')} with #{profile} profile and connectivity #{connectivity}.#{ options.replay ? ' Using WebPageReplay.' : ''}#{ options.multi ? ' Using multi mode ' : ''}
   if options.multi && options.html.showScript
     | (
     a(href= rootPath + 'scripts.html')= 'script'


### PR DESCRIPTION
- [X] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in this PR
- [X] Verify that the test works by running `npm test` and test linting by `npm run lint`

### Description
Browsertime supports `connectivity.alias` option to give connectivity profiles a custom name, though this is not documented in the Sitespeed cli help, and not consistently used in Sitespeed. (only used for writing to DB, but not in reports)

This PR
- adds option to sitespeed cli
- uses the alias in html reports
- adds documentation

Cheers,
Ferdinand
