### PR TITLE
List unmatched third party domains.

### DIFF
--- a/lib/plugins/html/templates/url/thirdparty/index.pug
+++ b/lib/plugins/html/templates/url/thirdparty/index.pug
@@ -49,6 +49,16 @@ if thirdparty.assets && Object.keys(thirdparty.assets).length > 0
                             li #{asset.url} 
                                 b (#{asset.entity.name})
 
+if thirdparty.possibileMissedThirdPartyDomains 
+    h3 Unmatched third party domains
+    p Here's a list of domains that didn't match any tool in 
+        a(href='https://github.com/patrickhulce/third-party-web') Third party web
+        | . If you are sure they are third party domains, please do a PR to that project.
+    table
+        each domain in thirdparty.possibileMissedThirdPartyDomains 
+            tr
+                td #{domain}
+
 - const pagexray = pageInfo.data.pagexray.run || pageInfo.data.pagexray.pageSummary;
 if pagexray.firstParty.requests
   include ./firstParty.pug

--- a/lib/plugins/thirdparty/index.js
+++ b/lib/plugins/thirdparty/index.js
@@ -25,7 +25,19 @@ module.exports = {
     const make = this.make;
     const thirdPartyAssetsByCategory = {};
     const toolsByCategory = {};
+    const possibileMissedThirdPartyDomains = [];
     if (message.type === 'pagexray.run') {
+      const firstPartyRegEx = message.data.firstPartyRegEx;
+      for (let d of Object.keys(message.data.domains)) {
+        const entity = getEntity(d);
+        if (entity !== undefined) {
+          // Here is a match
+        } else {
+          if (!d.match(firstPartyRegEx)) {
+            possibileMissedThirdPartyDomains.push(d);
+          }
+        }
+      }
       const byCategory = {};
       this.groups[message.url] = message.group;
       for (let asset of message.data.assets) {
@@ -70,7 +82,8 @@ module.exports = {
           {
             category: byCategory,
             assets: thirdPartyAssetsByCategory,
-            toolsByCategory
+            toolsByCategory,
+            possibileMissedThirdPartyDomains: possibileMissedThirdPartyDomains
           },
           {
             url: message.url,


### PR DESCRIPTION
This makes it easier to contribute to third party web +
makes it possible for us to track unmatched domains (even though
we don't do that at the moment).

