### PR TITLE
Use --android to test Chrome stable on Android

### DIFF
--- a/docs/documentation/sitespeed.io/mobile-phones/index.md
+++ b/docs/documentation/sitespeed.io/mobile-phones/index.md
@@ -91,7 +91,7 @@ You could also use [phuedxs](https://github.com/phuedx) [Pi Network Conditioner]
 You can also collect a video and get Visual Metrics. Running on Mac or without Docker you need to install the requirements for [VisualMetrics](https://github.com/sitespeedio/docker-visualmetrics-deps/blob/master/Dockerfile) yourself on your machine before you start. If you have everything setup you can run:
 
 ```bash
-sitespeed.io --browsertime.chrome.android.package com.android.chrome --video --speedIndex https://www.sitespeed.io
+sitespeed.io --browsertime.chrome.android.package com.android.chrome --video --visualMetrics https://www.sitespeed.io
 ```
 
 And using Docker (remember: only works in Linux hosts):
@@ -152,19 +152,11 @@ If you installed Chrome Canary on your phone and want to use it, then add `--chr
 One important thing when testing on mobile is to analyze the Chrome trace log. You can get that with _browsertime.chrome.collectTracingEvents_:
 
 ```bash
-sitespeed.io --browsertime.chrome.android.package com.android.chrome --browsertime.chrome.collectTracingEvents --video --speedIndex https://www.sitespeed.io
+sitespeed.io --browsertime.chrome.android.package com.android.chrome --cpu --video --visualMetrics https://www.sitespeed.io
 ```
 
-You can also change which categories to get. In this example we only get the devtools.timeline category.
+### Cookies
+ 
+Chrome on Android do not support WebExtensions and we use the [Browsertime Extension](https://github.com/sitespeedio/browsertime-extension) to set cookies, block requests and basic auth.
 
-```bash
-sitespeed.io --browsertime.chrome.android.package com.android.chrome --chrome.timeline https://www.sitespeed.io
-```
-
-### Collect the net log
-
-If you really want to deep dive into the what happens you can use the Chrome net log. You collect it with _browsertime.chrome.collectNetLog_:
-
-```bash
-sitespeed.io --browsertime.chrome.android.package com.android.chrome --browsertime.chrome.collectNetLog https://www.sitespeed.io
-```
+But you can set a cookie on Android you can do that with adding a request header `-r key:value`.

--- a/docs/documentation/sitespeed.io/thirdparty/index.md
+++ b/docs/documentation/sitespeed.io/thirdparty/index.md
@@ -67,5 +67,5 @@ You can also track CPU spent per tool/third party. It's turned off by default an
 
 ## Block all 3rd parties
 
-We have support to block specific third parties with `--block` but that isn't the most user friendly way sif you wanna test you site without third parties. We added support for blocking every domain except the one you configure (inspired by [WebPageTest](https://www.webpagetest.org)). 
+We have support to block specific third parties with `--block` but that isn't the most user friendly way if you wanna test you site without third parties. We added support for blocking every domain except the one you configure (inspired by [WebPageTest](https://www.webpagetest.org)). 
 Use `--chrome.blockDomainsExcept` to block all domains except. Use it multiple times to keep multiple domains. You can also use wildcard like *.sitespeed.io!

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -414,10 +414,17 @@ module.exports.parseCommandLine = function parseCommandLine() {
       group: 'Chrome'
     })
     .option('browsertime.chrome.android.package', {
-      alias: 'chrome.android.package',
+      alias: 'chu rome.android.package',
       describe:
         'Run Chrome on your Android device. Set to com.android.chrome for default Chrome version. You need to run adb start-server before you start.',
       group: 'Chrome'
+    })
+    .option('browsertime.android', {
+      alias: 'android',
+      type: 'boolean',
+      default: false,
+      describe:
+        'Short key to use Android. Will automatically use com.android.chrome (Chrome stable). If you want to use another Chrome version, use --chrome.android.package'
     })
     .option('browsertime.chrome.android.deviceSerial', {
       alias: 'chrome.android.deviceSerial',


### PR DESCRIPTION
To follow the same setup as Browsertime.