### PR TITLE
Bugfix: PageXray and the third party plugin sent messages in wrong group

### DIFF
--- a/lib/plugins/pagexray/index.js
+++ b/lib/plugins/pagexray/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const pagexrayAggregator = require('./pagexrayAggregator');
 const pagexray = require('pagexray');
+const urlParser = require('url');
 const log = require('intel').getLogger('plugin.pagexray');
 
 const DEFAULT_PAGEXRAY_PAGESUMMARY_METRICS = [
@@ -79,12 +80,14 @@ module.exports = {
             // The HAR file can have multiple URLs
             const sentURL = {};
             for (let summary of pageSummary) {
+              // The group can be different so take it per url
+              const myGroup = urlParser.parse(summary.url).hostname;
               if (!sentURL[summary.url]) {
                 sentURL[summary.url] = 1;
                 queue.postMessage(
                   make('pagexray.pageSummary', summary, {
                     url: summary.url,
-                    group // TODO get the group from the URL?
+                    group: myGroup
                   })
                 );
               } else {
@@ -94,7 +97,7 @@ module.exports = {
               queue.postMessage(
                 make('pagexray.run', summary, {
                   url: summary.url,
-                  group,
+                  group: myGroup,
                   runIndex: sentURL[summary.url] - 1,
                   iteration: sentURL[summary.url]
                 })

--- a/lib/plugins/thirdparty/index.js
+++ b/lib/plugins/thirdparty/index.js
@@ -144,7 +144,7 @@ module.exports = {
       queue.postMessage(
         make('thirdparty.run', runData, {
           url: message.url,
-          group: message.group,
+          group: urlParser.parse(message.url).hostname,
           runIndex: message.runIndex
         })
       );
@@ -161,7 +161,7 @@ module.exports = {
         queue.postMessage(
           make('thirdparty.pageSummary', summary[url], {
             url,
-            group: this.groups[url]
+            group: urlParser.parse(url).hostname
           })
         );
       }


### PR DESCRIPTION
When you tested URLs on different domains in the same script.

