### PR TITLE
Switch --debug to log in verbose log and use --debugMessages to log t…

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -91,13 +91,14 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .usage('$0 [options] <url>/<file>')
     .require(1, 'One or multiple URLs or scripts')
 
-    .option('debug', {
+    .option('debugMessages', {
       default: false,
-      describe: 'Debug mode logs all internal messages to the console.',
+      describe:
+        'Debug mode logs all internal messages in the message queue to the log.',
       type: 'boolean'
     })
     .option('verbose', {
-      alias: 'v',
+      alias: ['v', 'debug'],
       describe:
         'Verbose mode prints progress messages to the console. Enter up to three times (-vvv)' +
         ' to increase the level of detail.',

--- a/lib/core/pluginLoader.js
+++ b/lib/core/pluginLoader.js
@@ -31,7 +31,7 @@ module.exports = {
       defaultPlugins.has(name) ||
       typeof possibleConfiguredPlugins[name] === 'object';
     const addMessageLoggerIfDebug = pluginNames => {
-      if (options.debug) {
+      if (options.debugMessages) {
         // Need to make sure logger is first, so message logs appear
         // before messages are handled by other plugins
         pluginNames = ['messagelogger'].concat(pluginNames);


### PR DESCRIPTION
…he queue.

Users add --debug and think they get more detailed log messages but instead
they get the each message in the queue. With this fix we change that.

