### PR TITLE
Remove fast-crc32c and add Node 12 to travis, fixes #2633

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '10'
+- '12'
 sudo: required
 dist: bionic
 cache:
@@ -41,7 +42,7 @@ env:
   - secure: ZCqHD+/PhHNVFWoqir66Xd9YeJRcTHDJYvNL9j4+GTKDEI1h94twhAjQ7Z9DhlCnXwL1lsfEcIjvNCWd3ir/FNy2oZsUzu6kMpFF/niugurFbS551moJ2ObNEfOdj93/sTo4UWH2MZouC9eYeuj1vNYbAev6wBIptL95X/ArldQ=
   - secure: ZmEirO6J+rY+6T6eQWRNxqiqRNOYJktqQWaeUDR6WvzoR80oPdgKoNRS012dk4aCGr2+Dxf/KP6Iu2qbDE3YP3QD7PhoexicTVB6MTl81hZfX/eN0lt4lZknTYtjnAAWQB/aWAM6OVLjh8rAzq9PTBzl5EtAeMMJWmnhz6r+cLc=
 notifications:
-  slack: 
+  slack:
     on_success: change
     on_failure: always
     secure: 3Ca5MzTVkgeZDKk7xuiXnGnl0u4UgBXQtn72xIBwb1nked0JSdwZ4MVgNTVRTlIvwbTdTaYcTo7Pm4+rSrfFx2T1juawq3TkUStJ4AmZHH2gGrAr46snEauWCovHmgo3mMAOwz3fJknz8VfIu7WmtiCH/GO9h20aNmjE1UT3pTE=

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "cli-color": "1.4.0",
     "concurrent-queue": "7.0.2",
     "dayjs": "1.8.15",
-    "fast-crc32c": "1.0.4",
     "fast-stats": "0.0.5",
     "find-up": "4.1.0",
     "fs-extra": "8.1.0",


### PR DESCRIPTION
This fixes #2633 for Node 12.

Installing on node 12 fails with native add-on compile failure. This happens because there is a dependency on node-fast-crc32c that in its own turn uses  sse4_crc32 where the fail happens.

@grimen detailed the issue here also https://github.com/ashi009/node-fast-crc32c/issues/14

It was agreed to remove the dependency for now as it doesn't bring to much benefit and Travis has been updated to include Node 12 also.