### PR TITLE
fix(graphite): update indexed keys with names

### DIFF
--- a/lib/plugins/graphite/data-generator.js
+++ b/lib/plugins/graphite/data-generator.js
@@ -85,6 +85,44 @@ class GraphiteDataGenerator {
     return reduce(
       flatten.flattenMessageData(message),
       (entries, value, key) => {
+        if (
+          this.options.graphite &&
+          this.options.graphite.experimental &&
+          this.options.graphite.experimental.perIteration
+        ) {
+          if (message.type === 'browsertime.run') {
+            if (key.includes('timings') && key.includes('marks')) {
+              key = key.replace(/marks\.(\d+)/, function(match, idx) {
+                return (
+                  'marks.' + message.data.timings.userTimings.marks[idx].name
+                );
+              });
+            }
+
+            if (key.includes('timings') && key.includes('measures')) {
+              key = key.replace(/measures\.(\d+)/, function(match, idx) {
+                return (
+                  'measures.' +
+                  message.data.timings.userTimings.measures[idx].name
+                );
+              });
+            }
+          }
+          if (message.type === 'pagexray.run') {
+            if (key.includes('assets')) {
+              key = key.replace(
+                /assets\.(\d+)/,
+                function(match, idx) {
+                  let url = new URL(message.data.assets[idx].url);
+                  url.search = '';
+                  return 'assets.' + graphiteUtil.toSafeKey(url.toString());
+                },
+                {}
+              );
+            }
+          }
+        }
+
         const fullKey = util.format('%s.%s.%s', this.namespace, keypath, key);
         const args = [formatEntry(this.entryFormat), fullKey, value];
         this.entryFormat === GRAPHITE && args.push(timestamp);


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [ ] Check that your change/fix has corresponding unit tests (if applicable)
- [ ] Squash commits so it looks sane
- [ ] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
Please describe your pull request and tell us the fix #

Rename user timings and assets when running in perIteration mode. Fixes #2693

It is as late as we can rename the metrics while also knowing that we are running a per-iteration mode. It is right before it is sent out and should have no impact on anything downstream since it just rewrites the key instead of the object used for analysis.

Thank you for making sitespeed.io even better!
