### PR TITLE
Don't run node as root in Docker, fixes #1459

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,9 @@ RUN mkdir -m 0750 /root/.android
 ADD docker/adb/insecure_shared_adbkey /root/.android/adbkey
 ADD docker/adb/insecure_shared_adbkey.pub /root/.android/adbkey.pub
 
-# Allow all users to run "sudo tc"
-RUN echo 'ALL ALL=NOPASSWD: /usr/sbin/tc' > /etc/sudoers.d/tc
+# Allow all users to run commands needed by sitespeedio/throttle via sudo
+# See https://github.com/sitespeedio/throttle/blob/master/lib/tc.js
+RUN echo 'ALL ALL=NOPASSWD: /usr/sbin/tc, /usr/sbin/route, /usr/sbin/ip' > /etc/sudoers.d/tc
 
 ENTRYPOINT ["/start.sh"]
 VOLUME /sitespeed.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN mkdir -m 0750 /root/.android
 ADD docker/adb/insecure_shared_adbkey /root/.android/adbkey
 ADD docker/adb/insecure_shared_adbkey.pub /root/.android/adbkey.pub
 
+# Allow all users to run "sudo tc"
+RUN echo 'ALL ALL=NOPASSWD: /usr/sbin/tc' > /etc/sudoers.d/tc
+
 ENTRYPOINT ["/start.sh"]
 VOLUME /sitespeed.io
 WORKDIR /sitespeed.io


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

-  [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code (*This is not a big change IMO*) 
-  [ ] Check that your change/fix has corresponding unit tests (if applicable) (*Not applicable*) 
- [X] Squash commits so it looks sane
- [ ] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR (*Not applicable*)
- [X] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
This updates the start.sh script to create a group and user with the same GID and UID as the working directory (normally /sitespeed.io), then use that for running `node`. This fixes the issue of report files being owned by root reported in https://github.com/sitespeedio/sitespeed.io/issues/1459

This uses "chroot" to switch the new user instead of "su" because of the signal handling issues mentioned at https://github.com/tianon/gosu.

I tested this with the following script:

```shell
#!/bin/bash
set -e

docker build -t sitespeedio/sitespeed.io:test .

docker run --rm -v "$PWD:/sitespeed.io" sitespeedio/sitespeed.io:test -b chrome --outputFolder chrome-result -n 1 https://www.example.com
docker run --rm -v "$PWD:/sitespeed.io" sitespeedio/sitespeed.io:test -b firefox --outputFolder firefox-result -n 1 https://www.example.com
docker run --cap-add=NET_ADMIN --rm -v "$PWD:/sitespeed.io" -e REPLAY=true sitespeedio/sitespeed.io:test --outputFolder wpr-result -n 1 -b chrome https://www.example.com
docker run --cap-add=NET_ADMIN --rm -v "$PWD:/sitespeed.io" sitespeedio/sitespeed.io:test https://www.sitespeed.io/ -b chrome --outputFolder tc-result -n 1 -c 3g --browsertime.connectivity.engine=throttle

ls -ld . *result
```

<details>
<summary>Click here for the output</summary>

```
Sending build context to Docker daemon  11.27MB
Step 1/26 : FROM sitespeedio/webbrowsers:chrome-77.0-firefox-69.0
 ---> abbc92fcb0ee                                                                                                                                                                                                             Step 2/26 : ENV SITESPEED_IO_BROWSERTIME__XVFB true
 ---> Using cache
 ---> 721d9acb8d5f
Step 3/26 : ENV SITESPEED_IO_BROWSERTIME__DOCKER true
 ---> Using cache
 ---> b4f92a6550a6
Step 4/26 : ENV SITESPEED_IO_BROWSERTIME__VIDEO true
 ---> Using cache
 ---> 5fe9167d66a0
Step 5/26 : ENV SITESPEED_IO_BROWSERTIME__visualMetrics true                                                                                                                                                                    ---> Using cache
 ---> 0a0b3467aa44
Step 6/26 : COPY docker/webpagereplay/wpr /usr/local/bin/
 ---> Using cache
 ---> f42e75ae52a7
Step 7/26 : COPY docker/webpagereplay/wpr_cert.pem /webpagereplay/certs/
 ---> Using cache
 ---> 1aeb1aeff973
Step 8/26 : COPY docker/webpagereplay/wpr_key.pem /webpagereplay/certs/
 ---> Using cache
 ---> d13b62974fea
Step 9/26 : COPY docker/webpagereplay/deterministic.js /webpagereplay/scripts/deterministic.js
 ---> Using cache
 ---> 3e2bb9ea87f2
Step 10/26 : COPY docker/webpagereplay/LICENSE /webpagereplay/
 ---> Using cache
 ---> 6e5ceb55474d
Step 11/26 : RUN sudo apt-get update && sudo apt-get install libnss3-tools     net-tools     iproute2 -y &&     mkdir -p $HOME/.pki/nssdb &&     certutil -d $HOME/.pki/nssdb -N
 ---> Using cache                                                                                                                                                                                                               ---> 8eb285848fd5
Step 12/26 : ENV PATH="/usr/local/bin:${PATH}"
 ---> Using cache
 ---> 56e233dbb108
Step 13/26 : RUN wpr installroot --https_cert_file /webpagereplay/certs/wpr_cert.pem --https_key_file /webpagereplay/certs/wpr_key.pem
 ---> Using cache
 ---> 9e0eb8728bf4
Step 14/26 : RUN mkdir -p /usr/src/app
 ---> Using cache
 ---> e873f8876172                                                                                                                                                                                                             Step 15/26 : WORKDIR /usr/src/app
 ---> Using cache
 ---> 01d350fc6316
Step 16/26 : COPY package.* /usr/src/app/
 ---> Using cache
 ---> 2daa0ebf300f
Step 17/26 : RUN npm install --production
 ---> Using cache
 ---> ee6dcd4da90d
Step 18/26 : COPY . /usr/src/app
 ---> Using cache
 ---> f10bd2844a3d
Step 19/26 : COPY docker/scripts/start.sh /start.sh
 ---> Using cache
 ---> 89d9663cac9e
Step 20/26 : RUN mkdir -m 0750 /root/.android                                                                                                                                                                                   ---> Using cache
 ---> 6913c0c27624
Step 21/26 : ADD docker/adb/insecure_shared_adbkey /root/.android/adbkey
 ---> Using cache
 ---> 71c95b33f659
Step 22/26 : ADD docker/adb/insecure_shared_adbkey.pub /root/.android/adbkey.pub
 ---> Using cache
 ---> af046122a3e9
Step 23/26 : RUN echo 'ALL ALL=NOPASSWD: /usr/sbin/tc, /usr/sbin/route, /usr/sbin/ip' > /etc/sudoers.d/tc
 ---> Running in 50564bc46e90                                                                                                                                                                                                  Removing intermediate container 50564bc46e90
 ---> 7092a7371349
Step 24/26 : ENTRYPOINT ["/start.sh"]
 ---> Running in c49aadaf62e6
Removing intermediate container c49aadaf62e6
 ---> 66b9461c9596
Step 25/26 : VOLUME /sitespeed.io
 ---> Running in 0bef31415b8f
Removing intermediate container 0bef31415b8f
 ---> 2884d394d314
Step 26/26 : WORKDIR /sitespeed.io
 ---> Running in ad5b075b09f0
Removing intermediate container ad5b075b09f0
 ---> 205b29a0b349
Successfully built 205b29a0b349
Successfully tagged sitespeedio/sitespeed.io:test
Google Chrome 77.0.3865.75
Mozilla Firefox 69.0
[2019-10-21 00:25:06] INFO: Versions OS: linux 4.15.0-60-generic nodejs: v10.16.0 sitespeed.io: 10.3.2 browsertime: 6.1.4 coach: 4.1.0
[2019-10-21 00:25:06] INFO: Running tests using Chrome - 1 iteration(s)
[2019-10-21 00:25:09] INFO: Testing url https://www.example.com iteration 1
[2019-10-21 00:25:28] INFO: https://www.example.com 2 requests, backEndTime: 111ms, firstPaint: 171ms, firstVisualChange: 0ms, DOMContentLoaded: 156ms, Load: 157ms, speedIndex: 0, visualComplete85: 0ms, lastVisualChange: 0ms, rumSpeedIndex: 171
[2019-10-21 00:25:28] INFO: The server responded with a 404 status code for https://www.example.com/favicon.ico
[2019-10-21 00:25:30] INFO: HTML stored in /sitespeed.io/chrome-result
Google Chrome 77.0.3865.75
Mozilla Firefox 69.0
[2019-10-21 00:25:33] INFO: Versions OS: linux 4.15.0-60-generic nodejs: v10.16.0 sitespeed.io: 10.3.2 browsertime: 6.1.4 coach: 4.1.0
[2019-10-21 00:25:34] INFO: Running tests using Firefox - 1 iteration(s)
[2019-10-21 00:25:38] INFO: Testing url https://www.example.com iteration 1
[2019-10-21 00:25:46] INFO: Waiting on har-export-trigger to collect the HAR
        [2019-10-21 00:25:58] INFO: https://www.example.com 2 requests, backEndTime: 123ms, firstPaint: 270ms, firstVisualChange: 301ms, DOMContentLoaded: 246ms, Load: 246ms, speedIndex: 301, visualComplete85: 301ms, lastVisualChange: 301ms, rumSpeedIndex: 123
[2019-10-21 00:25:58] INFO: The server responded with a 404 status code for https://www.example.com/favicon.ico
[2019-10-21 00:26:00] INFO: HTML stored in /sitespeed.io/firefox-result
Google Chrome 77.0.3865.75
Mozilla Firefox 69.0
Start WebPageReplay Record
[2019-10-21 00:26:05] INFO: Running tests using Chrome - 1 iteration(s)
[2019-10-21 00:26:06] INFO: Testing url https://www.example.com iteration 1
[2019-10-21 00:26:12] INFO: https://www.example.com 2 requests
Stopped WebPageReplay record
Start WebPageReplay Replay
[2019-10-21 00:26:13] INFO: Versions OS: linux 4.15.0-60-generic nodejs: v10.16.0 sitespeed.io: 10.3.2 browsertime: 6.1.4 coach: 4.1.0
[2019-10-21 00:26:13] INFO: Changing network interfaces needs sudo rights.
[2019-10-21 00:26:13] INFO: Running tests using Chrome - 1 iteration(s)
[2019-10-21 00:26:20] INFO: Testing url https://www.example.com iteration 1
[2019-10-21 00:26:58] INFO: https://www.example.com 2 requests, backEndTime: 519ms, firstPaint: 577ms, firstVisualChange: 568ms, DOMContentLoaded: 558ms, Load: 558ms, speedIndex: 568, visualComplete85: 568ms, lastVisualChange: 568ms, rumSpeedIndex: 577
[2019-10-21 00:26:58] INFO: The server responded with a 404 status code for https://www.example.com/favicon.ico
[2019-10-21 00:27:00] INFO: HTML stored in /sitespeed.io/wpr-result
Google Chrome 77.0.3865.75
Mozilla Firefox 69.0
[2019-10-21 00:27:03] INFO: Versions OS: linux 4.15.0-60-generic nodejs: v10.16.0 sitespeed.io: 10.3.2 browsertime: 6.1.4 coach: 4.1.0
[2019-10-21 00:27:03] INFO: Changing network interfaces needs sudo rights.
[2019-10-21 00:27:03] INFO: Running tests using Chrome - 1 iteration(s)
[2019-10-21 00:27:04] INFO: Testing url https://www.sitespeed.io/ iteration 1
[2019-10-21 00:27:27] INFO: https://www.sitespeed.io/ 13 requests, backEndTime: 1.45s, firstPaint: 2.32s, firstVisualChange: 2.33s, DOMContentLoaded: 2.28s, Load: 3.25s, speedIndex: 2405, visualComplete85: 2.60s, lastVisualChange: 2.80s, rumSpeedIndex: 2649
[2019-10-21 00:27:30] INFO: HTML stored in /sitespeed.io/tc-result
drwxrwxr-x 15 masonm masonm 4096 Oct 20 17:27 .
drwxr-xr-x  8 masonm masonm 4096 Oct 20 17:25 chrome-result
drwxr-xr-x  8 masonm masonm 4096 Oct 20 17:26 firefox-result
drwxr-xr-x  8 masonm masonm 4096 Oct 20 17:27 tc-result
drwxr-xr-x  8 masonm masonm 4096 Oct 20 17:27 wpr-result
```
</details>
