### PR TITLE
Better differentiate sizes of HTML title tags

### DIFF
--- a/docs/_includes/css/sitespeed.css
+++ b/docs/_includes/css/sitespeed.css
@@ -20,27 +20,27 @@ h1 {
 }
 
 h2 {
- font-size: 2.8rem;
+ font-size: 2rem;
  line-height: 1.25;
 }
 
 h3 {
- font-size: 2.6rem;
+ font-size: 1.5rem;
  line-height: 1.3;
 }
 
 h4 {
- font-size: 2.4rem;
+ font-size: 1.3rem;
  line-height: 1.35;
 }
 
 h5 {
- font-size: 1.8rem;
+ font-size: 1.2rem;
  line-height: 1.5;
 }
 
 h6 {
- font-size: 1.5rem;
+ font-size: 1.1rem;
  line-height: 1.6;
  letter-spacing: 0;
 }


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code => Small change, proposed a PR directly
- [ ] Check that your change/fix has corresponding unit tests (if applicable) => Needs manual cross-browser testing
- [ ] Squash commits so it looks sane => Only one commit
- [ ] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR => I'm updating the docs :)
- [ ] Verify that the test works by running `npm test` and test linting by `npm run lint` => Useless?


### Description
Please describe your pull request and tell us the fix #

Hello,

The `h1,h2,h3...` tags vary in size very slightly, which makes understanding the content hierarchy/structure in documentation pages very hard. Here's a **WIP** merge request, I only tested h2 and h3 font-size in the browser dev-tools, even if this PR changes all of them (from h2 to h6). I didn't test locally at all. If someone wants to validate/adjust the changes, it would be awesome for docs readability (and my first contribution to sitespeed :) ).

> Thank you for making sitespeed.io even better!

You're welcome