### PR TITLE
Add a way to add plugins through node API

### DIFF
--- a/docs/documentation/sitespeed.io/configuration/config.md
+++ b/docs/documentation/sitespeed.io/configuration/config.md
@@ -123,7 +123,7 @@ Graphite
 
 Plugins
   --plugins.list    List all configured plugins in the log.  [boolean]
-  --plugins.add     Extra plugins that you want to run. Relative or absolute path to the plugin. Specify multiple plugin names separated by comma, or repeat the --plugins.add option
+  --plugins.add     Extra plugins that you want to run. Relative or absolute path to the plugin. Specify multiple plugin names separated by comma, or repeat the --plugins.add option. When used through the Node.js API you can also supply an array of plugins.
   --plugins.remove  Default plugins that you not want to run. Specify multiple plugin names separated by comma, or repeat the --plugins.remove option
 
 Budget

--- a/lib/sitespeed.js
+++ b/lib/sitespeed.js
@@ -1,25 +1,25 @@
-'use strict';
+"use strict";
 
-const dayjs = require('dayjs');
-const utc = require('dayjs/plugin/utc');
-const log = require('intel').getLogger('sitespeedio');
-const intel = require('intel');
-const os = require('os');
-const process = require('process');
-const logging = require('./core/logging');
-const toArray = require('./support/util').toArray;
-const pullAll = require('lodash.pullall');
-const union = require('lodash.union');
-const messageMaker = require('./support/messageMaker');
-const filterRegistry = require('./support/filterRegistry');
-const statsHelpers = require('./support/statsHelpers');
-const packageInfo = require('../package');
+const dayjs = require("dayjs");
+const utc = require("dayjs/plugin/utc");
+const log = require("intel").getLogger("sitespeedio");
+const intel = require("intel");
+const os = require("os");
+const process = require("process");
+const logging = require("./core/logging");
+const toArray = require("./support/util").toArray;
+const pullAll = require("lodash.pullall");
+const union = require("lodash.union");
+const messageMaker = require("./support/messageMaker");
+const filterRegistry = require("./support/filterRegistry");
+const statsHelpers = require("./support/statsHelpers");
+const packageInfo = require("../package");
 
-const QueueHandler = require('./core/queueHandler');
-const resultsStorage = require('./core/resultsStorage');
-const loader = require('./core/pluginLoader');
-const urlSource = require('./core/url-source');
-const scriptSource = require('./core/script-source');
+const QueueHandler = require("./core/queueHandler");
+const resultsStorage = require("./core/resultsStorage");
+const loader = require("./core/pluginLoader");
+const urlSource = require("./core/url-source");
+const scriptSource = require("./core/script-source");
 
 dayjs.extend(utc);
 
@@ -29,7 +29,7 @@ const budgetResult = {
 };
 
 function hasFunctionFilter(functionName) {
-  return obj => typeof obj[functionName] === 'function';
+  return obj => typeof obj[functionName] === "function";
 }
 
 function runOptionalFunction(objects, fN) {
@@ -56,54 +56,61 @@ module.exports = {
     );
 
     // Setup logging
-    const logDir = await storageManager.createDirectory('logs');
+    const logDir = await storageManager.createDirectory("logs");
     logging.configure(options, logDir);
 
     // Tell the world what we are using
     log.info(
-      'Versions OS: %s nodejs: %s sitespeed.io: %s browsertime: %s coach: %s',
-      os.platform() + ' ' + os.release(),
+      "Versions OS: %s nodejs: %s sitespeed.io: %s browsertime: %s coach: %s",
+      os.platform() + " " + os.release(),
       process.version,
       packageInfo.version,
       packageInfo.dependencies.browsertime,
       packageInfo.dependencies.webcoach
     );
     if (log.isEnabledFor(log.DEBUG)) {
-      log.debug('Running with options: %:2j', options);
+      log.debug("Running with options: %:2j", options);
     }
 
     let pluginNames = await loader.parsePluginNames(options);
 
     const plugins = options.plugins;
 
+    let runtimePlugins = [];
+
     // Deprecated setup
     if (plugins) {
       if (plugins.disable) {
         log.warn(
-          '--plugins.disable is deprecated, use plugins.remove instead.'
+          "--plugins.disable is deprecated, use plugins.remove instead."
         );
         plugins.remove = plugins.disable;
       }
       if (plugins.load) {
-        log.warn('--plugins.load is deprecated, use plugins.add instead.');
+        log.warn("--plugins.load is deprecated, use plugins.add instead.");
         plugins.add = plugins.load;
       }
 
       // Finalize the plugins that we wanna run
       pullAll(pluginNames, toArray(plugins.remove));
-      pluginNames = union(pluginNames, toArray(plugins.add));
+
+      if (typeof plugins.add === "string") {
+        pluginNames = union(pluginNames, toArray(plugins.add));
+      } else if (Array.isArray(plugins.add)) {
+        runtimePlugins = plugins.add;
+      }
 
       if (plugins.list) {
         log.info(
-          'The following plugins are enabled: %s',
-          pluginNames.join(', ')
+          "The following plugins are enabled: %s",
+          pluginNames.join(", ")
         );
       }
     }
 
     const runningPlugins = await loader.loadPlugins(pluginNames);
     const urlSources = [options.multi ? scriptSource : urlSource];
-    const allPlugins = urlSources.concat(runningPlugins);
+    const allPlugins = urlSources.concat(runningPlugins).concat(runtimePlugins);
     const queueHandler = new QueueHandler(runningPlugins, options);
 
     // This is the contect where we wanna run our tests
@@ -123,7 +130,7 @@ module.exports = {
     // Open/start each and every plugin
     try {
       await Promise.all(
-        runOptionalFunction(allPlugins, 'open', context, options)
+        runOptionalFunction(allPlugins, "open", context, options)
       );
 
       // Pass the URLs
@@ -131,11 +138,11 @@ module.exports = {
 
       // Close the plugins
       await Promise.all(
-        runOptionalFunction(allPlugins, 'close', options, errors)
+        runOptionalFunction(allPlugins, "close", options, errors)
       );
 
       if (resultUrls.hasBaseUrl()) {
-        log.info('Find the result at %s', resultUrls.reportSummaryUrl());
+        log.info("Find the result at %s", resultUrls.reportSummaryUrl());
       }
 
       if (options.summary && options.summary.out) {


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [x] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`

### Description

I'm using the sitespeed.io API through a node script and wanted to add an easier way to use plugins. This way there's no need to reference them by relative path, but you can just add them to the configuration hash like so:

```js
const { run } = require('sitespeed.io');

(async () => run({ plugins: { add: [{ processMessage: noop }] } }))();
```

I'm not sure if this needs unit tests or not, so please let me know if so and I'll add them!