### PR TITLE
feat(docker): add `grafana-piechart-panel` plugin

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,7 @@ services:
         - GF_AUTH_ANONYMOUS_ENABLED=true
         - GF_USERS_ALLOW_SIGN_UP=false
         - GF_USERS_ALLOW_ORG_CREATE=false
+        - GF_INSTALL_PLUGINS=grafana-piechart-panel
       volumes:
         - grafana:/var/lib/grafana
       restart: always


### PR DESCRIPTION
This should unblock [@sitespeedio/grafana-bootstrap-docker#19](https://github.com/sitespeedio/grafana-bootstrap-docker/pull/19) as the pie chart panel
is missing from the default installation of Grafana.

### Checklist for a pull request to sitespeed.io

- [x] ~~I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code~~
- [x] Check that your change/fix has corresponding unit tests (if applicable)
- [x] Squash commits so it looks sane
- [x] ~~Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/master/docs in another PR~~
- [x] ~~Verify that the test works by running `npm test` and test linting by `npm run lint`~~


### Description
@soulgalore [mentioned](https://github.com/sitespeedio/grafana-bootstrap-docker/pull/19#issuecomment-475890930) this was a blocked to move forward with the changes introduced in the linked pull request.

This is now shown at the Home section of Grafana:  
<img width="187" alt="Screenshot 2020-01-21 at 21 59 13" src="https://user-images.githubusercontent.com/607262/72843431-c8388980-3c9a-11ea-82b0-245da5cd4358.png">

