### PR TITLE
Disable --cpu for Firefox so we can investigate if all configs are right

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1531,9 +1531,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
     ) {
       set(argv, 'browsertime.chrome.collectLongTasks', true);
       set(argv, 'browsertime.chrome.timeline', true);
-    } else if (argv.browsertime.browser === 'firefox') {
-      set(argv, 'browsertime.firefox.geckoProfiler', true);
     }
+    // Enable when we know how much overhead it will add
+    /*
+      else if (argv.browsertime.browser === 'firefox') {
+      set(argv, 'browsertime.firefox.geckoProfiler', true);
+    }*/
   }
 
   // we missed to populate this to Browsertime in the cli


### PR DESCRIPTION
And we don't add too much over head.

