### PR TITLE
feat(plugins): move influxdb CLI options to the plugin defintion

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -13,8 +13,8 @@ const toArray = require('../support/util').toArray;
 
 const grafanaPlugin = require('../plugins/grafana/index');
 const graphitePlugin = require('../plugins/graphite/index');
+const influxdbPlugin = require('../plugins/influxdb/index');
 
-const influxdbConfig = require('../plugins/influxdb/index').config;
 const browsertimeConfig = require('../plugins/browsertime/index').config;
 const metricsConfig = require('../plugins/metrics/index').config;
 const webPageTestConfig = require('../plugins/webpagetest/index').config;
@@ -966,63 +966,14 @@ module.exports.parseCommandLine = function parseCommandLine() {
       describe: 'The max size of the screenshot (width and height).',
       default: browsertimeConfig.screenshotParams.maxSize,
       group: 'Screenshot'
-    })
-    /**
-     InfluxDB cli option
-     */
-    .option('influxdb.protocol', {
-      describe: 'The protocol used to store connect to the InfluxDB host.',
-      default: influxdbConfig.protocol,
-      group: 'InfluxDB'
-    })
-    .option('influxdb.host', {
-      describe: 'The InfluxDB host used to store captured metrics.',
-      group: 'InfluxDB'
-    })
-    .option('influxdb.port', {
-      default: influxdbConfig.port,
-      describe: 'The InfluxDB port used to store captured metrics.',
-      group: 'InfluxDB'
-    })
-    .option('influxdb.username', {
-      describe: 'The InfluxDB username for your InfluxDB instance.',
-      group: 'InfluxDB'
-    })
-    .option('influxdb.password', {
-      describe: 'The InfluxDB password for your InfluxDB instance.',
-      group: 'InfluxDB'
-    })
-    .option('influxdb.database', {
-      default: influxdbConfig.database,
-      describe: 'The database name used to store captured metrics.',
-      group: 'InfluxDB'
-    })
-    .option('influxdb.tags', {
-      default: influxdbConfig.tags,
-      describe:
-        'A comma separated list of tags and values added to each metric',
-      group: 'InfluxDB'
-    })
-    .option('influxdb.includeQueryParams', {
-      default: influxdbConfig.includeQueryParams,
-      describe:
-        'Whether to include query parameters from the URL in the InfluxDB keys or not',
-      type: 'boolean',
-      group: 'InfluxDB'
-    })
-    .option('influxdb.groupSeparator', {
-      default: '_',
-      describe:
-        'Choose which character that will seperate a group/domain. Default is underscore, set it to a dot if you wanna keep the original domain name.',
-      group: 'InfluxDB'
-    })
-    .option('influxdb.annotationScreenshot', {
-      default: false,
-      type: 'boolean',
-      describe:
-        'Include screenshot (from Browsertime) in the annotation. You need to specify a --resultBaseURL for this to work.',
-      group: 'InfluxDB'
-    })
+    });
+  /**
+   InfluxDB cli option
+   */
+  cliUtil.registerPluginOptions(parsed, influxdbPlugin);
+
+  parsed
+    // Metrics
     .option('metrics.list', {
       describe: 'List all possible metrics in the data folder (metrics.txt).',
       type: 'boolean',

--- a/lib/plugins/influxdb/cli.js
+++ b/lib/plugins/influxdb/cli.js
@@ -1,0 +1,54 @@
+module.exports = {
+  protocol: {
+    describe: 'The protocol used to store connect to the InfluxDB host.',
+    default: 'http',
+    group: 'InfluxDB'
+  },
+  host: {
+    describe: 'The InfluxDB host used to store captured metrics.',
+    group: 'InfluxDB'
+  },
+  port: {
+    default: 8086,
+    describe: 'The InfluxDB port used to store captured metrics.',
+    group: 'InfluxDB'
+  },
+  username: {
+    describe: 'The InfluxDB username for your InfluxDB instance.',
+    group: 'InfluxDB'
+  },
+  password: {
+    describe: 'The InfluxDB password for your InfluxDB instance.',
+    group: 'InfluxDB'
+  },
+  database: {
+    default: 'sitespeed',
+    describe: 'The database name used to store captured metrics.',
+    group: 'InfluxDB'
+  },
+  tags: {
+    default: 'category=default',
+    describe: 'A comma separated list of tags and values added to each metric',
+    group: 'InfluxDB'
+  },
+  includeQueryParams: {
+    default: false,
+    describe:
+      'Whether to include query parameters from the URL in the InfluxDB keys or not',
+    type: 'boolean',
+    group: 'InfluxDB'
+  },
+  groupSeparator: {
+    default: '_',
+    describe:
+      'Choose which character that will seperate a group/domain. Default is underscore, set it to a dot if you wanna keep the original domain name.',
+    group: 'InfluxDB'
+  },
+  annotationScreenshot: {
+    default: false,
+    type: 'boolean',
+    describe:
+      'Include screenshot (from Browsertime) in the annotation. You need to specify a --resultBaseURL for this to work.',
+    group: 'InfluxDB'
+  }
+};

--- a/lib/plugins/influxdb/index.js
+++ b/lib/plugins/influxdb/index.js
@@ -7,16 +7,24 @@ const Sender = require('./sender');
 const tsdbUtil = require('../../support/tsdbUtil');
 const sendAnnotations = require('./send-annotation');
 const DataGenerator = require('./data-generator');
-
-const defaultConfig = {
-  port: 8086,
-  protocol: 'http',
-  database: 'sitespeed',
-  tags: 'category=default',
-  includeQueryParams: false
-};
+const path = require('path');
+const cliUtil = require('../../cli/util');
 
 module.exports = {
+  name() {
+    return path.basename(__dirname);
+  },
+
+  /**
+   * Define `yargs` options with their respective default values. When displayed by the CLI help message
+   * all options are namespaced by its plugin name.
+   *
+   * @return {Object<string, require('yargs').Options} an object mapping the name of the option and its yargs configuration
+   */
+  get cliOptions() {
+    return require(path.resolve(__dirname, 'cli.js'));
+  },
+
   open(context, options) {
     throwIfMissing(options.influxdb, ['host', 'database'], 'influxdb');
     this.filterRegistry = context.filterRegistry;
@@ -153,5 +161,7 @@ module.exports = {
       );
     }
   },
-  config: defaultConfig
+  get config() {
+    return cliUtil.pluginDefaults(this.cliOptions);
+  }
 };

--- a/test/cliTests.js
+++ b/test/cliTests.js
@@ -153,5 +153,16 @@ describe('cli', () => {
         'Experimental setup to send each iteration of metrics to Graphite. Experimental means this can change and is not released as stable. Use it with care.'
       );
     });
+
+    it('should contain influxdb options', () => {
+      expect(stdout).to.contain('--influxdb.protocol');
+      expect(stdout).to.contain('--influxdb.host');
+      expect(stdout).to.contain('--influxdb.port');
+      expect(stdout).to.contain('--influxdb.username');
+      expect(stdout).to.contain('--influxdb.database');
+      expect(stdout).to.contain('--influxdb.includeQueryParams');
+      expect(stdout).to.contain('--influxdb.groupSeparator');
+      expect(stdout).to.contain('--influxdb.annotationScreenshot');
+    });
   });
 });


### PR DESCRIPTION
Move `influxdb` plugin CLI options into the plugin defintion/structure.

---

It follows the same pattern implemented for both Graphite/Grafana