### PR TITLE
Use Browsertime test time for annotations to InfluxDB #2998

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -140,7 +140,6 @@ module.exports = {
         );
 
         log.verbose('Result from Browsertime for %s with %:2j', url, result);
-
         // We need to check for alias first, since when we send the HAR (incliude all runs)
         // need to know if alias exists, else we will end up with things like
         // https://github.com/sitespeedio/sitespeed.io/issues/2341
@@ -427,7 +426,8 @@ module.exports = {
           queue.postMessage(
             make('browsertime.pageSummary', result[resultIndex], {
               url,
-              group
+              group,
+              runTime: result.timestamp
             })
           );
           // Post the HAR on the queue so other plugins can use it

--- a/lib/plugins/influxdb/index.js
+++ b/lib/plugins/influxdb/index.js
@@ -144,7 +144,8 @@ module.exports = {
             absolutePagePath,
             this.useScreenshots,
             this.screenshotType,
-            this.timestamp,
+            // Browsertime pass on when the first run was done for that URL
+            message.runTime,
             this.alias,
             this.wptExtras[message.url],
             this.usingBrowsertime,

--- a/lib/plugins/influxdb/send-annotation.js
+++ b/lib/plugins/influxdb/send-annotation.js
@@ -14,7 +14,7 @@ module.exports = {
     absolutePagePath,
     screenShotsEnabledInBrowsertime,
     screenshotType,
-    time,
+    runTime,
     alias,
     webPageTestExtraData,
     usingBrowsertime,
@@ -52,7 +52,9 @@ module.exports = {
       usingBrowsertime,
       options
     );
-    const timestamp = Math.round(dayjs() / 1000);
+    const timestamp = runTime
+      ? Math.round(dayjs(runTime) / 1000)
+      : Math.round(dayjs() / 1000);
     // if we have a category, let us send that category too
     if (options.influxdb.tags) {
       for (let row of options.influxdb.tags.split(',')) {


### PR DESCRIPTION
When sending annotations to InfluxDB: instead of using a timestamp
of when the annotation is sent, use when the first run for that
URL was done in Browsertime.