### PR TITLE
Send a setup message when the plugin start.

### DIFF
--- a/lib/plugins/gcs/index.js
+++ b/lib/plugins/gcs/index.js
@@ -61,7 +61,10 @@ module.exports = {
   },
 
   async processMessage(message, queue) {
-    if (message.type === 'html.finished') {
+    if (message.type === 'sitespeedio.setup') {
+      // Let other plugins know that the GCS plugin is alive
+      queue.postMessage(this.make('gcs.setup'));
+    } else if (message.type === 'html.finished') {
       const make = this.make;
       const gcsOptions = this.gcsOptions;
       const baseDir = this.storageManager.getBaseDir();

--- a/lib/plugins/s3/index.js
+++ b/lib/plugins/s3/index.js
@@ -82,7 +82,10 @@ module.exports = {
   },
 
   async processMessage(message, queue) {
-    if (message.type === 'html.finished') {
+    if (message.type === 'sitespeedio.setup') {
+      // Let other plugins know that the s3 plugin is alive
+      queue.postMessage(this.make('s3.setup'));
+    } else if (message.type === 'html.finished') {
       const make = this.make;
       const s3Options = this.s3Options;
       const baseDir = this.storageManager.getBaseDir();


### PR DESCRIPTION
This makes it possible for other plugins to know if S3 or GCS is configured.