### PR TITLE
Update Docker usage in docs for compatibility w/ PowerShell

### DIFF
--- a/docs/_includes/index/install.md
+++ b/docs/_includes/index/install.md
@@ -4,7 +4,7 @@
 Use our [Docker container](https://hub.docker.com/r/sitespeedio/sitespeed.io/) to get an environment with Firefox, Chrome, XVFB and sitespeed.io up and running as fast as you can download them. They work [extremely well]({{site.baseurl}}/documentation/sitespeed.io/performance-dashboard/) together with Graphite/InfluxDB and Grafana that you can use to monitor your web site.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt  %} https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt  %} https://www.sitespeed.io/
 ~~~
 
 If you want to test a user scenario/journey read [how to run test scripts](/documentation/sitespeed.io/scripting/).

--- a/docs/_posts/2016-10-27-sitespeed.io-4.0-is-released.md
+++ b/docs/_posts/2016-10-27-sitespeed.io-4.0-is-released.md
@@ -17,7 +17,7 @@ Yes we have finally released 4.0. We ([Peter](https://twitter.com/soulislove)/[T
 Before reading, you should just try it out:
 
 ~~~bash
-docker run --privileged --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io https://www.sitespeed.io/
+docker run --privileged --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io https://www.sitespeed.io/
 ~~~
 
 Or using npm:

--- a/docs/_posts/2016-12-01-speed-index-and-video.md
+++ b/docs/_posts/2016-12-01-speed-index-and-video.md
@@ -20,7 +20,7 @@ Recording a video and slicing and dicing the result needs a lot of extra softwar
 If you wanna collect SpeedIndex (and First Visual Change, Last Visual Change and Perceptual Speed Index) you run like this:
 
 ~~~bash
-docker run --privileged --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io --video --speedIndex -c cable https://www.sitespeed.io/
+docker run --privileged --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io --video --speedIndex -c cable https://www.sitespeed.io/
 ~~~
 
 All metrics will automatically be shown in the result report and sent to Graphite if you run is configured to do that. You will also get a video on your Browsertime result tab that looks like this:
@@ -40,7 +40,7 @@ Also a very special thanks to [Walter Ebert](https://github.com/walterebert) tha
 The other big thing in 4.1 is that we made it easy to test second view. Ehh, second view you say? Well many tools have the repeat view (they access the same URL twice), to make it easy to see how the cache works. In real user scenarios it's better to first access one URL and then go to another that you want to measure (exactly as a user would do). In 4.0 we had support for that, but you needed to supply your own preScript. In 4.1 we made it super easy, just add the URL in the cli:
 
 ~~~bash
-docker run --privileged --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io -c cable --preURL https://www.sitespeed.io/ https://www.sitespeed.io/documentation/
+docker run --privileged --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io -c cable --preURL https://www.sitespeed.io/ https://www.sitespeed.io/documentation/
 ~~~
 
 The browser will first access the preURL and then the URL you want to measure. If you have assets that are cached between requests, you can see that now. With this update you will now have a more realistic way of measuring when your user first go to your sites start page and then accesses the next.

--- a/docs/_posts/2017-02-14-sitespeed.io-4.4.0-is-released.md
+++ b/docs/_posts/2017-02-14-sitespeed.io-4.4.0-is-released.md
@@ -21,7 +21,7 @@ In a [previous post]({{site.baseurl}}/usertimings-best-practices) on best practi
 allows you to now define that namespace to filter out all other that do not match. Yay! The following will whitelist and capture only user timings that are prefixed with `sitespeedio_`.
 
 ~~~bash
-docker run --privileged --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io --userTimingWhitelist "^sitespeedio_" https://www.sitespeed.io/
+docker run --privileged --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io --userTimingWhitelist "^sitespeedio_" https://www.sitespeed.io/
 ~~~
 
 
@@ -33,7 +33,7 @@ This is great since it now easy to filter out only the user timings that you nee
 This feature allows for annotations automatically to be sent to Graphite and picked up Grafana, so we can link between metrics in Grafana and HTML result pages. These annotations can be configure along side of S3, so it's super easy to keep the result and have everything you need to keep track of your sites performance. Finally the gap between Grafana and the HTML generated results by sitespeedio is here :)
 
 ~~~bash
-docker run --privileged --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io -b firefox -n 1 --graphite.host <your graphite host>  --resultBaseURL https://example.yoursite.com https://www.sitespeed.io/
+docker run --privileged --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io -b firefox -n 1 --graphite.host <your graphite host>  --resultBaseURL https://example.yoursite.com https://www.sitespeed.io/
 ~~~
 
 ![Send annotations and link to the result pages]({{site.baseurl}}/img/annotations-example.png)
@@ -48,7 +48,7 @@ This feature will allow for capturing resulting HTML reports/videos and HAR file
 
 
 ~~~bash
-docker run --privileged --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io -b firefox -n 1 --graphite.host <location to your graphite instance> --resultBaseURL https://example.yoursite.com --s3.key <insert key here> --s3.secret <insert secret here> --s3.bucketname <insert your bucket name here> https://www.sitespeed.io/
+docker run --privileged --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io -b firefox -n 1 --graphite.host <location to your graphite instance> --resultBaseURL https://example.yoursite.com --s3.key <insert key here> --s3.secret <insert secret here> --s3.bucketname <insert your bucket name here> https://www.sitespeed.io/
 ~~~
 
 This is nice because you can setup S3 to keep the result for your runs for X days and have the same configuration for Graphite, so that you go back and forth from the graphs to the result pages (see next feature!).

--- a/docs/_posts/2017-04-24-sitespeed.io-5.0.md
+++ b/docs/_posts/2017-04-24-sitespeed.io-5.0.md
@@ -107,13 +107,13 @@ We have finally been able to add support for your own request headers as well as
 Adding a request header:
 
 ~~~bash
-docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io https://www.sitespeed.io/ -r Name:Value
+docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io https://www.sitespeed.io/ -r Name:Value
 ~~~
 
 Blocking all request on my.example.com:
 
 ~~~bash
-docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io https://www.sitespeed.io/ --block my.example.com
+docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io https://www.sitespeed.io/ --block my.example.com
 ~~~
 
 ## Non backward compatible changes in 5.0

--- a/docs/_posts/2017-12-12-sitespeed.io-6.1.md
+++ b/docs/_posts/2017-12-12-sitespeed.io-6.1.md
@@ -67,13 +67,13 @@ The Docker container name is *sitespeedio/sitespeed.io:6.1.0-wpr-alpha* and you 
 Running for Chrome is easy:
 
 ~~~bash
-docker run --cap-add=NET_ADMIN --shm-size=1g --rm -v "$(pwd)":/sitespeed.io -e REPLAY=true sitespeedio/sitespeed.io:6.1.1-wpr-alpha -n 5 -b chrome https://en.wikipedia.org/wiki/Barack_Obama
+docker run --cap-add=NET_ADMIN --shm-size=1g --rm -v "$(pwd):/sitespeed.io" -e REPLAY=true sitespeedio/sitespeed.io:6.1.1-wpr-alpha -n 5 -b chrome https://en.wikipedia.org/wiki/Barack_Obama
 ~~~
 
 It also works for Firefox (note that we need the *skipHar* until the next HAR exporter is released):
 
 ~~~bash
-docker run --cap-add=NET_ADMIN --shm-size=1g --rm -v "$(pwd)":/sitespeed.io -e REPLAY=true sitespeedio/sitespeed.io:6.1.1-wpr-alpha -n 11 --browsertime.skipHar -b firefox https://en.wikipedia.org/wiki/Barack_Obama
+docker run --cap-add=NET_ADMIN --shm-size=1g --rm -v "$(pwd):/sitespeed.io" -e REPLAY=true sitespeedio/sitespeed.io:6.1.1-wpr-alpha -n 11 --browsertime.skipHar -b firefox https://en.wikipedia.org/wiki/Barack_Obama
 ~~~
 
 ### Test it out with Browsertime

--- a/docs/_posts/2018-05-24-sitespeed.io-7.0.md
+++ b/docs/_posts/2018-05-24-sitespeed.io-7.0.md
@@ -68,7 +68,7 @@ WebPageReplay is proxy that first records your web site and then replay it local
 
 You can run like this:
 <code>
-docker run --cap-add=NET_ADMIN --shm-size=1g --rm -v "$(pwd)":/sitespeed.io -e REPLAY=true -e LATENCY=100 sitespeedio/sitespeed.io https://en.wikipedia.org/wiki/Barack_Obama
+docker run --cap-add=NET_ADMIN --shm-size=1g --rm -v "$(pwd):/sitespeed.io" -e REPLAY=true -e LATENCY=100 sitespeedio/sitespeed.io https://en.wikipedia.org/wiki/Barack_Obama
 </code>
 
 Here are a couple of examples from our real world tests. We test on Digital Ocean Optimized Droplets 4 gb memory with 2 vCPUs. We test both with connectivity set to cable (to try to minimize the impact of flaky internet) and one tests using WebPageReplay. We tests with the same amount of runs on the same machine.

--- a/docs/_posts/2018-10-10-sitespeed.io-7.5.md
+++ b/docs/_posts/2018-10-10-sitespeed.io-7.5.md
@@ -55,7 +55,7 @@ We also made it easy to use Lighthouse and the Google PageSpeed Insights plugin 
 You can run it with: 
 
 ```bash
-docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:7.5.0-plus1 https://www.sitespeed.io/
+docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:7.5.0-plus1 https://www.sitespeed.io/
 ``` 
 
 And you will also automatically run Lighthouse and GPSI. We will release a new version of the container per release by adding *-plus1* to the tag. If you use Graphite/InfluxDb the score from Lighthouse and GPSI will be automatically stored.

--- a/docs/_posts/2019-01-21-sitespeed.io-8.0-and-browsertime.4.0.md
+++ b/docs/_posts/2019-01-21-sitespeed.io-8.0-and-browsertime.4.0.md
@@ -32,7 +32,7 @@ Lets say tou want to test the following user journey: A user first visits the st
 You can do that now by just adding the ```--multi``` parameter:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --multi https://www.sitespeed.io https://www.sitespeed.io/documentation/ https://www.sitespeed.io/documentation/sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --multi https://www.sitespeed.io https://www.sitespeed.io/documentation/ https://www.sitespeed.io/documentation/sitespeed.io/
 ~~~
 
 If you leave out ```--multi``` each and every URL will be tested by starting a new browser session with the cached cleared between each URL.
@@ -49,7 +49,7 @@ module.exports = async function(context, commands) {
 
 And run it with 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --multi script.js
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --multi script.js
 ~~~
 
 The new scripting capabilities adds a couple of commands to make scripting easier ([see the documentation](../documentation/sitespeed.io/scripting/)). And you can still also use raw Selenium if you prefer that.
@@ -128,7 +128,7 @@ module.exports = async function(context, commands) {
 And then you run it by passing on the script file, using  ```--spa``` to notify that you are testing a single page application and ```--multi``` that you test multiple pages withing one run. 
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} thirtydays.js --spa --multi
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} thirtydays.js --spa --multi
 ~~~
 
 Read the full [documentation](../documentation/sitespeed.io/spa/) for testing your single page application.

--- a/docs/_posts/2019-09-11-sitespeed.io-10.0.md
+++ b/docs/_posts/2019-09-11-sitespeed.io-10.0.md
@@ -27,7 +27,7 @@ So what's new in the latest version?
 With the new release you can automate parts of your accessibility testing using [Axe](https://github.com/dequelabs/axe-core). You can enable Axe tests with `--axe.enable`. It will run after all other metrics is collected.
 
 ```bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --axe.enable https://www.sitespeed.io
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --axe.enable https://www.sitespeed.io
 ```
 
 It will generate a new result tab in the page summary HTML, where you can see on a high level all violations:

--- a/docs/_posts/2020-02-06-sitespeed.io-12.0-and-browsertime-8.0.md
+++ b/docs/_posts/2020-02-06-sitespeed.io-12.0-and-browsertime-8.0.md
@@ -58,7 +58,7 @@ If your OS support, you can get TCPdumps (desktop only). A very special thanks t
 If you run sitespeed.io you can get the TCP dump and the SSL key log file by just running:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --tcpdump
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --tcpdump
 ~~~
 
 If you use Browsertime you can choose where you want the key log file: `SSLKEYLOGFILE=/path/to/file browsertime --tcpdump https://www.sitespeed.io` or in Docker `docker run --rm -v "$(pwd)":/browsertime -e SSLKEYLOGFILE=/browsertime/keylog.txt sitespeedio/browsertime:{% include version/browsertime.txt %} https://www.sitespeed.io/ -n 1 --tcpdump`. Implemented in [#1159](https://github.com/sitespeedio/browsertime/pull/1159).

--- a/docs/_posts/2020-03-03-sitespeed.io-12.1-and-browsertime-8.1.md
+++ b/docs/_posts/2020-03-03-sitespeed.io-12.1-and-browsertime-8.1.md
@@ -40,7 +40,7 @@ We work out how much energy it takes to serve a site, then work out how much CO2
 Enable the plugin by adding `--sustainable.enable`:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --sustainable.enable
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --sustainable.enable
 ~~~
 
 ### The result

--- a/docs/documentation/sitespeed.io/axe/index.md
+++ b/docs/documentation/sitespeed.io/axe/index.md
@@ -23,7 +23,7 @@ twitterdescription:
 You enable testing with `--axe.enable`.
 
 ```bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --axe.enable https://www.sitespeed.io
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --axe.enable https://www.sitespeed.io
 ```
 
 That will run [axe-core](https://github.com/dequelabs/axe-core) and generate a new **axe** tab in your HTML result. The number of violations (per type) will automatically be sent to Graphite/InfluxDB.

--- a/docs/documentation/sitespeed.io/best-practice/index.md
+++ b/docs/documentation/sitespeed.io/best-practice/index.md
@@ -25,7 +25,7 @@ Read this before you start to collect metrics.
 How do I test cached pages? The easiest way to do that is to use the **--preURL** parameter:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --preURL https://www.sitespeed.io/documentation/ https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --preURL https://www.sitespeed.io/documentation/ https://www.sitespeed.io/
 ~~~
 
 In the example the browser will first go to https://www.sitespeed.io/documentation/ and then with a primed cache navigate to https://www.sitespeed.io/. You can also use [scripting](../scripting/) if you don't mind writing code.
@@ -38,7 +38,7 @@ You can add a cookie is by using <code>--cookie name=value</code> where the name
 If you want to test multiple URLs, you can used line them up in the cli:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io https://www.sitespeed.io/documentation/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io https://www.sitespeed.io/documentation/
 ~~~
 
 You can also use a plain text file with one URL on each line. Create a file called urls.txt (but you can call it whatever you want):
@@ -60,7 +60,7 @@ http://www.yoursite.com/where/we/are/ We_are
 And then you give feed the file to sitespeed.io:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} urls.txt
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} urls.txt
 ~~~
 
 ### How many runs should I do on the same page to get stable metrics?
@@ -109,7 +109,7 @@ If you need to debug CLI parameters the best way is to turn on verbose logging. 
 There's a plugin bundled with sitespeed.io called *analysisstorer* plugin that isn't enabled by default. It stores the original JSON data from all analyzers (from Browsertime, Coach data, WebPageTest etc) to disk. You can enable this plugin:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.add analysisstorer
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.add analysisstorer
 ~~~
 
 The JSON files for the whole run (summary files) will end up in *$RESULT/data/*. JSON for each individual page is stored in *$RESULT/data/pages/$PAGE/data/*.
@@ -120,13 +120,13 @@ By default the # part of a URL is stripped off from your page. Yep we know, it i
 If you have pages that are generated differently depending of what's after you #-sign, you can use the <code>--useHash</code> switch. Then all pages will be tested as a unique page.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --useHash https://www.sitespeed.io/#/super
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --useHash https://www.sitespeed.io/#/super
 ~~~
 
 You can also use the <code>--urlAlias</code> if you want to give the page a friendly name. Use it multiple times if you have multiple URLs.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --useHash --urlAlias super --urlAlias duper https://www.sitespeed.io/#/super https://www.sitespeed.io/#/duper
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --useHash --urlAlias super --urlAlias duper https://www.sitespeed.io/#/super https://www.sitespeed.io/#/duper
 ~~~
 
 

--- a/docs/documentation/sitespeed.io/browsers/index.md
+++ b/docs/documentation/sitespeed.io/browsers/index.md
@@ -90,7 +90,7 @@ If you need to pass on extra command line arguments to the Firefox binary you ca
 When you run Firefox in Docker you should use `--shm-size 2g` to make sure Firefox get enough shared memory (for Chrome we disabled the use of shm with --disable-dev-shm-usage).
 
 ~~~bash
-docker run --shm-size 2g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io -b firefox
+docker run --shm-size 2g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io -b firefox
 ~~~
 
 ## Chrome
@@ -123,7 +123,7 @@ If you want to use it in the configuration file, you can just add each arg in ar
  You can get the trace log from Chrome by adding ```--chrome.timeline```. Doing that you will see how much time the CPU spend in different categories and a trace log file that you can drag and drop into your devtools timeline.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --chrome.timeline https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --chrome.timeline https://www.sitespeed.io/
 ~~~
 
 You can also choose which Chrome trace categories you want to collect by adding ```--chrome.traceCategories```  to your parameters.
@@ -203,7 +203,7 @@ By default the browser will collect data until  [window.performance.timing.loadE
 In this example we wait 10 seconds until the loadEventEnd happens, but you can also choose to trigger it at a specific event.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --browsertime.pageCompleteCheck 'return (function() {try { return (Date.now() - window.performance.timing.loadEventEnd) > 10000;} catch(e) {} return true;})()'
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --browsertime.pageCompleteCheck 'return (function() {try { return (Date.now() - window.performance.timing.loadEventEnd) > 10000;} catch(e) {} return true;})()'
 ~~~
 
 You can also configure how long time your current check will wait until completing with ```--pageCompleteWaitTime```. By default the pageCompleteCheck waits for 5000 ms after the onLoad event to happen. If you want to increase that to 10 seconds use ```--pageCompleteWaitTime 10000```. This is also useful if you test with *pageCompleteCheckInactivity* and it takes long time for the server to respond, you can use the *pageCompleteWaitTime* to wait longer than the default value.
@@ -232,7 +232,7 @@ For example say we have one file called scripts.js that checks how many scripts 
 Then to pick up the script, you would run it like this:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --browsertime.script scripts.js -b firefox
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --browsertime.script scripts.js -b firefox
 ~~~
 
 You will get a custom script section in the Browsertime tab.
@@ -250,7 +250,7 @@ Bonus: All custom scripts values will be sent to Graphite, no extra configuratio
 Visual metrics (Speed Index, Perceptual Speed Index, First and Last Visual Complete, and 85-95-99% Visual Complete) can be collected if you also record a video of the screen. If you use our Docker container you automagically get all what you need. Video and Visual Metrics is turned on by default.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
 ~~~
 
 On Android you need to follow [these instructions]({{site.baseurl}}/documentation/sitespeed.io/mobile-phones/#video-and-speedindex).
@@ -267,7 +267,7 @@ For example if you want to pass on an extra native arguments to Chrome. In stand
 You can generate a TCP dump with `--tcpdump`.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --tcpdump
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --tcpdump
 ~~~
 
 You can then download the TCP dump for each iteration and the SSL key log file from the result page.

--- a/docs/documentation/sitespeed.io/configuration/index.md
+++ b/docs/documentation/sitespeed.io/configuration/index.md
@@ -35,13 +35,13 @@ You can analyse a site either by crawling or by feeding sitespeed.io with a list
 The simplest way to run sitespeed.io is to give it a URL:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io
 ~~~
 
 If you want to test multiple URLs, then just add them. Each page will be tested with a new browser session, browser cache cleared between each URL.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io https://www.sitespeed.io/documentation/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io https://www.sitespeed.io/documentation/
 ~~~
 
 
@@ -67,13 +67,13 @@ Aliases are great in combination with sending metrics to a TSDB (such as Graphit
 And run it:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} urls.txt
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} urls.txt
 ~~~
 
 You can also add alias directly from the command line. Make yore that you pass on the same amount of alias and URLs.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --urlAlias doc https://www.sitespeed.io/documumentation/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --urlAlias doc https://www.sitespeed.io/documumentation/
 ~~~
 
 Pass on multiple --urlAlias for multiple alias/URLs.
@@ -81,7 +81,7 @@ Pass on multiple --urlAlias for multiple alias/URLs.
 If you want to test multiple URLs in a sequence (where the browser cache is not cleared) use --multi:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --multi https://www.sitespeed.io https://www.sitespeed.io/documentation/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --multi https://www.sitespeed.io https://www.sitespeed.io/documentation/
 ~~~
 
 If you wanna do more complicated things like log in the user, add items to a cart etc, checkout [scripting](../scripting/).
@@ -92,21 +92,21 @@ If you wanna do more complicated things like log in the user, add items to a car
 If you want to find pages that are not so performant it's a good idea to crawl. Sitespeed.io will start with the URL and fetch all links on that page and continue to dig deeper into the site structure. You can choose how deep to crawl (1=only one page, 2=include links from first page, etc.):
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io -d 2
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io -d 2
 ~~~
 
 ### How many runs per URL?
 When collecting timing metrics, it's good to test the URL more than one time (default is three times). You can configure how many runs like this (five runs):
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io -n 5
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io -n 5
 ~~~
 
 ### Choose browser
 Choose which browser to use (default is Chrome):
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io -b firefox
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io -b firefox
 ~~~
 
 ### Connectivity
@@ -120,13 +120,13 @@ You can set the viewport & user agent, so you can fake testing a site as a mobil
 The simplest way is to just add <code>--mobile</code> as a parameter. The viewport will be set to 360x640 and the user agent will be Iphone6. If you use Chrome it will use the preset Apple iPhone 6 device.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --mobile
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --mobile
 ~~~
 
 You can also set a specific viewport and user agent:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --browsertime.viewPort 400x400 --browsertime.userAgent "UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.4; en-US; XT1022) U2/1.0.0 UCBrowser/10.6.0.706 U2/1.0.0 Mobile"
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --browsertime.viewPort 400x400 --browsertime.userAgent "UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.4; en-US; XT1022) U2/1.0.0 UCBrowser/10.6.0.706 U2/1.0.0 Mobile"
 ~~~
 
 Mobile testing is always best on actual mobile devices. You can [test on Android phones](../mobile-phones/) using sitespeed.io.
@@ -138,12 +138,12 @@ In 4.1 we released support for recording a video of the browser screen and use t
 In 6.0 video and Visual Metrics is turned on by default, and if you want to turn them off you do like this:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --visualMetrics false https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --visualMetrics false https://www.sitespeed.io/
 ~~~
 
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --visualMetrics false --video false https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --visualMetrics false --video false https://www.sitespeed.io/
 ~~~
 
 
@@ -151,7 +151,7 @@ docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include ve
 By default we will categorise the current main domain as first party and the rest as a third party. And you probably wanna categorise requests yourself as first or third parties by adding a regex.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --firstParty ".ryanair.com" https://www.ryanair.com/us/en/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --firstParty ".ryanair.com" https://www.ryanair.com/us/en/
 ~~~
 
 This is a JavaScript regex and if you need help you should test it out at [https://regexr.com](https://regexr.com) to see that it will match.
@@ -160,7 +160,7 @@ This is a JavaScript regex and if you need help you should test it out at [https
 You can change where you want the data to be stored by setting the <code>--outputFolder</code> parameter. That is good in scenarios where you want to change the default behaviour and put the output in a specific location:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --outputFolder /my/folder https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --outputFolder /my/folder https://www.sitespeed.io/
 ~~~
 
 ### Configuration as JSON
@@ -200,13 +200,13 @@ A more complex example: Create a config file and call it config.json:
 Then, run it like this:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --config config.json https://www.sitespeed.io
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --config config.json https://www.sitespeed.io
 ~~~
 
 If you want to override and run the same configuration but using Firefox, you just override with the CLI parameter:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --config config.json -b firefox https://www.sitespeed.io
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --config config.json -b firefox https://www.sitespeed.io
 ~~~
 
 The CLI will always override the JSON config.
@@ -240,13 +240,13 @@ You can check out [our example configuration](https://github.com/sitespeedio/das
 You can send the result of a run to Slack. First, set up a webhook in the Slack API (https://<your team>.slack.com/apps/manage/custom-integrations) and then configure it:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --slack.hookUrl https://hooks.slack.com/services/YOUR/HOOK/URL
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --slack.hookUrl https://hooks.slack.com/services/YOUR/HOOK/URL
 ~~~
 
 You can choose to send just a summary (the summary for all runs), individual runs (with URL), only errors, or everything, by choosing the respective <code>slack.type</code>.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --slack.hookUrl https://hooks.slack.com/services/YOUR/HOOK/URL --slack.type summary
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --slack.hookUrl https://hooks.slack.com/services/YOUR/HOOK/URL --slack.type summary
 ~~~
 
 ![Slack]({{site.baseurl}}/img/slack.png)

--- a/docs/documentation/sitespeed.io/configure-html/index.md
+++ b/docs/documentation/sitespeed.io/configure-html/index.md
@@ -30,7 +30,7 @@ When your test, the pages page is generated where you can compare all the URLs t
 You can configure which metrics to show in the columns with the `--html.pageSummaryMetrics` cli parameter. Pass it multiple times to add multiple columns or use the configuration file json and create an array with metrics that you want use.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --html.pageSummaryMetrics timings.pageLoadTime  --html.pageSummaryMetrics requests.total https://www.sitespeed.io 
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --html.pageSummaryMetrics timings.pageLoadTime  --html.pageSummaryMetrics requests.total https://www.sitespeed.io 
 ~~~
 
 Or use a configuration json:
@@ -67,7 +67,7 @@ The start page with summary boxes are also configurable. You can choose which me
 It follows the same pattern as page columns and uses the same friendly names. 
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --html.summaryBoxes timings.pageLoadTime  --html.summaryBoxes requests.total https://www.sitespeed.io 
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --html.summaryBoxes timings.pageLoadTime  --html.summaryBoxes requests.total https://www.sitespeed.io 
 ~~~
 
 
@@ -108,7 +108,7 @@ Say that you are testing on a slow 3g connection and the default settings for fi
 
 And then run:
  ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --html.summaryBoxesThresholds summaryLimits.json https://www.sitespeed.io 
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --html.summaryBoxesThresholds summaryLimits.json https://www.sitespeed.io 
 ~~~
 
 

--- a/docs/documentation/sitespeed.io/configure-metrics/index.md
+++ b/docs/documentation/sitespeed.io/configure-metrics/index.md
@@ -36,7 +36,7 @@ are loading, so you will need to do an actual run to generate the list. The list
 named **configuredMetrics.txt**.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --metrics.filterList
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --metrics.filterList
 ~~~
 
 The file will look something like this:
@@ -59,7 +59,7 @@ You can also list all possible metrics that you can send. You can do that by usi
 generate a text file named **metrics.txt** in the data folder.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --metrics.list
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --metrics.list
 ~~~
 
 
@@ -96,7 +96,7 @@ filter like this **coach.pageSummary.advice.performance.adviceList.\*.score** wi
 the name).
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --metrics.filter coach.pageSummary.advice.performance.adviceList.*.score -n 1
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --metrics.filter coach.pageSummary.advice.performance.adviceList.*.score -n 1
 ~~~
 
 The best way to test and verify on your local, is to checkout the sitespeed.io project and then start a TCP server that
@@ -115,7 +115,7 @@ $ Server listening on :::52860
 It will output the port, so you can then use it when you run sitespeed.io:
 
 ~~~bash
-docker run --net host --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --metrics.list https://www.sitespeed.io -n 1 --metrics.filter coach.pageSummary.advice.performance.adviceList.*.score --graphite.host 127.0.0.1 --graphite.port 52860
+docker run --net host --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --metrics.list https://www.sitespeed.io -n 1 --metrics.filter coach.pageSummary.advice.performance.adviceList.*.score --graphite.host 127.0.0.1 --graphite.port 52860
 ~~~
 
 The previous example it will log all metrics you send to Graphite to the console.
@@ -156,5 +156,5 @@ remove all configured metrics with the parameter value *\*-*. Here is an example
 **coach.pageSummary.advice.performance.adviceList.\*.score** metrics.
 
 ~~~bash
-docker run --net host --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --metrics.list https://www.sitespeed.io -n 1 --metrics.filter *- coach.pageSummary.advice.performance.adviceList.*.score --graphite.host 127.0.0.1 --graphite.port 52860
+docker run --net host --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --metrics.list https://www.sitespeed.io -n 1 --metrics.filter *- coach.pageSummary.advice.performance.adviceList.*.score --graphite.host 127.0.0.1 --graphite.port 52860
 ~~~

--- a/docs/documentation/sitespeed.io/continuous-integration/index.md
+++ b/docs/documentation/sitespeed.io/continuous-integration/index.md
@@ -63,7 +63,7 @@ jobs:
       - name: code checkout
         uses: actions/checkout@v2
       - name: running sitespeed.io container with arguments and optional Docker options
-        run: docker run -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --budget.configPath .github/budget.json -n 1 
+        run: docker run -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --budget.configPath .github/budget.json -n 1 
 ```
 As arguments and Docker options you can use all [configurations options](/documentation/sitespeed.io/configuration/#the-options) as you usually do with sitespeed.io. Since we don't use any timing metrics in the budget we only do one run.
 
@@ -134,7 +134,7 @@ jobs:
       - run: docker run --shm-size=1g --rm sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
 
       # No traffic shaping with performance budget
-      - run: docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -n 3 --budget.configPath myBudget.json https://www.sitespeed.io/
+      - run: docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -n 3 --budget.configPath myBudget.json https://www.sitespeed.io/
 
 workflows:
   version: 2

--- a/docs/documentation/sitespeed.io/continuously-run-your-tests/index.md
+++ b/docs/documentation/sitespeed.io/continuously-run-your-tests/index.md
@@ -132,7 +132,7 @@ Then our configuration files in [**/config/**](https://github.com/sitespeedio/da
 And when we run our tests, we map the volume on the server /config to our docker container. You can see that in the [run.sh](https://github.com/sitespeedio/dashboard.sitespeed.io/blob/main/run.sh) file. Look for `-v /config:/config`. That is the magic line.
 
 
-We then also map the current working dir to `-v "$(pwd)":/sitespeed.io` and then feed the the config file to sitespeed `--config /sitespeed.io/config`. That way, inside the Docker container we have **/config/** that has the secret configuration files and in **/sitespeed.io/config** the configuration we want to use for our tests.
+We then also map the current working dir to `-v "$(pwd):/sitespeed.io"` and then feed the the config file to sitespeed `--config /sitespeed.io/config`. That way, inside the Docker container we have **/config/** that has the secret configuration files and in **/sitespeed.io/config** the configuration we want to use for our tests.
 
 
 #### Change the tests

--- a/docs/documentation/sitespeed.io/developers/index.md
+++ b/docs/documentation/sitespeed.io/developers/index.md
@@ -136,13 +136,13 @@ To run the Docker version:
 - Install [Docker Community Edition](https://docs.docker.com/install/)
 - You need to fork and clone [sitespeed.io](https://github.com/sitespeedio/sitespeed.io).
 - Run <code>docker build -t sitespeedio/sitespeed.io .</code> in the cloned directory to build the container
-- Run <code>docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io https://www.sitespeed.io/</code>
+- Run <code>docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io https://www.sitespeed.io/</code>
 
 If you want to test and push to Graphite/InfluxDB:
 
 - Go to *docker/* in the cloned dir and start the container: <code>docker-compose up</code>
 - Go back one level and run <code>docker build -t sitespeedio/sitespeed.io .</code> in the cloned directory to build the container
-- Run: <code>docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io https://www.sitespeed.io -n 1 --graphite.host=192.168.65.1</code> to push the data to Graphite. The IP is the localhost IP if you run on a Mac.
+- Run: <code>docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io https://www.sitespeed.io -n 1 --graphite.host=192.168.65.1</code> to push the data to Graphite. The IP is the localhost IP if you run on a Mac.
 - Check the metrics at [http://127.0.0.1:3000/](http://127.0.0.1:3000/).
 
 If you are new to Git/GitHub and want to make a PR you can start with reading [Digital Oceans tutorial on how to make PRs](https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github).

--- a/docs/documentation/sitespeed.io/docker/index.md
+++ b/docs/documentation/sitespeed.io/docker/index.md
@@ -45,27 +45,27 @@ We lock down the browsers to specific versions for maximum compatibility and sta
 The simplest way to run using Chrome:
 
 ```bash
-docker run --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome https://www.sitespeed.io/
 ```
 
 In the real world you should always specify the exact version (tag) of the Docker container to make sure you use the same version for every run. If you use the latest tag you will download newer version of sitespeed.io as they become available, meaning you can have major changes between test runs (version upgrades, dependencies updates, browser versions, etc). So you should always specify a tag after the container name(X.Y.Z). Know that the tag/version number will be the same number as the sitespeed.io release:
 
 ```bash
-docker run --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome https://www.sitespeed.io/
 ```
 
 If you want to use Firefox (make sure you make the shared memory larger using --shm-size):
 
 ```bash
-docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
+docker run --shm-size 2g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
 ```
 
-Using `-v ${pwd}:/sitespeed.io` will map the current directory inside Docker and output the result directory there.
+Using `-v "$(pwd):/sitespeed.io`" will map the current directory inside Docker and output the result directory there.
 {: .note .note-info}
 
 ## More about volumes
 
-If you want to feed sitespeed.io with a file with URLs or if you want to store the HTML result, you should setup a volume. Sitespeed.io will do all the work inside the container in a directory located at _/sitespeed.io_. To setup your current working directory add the _-v ${pwd}:/sitespeed.io_ to your parameter list. Using ${pwd} will default to the current directory. In order to specify a static location, simply define an absolute path: _-v /Users/sitespeedio/html:/sitespeed.io_
+If you want to feed sitespeed.io with a file with URLs or if you want to store the HTML result, you should setup a volume. Sitespeed.io will do all the work inside the container in a directory located at _/sitespeed.io_. To setup your current working directory add the _-v "$(pwd):/sitespeed.io_" to your parameter list. Using "$(pwd)" will default to the current directory. In order to specify a static location, simply define an absolute path: _-v /Users/sitespeedio/html:/sitespeed.io_
 
 If you run on Windows, it could be that you need to map a absolute path. If you have problems on Windows please check [https://docs.docker.com/docker-for-windows/](https://docs.docker.com/docker-for-windows/).
 
@@ -90,7 +90,7 @@ If you want to make sure your containers have the same time as the host, you can
 Full example:
 
 ```bash
-docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io -v /etc/localtime:/etc/localtime:ro sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
+docker run --shm-size 2g --rm -v "$(pwd):/sitespeed.io" -v /etc/localtime:/etc/localtime:ro sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
 ```
 
 ## Setting time zone
@@ -98,7 +98,7 @@ docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io -v /etc/localtime:/etc/loc
 If you want your container to run in a specific time zone you can do that with TZ.
 
 ```bash
-docker run -e TZ=America/New_York --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -n 1 https://www.sitespeed.io
+docker run -e TZ=America/New_York --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -n 1 https://www.sitespeed.io
 ```
 
 ## Change connectivity
@@ -110,7 +110,7 @@ To change connectivity you should use Docker networks, read all about it [here](
 If you test many URLs or many runs at the same time you may get errors like `Allocation failed - JavaScript heap out of memory`. The default memory size for NodeJS is set to 2048 in the Docker container. You can increase that by using the Docker environment variable **MAX_OLD_SPACE_SIZE**.
 
 ```bash
-docker run -e MAX_OLD_SPACE_SIZE=4096 --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
+docker run -e MAX_OLD_SPACE_SIZE=4096 --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
 ```
 
 ## Access localhost
@@ -118,13 +118,13 @@ docker run -e MAX_OLD_SPACE_SIZE=4096 --rm -v ${pwd}:/sitespeed.io sitespeedio/s
 If you run a server local on your machine and want to access it with sitespeed.io you can do that on Mac and Windows super easy if you are using Docker 18.03 or later by using _host.docker.internal_.
 
 ```bash
-docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://host.docker.internal:4000/
+docker run --shm-size 2g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://host.docker.internal:4000/
 ```
 
 If you are using Linux you should use `--network=host` to make sure localhost is your host machine.
 
 ```bash
-docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io --network=host sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://localhost:4000/
+docker run --shm-size 2g --rm -v "$(pwd):/sitespeed.io" --network=host sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://localhost:4000/
 ```
 
 ## Access host in your local network
@@ -136,7 +136,7 @@ Sometimes the server you wanna test is in your local network at work and Docker 
 If you are using docker-compose for setting up Graphite and Grafana, your network name is normally named after the folder that you are running docker-compose from with an additional `_default` in the name, so if your folder name is sitespeedio, your network name would be `sitespeedio_default`.
 
 ```bash
-docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io --network sitespeedio_default sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://localhost:4000/
+docker run --shm-size 2g --rm -v "$(pwd):/sitespeed.io" --network sitespeedio_default sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://localhost:4000/
 ```
 
 
@@ -145,7 +145,7 @@ docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io --network sitespeedio_defa
 You can run your extra start script in the Docker container:
 
 ```bash
-docker run -e EXTRA_START_SCRIPT=/sitespeed.io/test.sh --rm -v ${pwd}:/sitespeed.io ...`.
+docker run -e EXTRA_START_SCRIPT=/sitespeed.io/test.sh --rm -v "$(pwd):/sitespeed.io" ...`.
 ```
 
 ## Troubleshooting
@@ -167,7 +167,7 @@ The docker containers have `x11vnc` installed which enables visualisation of the
 - You will need to run the sitespeed.io image by exposing a PORT for vnc server. By default this port is 5900. If you plan to change your port for VNC server, then you need to expose that port.
 
 ```bash
-docker run --rm -v ${pwd}:/sitespeed.io -p 5900:5900 sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ -b chrome
+docker run --rm -v "$(pwd):/sitespeed.io" -p 5900:5900 sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ -b chrome
 ```
 
 - Find the container id of the docker container for sitespeed by running:

--- a/docs/documentation/sitespeed.io/docker/index.md
+++ b/docs/documentation/sitespeed.io/docker/index.md
@@ -45,27 +45,27 @@ We lock down the browsers to specific versions for maximum compatibility and sta
 The simplest way to run using Chrome:
 
 ```bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome https://www.sitespeed.io/
+docker run --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome https://www.sitespeed.io/
 ```
 
 In the real world you should always specify the exact version (tag) of the Docker container to make sure you use the same version for every run. If you use the latest tag you will download newer version of sitespeed.io as they become available, meaning you can have major changes between test runs (version upgrades, dependencies updates, browser versions, etc). So you should always specify a tag after the container name(X.Y.Z). Know that the tag/version number will be the same number as the sitespeed.io release:
 
 ```bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome https://www.sitespeed.io/
+docker run --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome https://www.sitespeed.io/
 ```
 
 If you want to use Firefox (make sure you make the shared memory larger using --shm-size):
 
 ```bash
-docker run --shm-size 2g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
+docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
 ```
 
-Using `-v "$(pwd)":/sitespeed.io` will map the current directory inside Docker and output the result directory there.
+Using `-v ${pwd}:/sitespeed.io` will map the current directory inside Docker and output the result directory there.
 {: .note .note-info}
 
 ## More about volumes
 
-If you want to feed sitespeed.io with a file with URLs or if you want to store the HTML result, you should setup a volume. Sitespeed.io will do all the work inside the container in a directory located at _/sitespeed.io_. To setup your current working directory add the _-v "$(pwd)":/sitespeed.io_ to your parameter list. Using "$(pwd)" will default to the current directory. In order to specify a static location, simply define an absolute path: _-v /Users/sitespeedio/html:/sitespeed.io_
+If you want to feed sitespeed.io with a file with URLs or if you want to store the HTML result, you should setup a volume. Sitespeed.io will do all the work inside the container in a directory located at _/sitespeed.io_. To setup your current working directory add the _-v ${pwd}:/sitespeed.io_ to your parameter list. Using ${pwd} will default to the current directory. In order to specify a static location, simply define an absolute path: _-v /Users/sitespeedio/html:/sitespeed.io_
 
 If you run on Windows, it could be that you need to map a absolute path. If you have problems on Windows please check [https://docs.docker.com/docker-for-windows/](https://docs.docker.com/docker-for-windows/).
 
@@ -90,7 +90,7 @@ If you want to make sure your containers have the same time as the host, you can
 Full example:
 
 ```bash
-docker run --shm-size 2g --rm -v "$(pwd)":/sitespeed.io -v /etc/localtime:/etc/localtime:ro sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
+docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io -v /etc/localtime:/etc/localtime:ro sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
 ```
 
 ## Setting time zone
@@ -98,7 +98,7 @@ docker run --shm-size 2g --rm -v "$(pwd)":/sitespeed.io -v /etc/localtime:/etc/l
 If you want your container to run in a specific time zone you can do that with TZ.
 
 ```bash
-docker run -e TZ=America/New_York --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -n 1 https://www.sitespeed.io
+docker run -e TZ=America/New_York --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -n 1 https://www.sitespeed.io
 ```
 
 ## Change connectivity
@@ -110,7 +110,7 @@ To change connectivity you should use Docker networks, read all about it [here](
 If you test many URLs or many runs at the same time you may get errors like `Allocation failed - JavaScript heap out of memory`. The default memory size for NodeJS is set to 2048 in the Docker container. You can increase that by using the Docker environment variable **MAX_OLD_SPACE_SIZE**.
 
 ```bash
-docker run -e MAX_OLD_SPACE_SIZE=4096 --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
+docker run -e MAX_OLD_SPACE_SIZE=4096 --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
 ```
 
 ## Access localhost
@@ -118,13 +118,13 @@ docker run -e MAX_OLD_SPACE_SIZE=4096 --rm -v "$(pwd)":/sitespeed.io sitespeedio
 If you run a server local on your machine and want to access it with sitespeed.io you can do that on Mac and Windows super easy if you are using Docker 18.03 or later by using _host.docker.internal_.
 
 ```bash
-docker run --shm-size 2g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://host.docker.internal:4000/
+docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://host.docker.internal:4000/
 ```
 
 If you are using Linux you should use `--network=host` to make sure localhost is your host machine.
 
 ```bash
-docker run --shm-size 2g --rm -v "$(pwd)":/sitespeed.io --network=host sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://localhost:4000/
+docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io --network=host sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://localhost:4000/
 ```
 
 ## Access host in your local network
@@ -136,7 +136,7 @@ Sometimes the server you wanna test is in your local network at work and Docker 
 If you are using docker-compose for setting up Graphite and Grafana, your network name is normally named after the folder that you are running docker-compose from with an additional `_default` in the name, so if your folder name is sitespeedio, your network name would be `sitespeedio_default`.
 
 ```bash
-docker run --shm-size 2g --rm -v "$(pwd)":/sitespeed.io --network sitespeedio_default sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://localhost:4000/
+docker run --shm-size 2g --rm -v ${pwd}:/sitespeed.io --network sitespeedio_default sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox http://localhost:4000/
 ```
 
 
@@ -145,7 +145,7 @@ docker run --shm-size 2g --rm -v "$(pwd)":/sitespeed.io --network sitespeedio_de
 You can run your extra start script in the Docker container:
 
 ```bash
-docker run -e EXTRA_START_SCRIPT=/sitespeed.io/test.sh --rm -v "$(pwd)":/sitespeed.io ...`.
+docker run -e EXTRA_START_SCRIPT=/sitespeed.io/test.sh --rm -v ${pwd}:/sitespeed.io ...`.
 ```
 
 ## Troubleshooting
@@ -167,7 +167,7 @@ The docker containers have `x11vnc` installed which enables visualisation of the
 - You will need to run the sitespeed.io image by exposing a PORT for vnc server. By default this port is 5900. If you plan to change your port for VNC server, then you need to expose that port.
 
 ```bash
-docker run --rm -v "$(pwd)":/sitespeed.io -p 5900:5900 sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ -b chrome
+docker run --rm -v ${pwd}:/sitespeed.io -p 5900:5900 sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ -b chrome
 ```
 
 - Find the container id of the docker container for sitespeed by running:

--- a/docs/documentation/sitespeed.io/docker/index.md
+++ b/docs/documentation/sitespeed.io/docker/index.md
@@ -60,12 +60,12 @@ If you want to use Firefox (make sure you make the shared memory larger using --
 docker run --shm-size 2g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox https://www.sitespeed.io/
 ```
 
-Using `-v "$(pwd):/sitespeed.io`" will map the current directory inside Docker and output the result directory there.
+Using `-v "$(pwd):/sitespeed.io"` will map the current directory inside Docker and output the result directory there.
 {: .note .note-info}
 
 ## More about volumes
 
-If you want to feed sitespeed.io with a file with URLs or if you want to store the HTML result, you should setup a volume. Sitespeed.io will do all the work inside the container in a directory located at _/sitespeed.io_. To setup your current working directory add the _-v "$(pwd):/sitespeed.io_" to your parameter list. Using "$(pwd)" will default to the current directory. In order to specify a static location, simply define an absolute path: _-v /Users/sitespeedio/html:/sitespeed.io_
+If you want to feed sitespeed.io with a file with URLs or if you want to store the HTML result, you should setup a volume. Sitespeed.io will do all the work inside the container in a directory located at _/sitespeed.io_. To setup your current working directory add the _-v "$(pwd):/sitespeed.io"_ to your parameter list. Using "$(pwd)" will default to the current directory. In order to specify a static location, simply define an absolute path: _-v /Users/sitespeedio/html:/sitespeed.io_
 
 If you run on Windows, it could be that you need to map a absolute path. If you have problems on Windows please check [https://docs.docker.com/docker-for-windows/](https://docs.docker.com/docker-for-windows/).
 

--- a/docs/documentation/sitespeed.io/google-page-speed-insights/index.md
+++ b/docs/documentation/sitespeed.io/google-page-speed-insights/index.md
@@ -17,7 +17,7 @@ There's a Google Page Speed Insights plugin at [https://github.com/sitespeedio/p
 You can run it with: 
 
 ```bash
-docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}-plus1 https://www.sitespeed.io/ --plugins.remove /lighthouse
+docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}-plus1 https://www.sitespeed.io/ --plugins.remove /lighthouse
 ``` 
 
 The container also includes Lighthouse. We automatically release a new version of the container per release by adding *-plus1* to the tag. If you use Graphite/InfluxDb the score from Lighthouse and GPSI will be automatically stored.

--- a/docs/documentation/sitespeed.io/graphite/index.md
+++ b/docs/documentation/sitespeed.io/graphite/index.md
@@ -82,7 +82,7 @@ If you want to test and verify what the metrics looks like that you send to Grap
 1. Start the server (you need to clone the sitespeed.io repo first): <code>tools/tcp-server.js</code>
 2. You will then get back the port for the server (60447 in this example): <code>Server listening on :::60447</code>
 3. Open another terminal and run sitespeed.io and send the metrics to the tcp-server ([read how to reach localhost from Docker](/documentation/sitespeed.io/docker/#access-localhost)):
-<code>docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --graphite.host 192.168.65.2 --graphite.port 60447  -n 1</code>
+<code>docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --graphite.host 192.168.65.2 --graphite.port 60447  -n 1</code>
 4. Check the terminal where you have the TCP server running and you will see something like:
 
 ~~~

--- a/docs/documentation/sitespeed.io/installation/index.md
+++ b/docs/documentation/sitespeed.io/installation/index.md
@@ -26,7 +26,7 @@ We have [Docker images](https://hub.docker.com/r/sitespeedio/sitespeed.io/) with
 ### Mac & Linux
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io https://www.sitespeed.io -b firefox
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io https://www.sitespeed.io -b firefox
 ~~~
 
 ### Windows

--- a/docs/documentation/sitespeed.io/lighthouse/index.md
+++ b/docs/documentation/sitespeed.io/lighthouse/index.md
@@ -21,7 +21,7 @@ We also made it easy to use Lighthouse and the Google PageSpeed Insights plugin 
 You can run it with: 
 
 ```bash
-docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}-plus1 https://www.sitespeed.io/
+docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}-plus1 https://www.sitespeed.io/
 ``` 
 
 And you will also automatically run Lighthouse and GPSI. We automatically release a new version of the container per release by adding *-plus1* to the tag. If you use Graphite/InfluxDb the score from Lighthouse and GPSI will be automatically stored. If you want to add functionality please send PRs to [https://github.com/sitespeedio/plugin-lighthouse](https://github.com/sitespeedio/plugin-lighthouse) and [https://github.com/sitespeedio/plugin-gpsi](https://github.com/sitespeedio/plugin-gpsi).
@@ -31,7 +31,7 @@ The Lighthouse tests will run after Browsertime finished and run Chrome headless
 *Note:* If you want to run more plugins with <code>--plugins.add</code> that will override the default settings so you will need to add the Lighthouse plugin again like this:
 
 ```bash
-docker run --shm-size=1g --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}-plus1 https://www.sitespeed.io/ --plugins.add analysisstorer --plugins.add /lighthouse
+docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}-plus1 https://www.sitespeed.io/ --plugins.add analysisstorer --plugins.add /lighthouse
 ``` 
 
 The Lighthouse result is iframed into sitespeed.io:

--- a/docs/documentation/sitespeed.io/mobile-phones/index.md
+++ b/docs/documentation/sitespeed.io/mobile-phones/index.md
@@ -64,7 +64,7 @@ sitespeed.io --android https://www.sitespeed.io
 Remember: To test on Android using Docker you need to be on Linux (tested on Ubuntu). It will not work on OS X.
 
 ```bash
-docker run --privileged -v /dev/bus/usb:/dev/bus/usb -e START_ADB_SERVER=true --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}  -n 1 --android --browsertime.xvfb false https://www.sitespeed.io
+docker run --privileged -v /dev/bus/usb:/dev/bus/usb -e START_ADB_SERVER=true --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}  -n 1 --android --browsertime.xvfb false https://www.sitespeed.io
 ```
 
 You will get result as you would with running this normally with summaries and waterfall graphs.
@@ -108,7 +108,7 @@ sitespeed.io --android --video --visualMetrics https://www.sitespeed.io
 And using Docker (remember: only works in Linux hosts):
 
 ```bash
-docker run --privileged -v /dev/bus/usb:/dev/bus/usb -e START_ADB_SERVER=true --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}  -n 1 --android --browsertime.xvfb false https://www.sitespeed.io
+docker run --privileged -v /dev/bus/usb:/dev/bus/usb -e START_ADB_SERVER=true --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %}  -n 1 --android --browsertime.xvfb false https://www.sitespeed.io
 ```
 
 If you want to run Docker on Mac OS X, you can follow Appiums [setup](https://github.com/appium/appium-docker-android) by creating a docker-machine, give out USB access and then run the container from that Docker machine.

--- a/docs/documentation/sitespeed.io/performance-budget/index.md
+++ b/docs/documentation/sitespeed.io/performance-budget/index.md
@@ -241,7 +241,7 @@ You can read more about the metrics/data structure in the [metrics section]({{si
 Then run it like this:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --budget.configPath myBudget.json -b chrome -n 11
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --budget.configPath myBudget.json -b chrome -n 11
 ~~~
 
 And, if the budget fails, the exit status will be > 0. You can also choose to report the budget as JUnitXML (Jenkins) or TAP.
@@ -250,7 +250,7 @@ And, if the budget fails, the exit status will be > 0. You can also choose to re
 You can output a JUnit XML file from the budget result like this:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --budget.configPath myBudget.json --budget.output junit -b chrome -n 5
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --budget.configPath myBudget.json --budget.output junit -b chrome -n 5
 ~~~
 
 It will create a *junit.xml* in the outputFolder.
@@ -259,7 +259,7 @@ It will create a *junit.xml* in the outputFolder.
 If you would instead like to use TAP, you can do so like this:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --budget.configPath myBudget.json --budget.output tap -b chrome -n 5
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --budget.configPath myBudget.json --budget.output tap -b chrome -n 5
 ~~~
 
 It will create a *budget.tap* in the outputFolder.
@@ -268,7 +268,7 @@ It will create a *budget.tap* in the outputFolder.
 You can output the result of the budget as JSON:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --budget.configPath myBudget.json --budget.output json -b chrome -n 5
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --budget.configPath myBudget.json --budget.output json -b chrome -n 5
 ~~~
 
 It will create a *budgetResult.json* in the outputFolder.

--- a/docs/documentation/sitespeed.io/performance-dashboard/index.md
+++ b/docs/documentation/sitespeed.io/performance-dashboard/index.md
@@ -26,7 +26,7 @@ You need [Docker](https://docs.docker.com/engine/installation/) and [Docker Comp
 
 1. Download our Docker compose file: <code>curl -O https://raw.githubusercontent.com/sitespeedio/sitespeed.io/main/docker/docker-compose.yml</code>
 2. Run: <code>docker-compose up -d</code> (make sure you run the latest [Docker compose](https://docs.docker.com/compose/install/) version)
-3. Run sitespeed to get some metrics: <code> docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --graphite.host=host.docker.internal</code> (running on Linux? [Check how to access localhost]({{site.baseurl}}/documentation/sitespeed.io/docker/#access-localhost)).
+3. Run sitespeed to get some metrics: <code> docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --graphite.host=host.docker.internal</code> (running on Linux? [Check how to access localhost]({{site.baseurl}}/documentation/sitespeed.io/docker/#access-localhost)).
 4. Access the dashboard: http://127.0.0.1:3000
 5. When you are done you can shut down and remove all the Docker containers by running <code>docker-compose stop && docker-compose rm</code>. Container data will be kept.
 6. To start from scratch, also remove the Graphite and Grafana data volumes by running `docker volume rm performancedashboard_graphite performancedashboard_grafana`.
@@ -224,7 +224,7 @@ How large will your instances need to be? You need to have enough memory for Chr
 If you test a lot a pages (100+) in the same run, your NodeJS process can run out of memory (default memory for NodeJS is 1.76 GB). You can change and increase by setting MAX_OLD_SPACE_SIZE:
 
 ```bash
-docker run -e MAX_OLD_SPACE_SIZE=4096 --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
+docker run -e MAX_OLD_SPACE_SIZE=4096 --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/
 ```
 
 ## Cost

--- a/docs/documentation/sitespeed.io/plugins/index.md
+++ b/docs/documentation/sitespeed.io/plugins/index.md
@@ -24,7 +24,7 @@ The most basic things you can do is list configured plugins (which are currently
 You can list the plugins that will be used when you do a run:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --plugins.list https://en.wikipedia.org/wiki/Barack_Obama
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --plugins.list https://en.wikipedia.org/wiki/Barack_Obama
 ~~~
 
 And you will get a log entry that looks something like this:
@@ -41,19 +41,19 @@ The default plugins lives in the [plugin folder](https://github.com/sitespeedio/
 You can remove/disable default plugins if needed. For instance you may not want to output HTML and strictly send the data to Graphite.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.remove html
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.remove html
 ~~~
 
 If you want to disable multiple plugins say you don't need the HTML and the har files (the harstorer plugin):
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.remove html --plugins.remove harstorer
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.remove html --plugins.remove harstorer
 ~~~
 
 At anytime if you want to verify that disabling worked, add the plugins.list to your command:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.remove html --plugins.remove harstorer --plugins.list
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.remove html --plugins.remove harstorer --plugins.list
 ~~~
 
 ## Add a plugin
@@ -62,7 +62,7 @@ You can also add a plugin. This is great if you have plugins you created yoursel
 There's a plugin bundled with sitespeed.io called *analysisstorer* plugin that isn't enabled by default. It stores the original JSON data from all analyzers (from Browsertime, Coach data, WebPageTest etc) to disk. You can enable this plugin:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.add analysisstorer
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --plugins.add analysisstorer
 ~~~
 
 If you want to run plugins that you created yourself or that are shared from others, you can either install the plugin using npm (locally) and load it by name or point out the directory where the plugin lives.
@@ -73,7 +73,7 @@ If you want to run plugins that you created yourself or that are shared from oth
 If you run in Docker and you should. You will need to mount your plugin directory as a volume. This is the recommended best practice. Practically you should clone your repo on your server and then mount it like this.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox --plugins.add /sitespeed.io/myplugin -n 1 https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b firefox --plugins.add /sitespeed.io/myplugin -n 1 https://www.sitespeed.io/
 ~~~
 
 ### Relative using NodeJS
@@ -111,7 +111,7 @@ docker build -t my-custom-sitespeedio .
 Finally you can run it the same way as mentioned above without the volume mount and without adding your plugin (that was automatically fixed in your Docker file).
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io my-custom-sitespeedio -b firefox --my-custom-plugin.option test -n 1 https://www.sitespeed.io/
+docker run --rm -v "$(pwd):/sitespeed.io" my-custom-sitespeedio -b firefox --my-custom-plugin.option test -n 1 https://www.sitespeed.io/
 ~~~
 
 Pretty cool, huh? :-)

--- a/docs/documentation/sitespeed.io/prepostscript/index.md
+++ b/docs/documentation/sitespeed.io/prepostscript/index.md
@@ -91,7 +91,7 @@ Make sure to change the username & password if you try this on Wikipedia. And of
 Then run it like this:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --preScript /sitespeed.io/login.js https://en.wikipedia.org/wiki/Barack_Obama
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --preScript /sitespeed.io/login.js https://en.wikipedia.org/wiki/Barack_Obama
 ~~~
 
 The script will then login the user and access https://en.wikipedia.org/wiki/Barack_Obama and measure that page.

--- a/docs/documentation/sitespeed.io/scripting/index.md
+++ b/docs/documentation/sitespeed.io/scripting/index.md
@@ -76,7 +76,7 @@ Scripting only works for Browsertime. It will not work with Lighthouse/Google Pa
 Run your script by passing it to sitespeed.io and adding the parameter ```--multi```. If you have multiple scripts, you can just pass them in as well.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} script.js script2.js script3.js --multi
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} script.js script2.js script3.js --multi
 ~~~
 
 If you want to pass data between your scripts you can do that with the context object. Here's an example of the first script:

--- a/docs/documentation/sitespeed.io/spa/index.md
+++ b/docs/documentation/sitespeed.io/spa/index.md
@@ -67,6 +67,6 @@ module.exports = async function(context, commands) {
 Then you run it by passing on the script file, using  ```--spa``` to notify that you are testing a single page application and ```--multi``` that you plan to test multiple pages within one run.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} thirtydays.js --spa --multi
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} thirtydays.js --spa --multi
 ~~~
 

--- a/docs/documentation/sitespeed.io/sustainable/index.md
+++ b/docs/documentation/sitespeed.io/sustainable/index.md
@@ -30,7 +30,7 @@ We work out how much energy it takes to serve a site, then work out how much CO2
 Enable the plugin by adding `--sustainable.enable`:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --sustainable.enable
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io/ --sustainable.enable
 ~~~
 
 ### The result

--- a/docs/documentation/sitespeed.io/webpagereplay/index.md
+++ b/docs/documentation/sitespeed.io/webpagereplay/index.md
@@ -52,7 +52,7 @@ You need to give Docker access to the network with `--cap-add=NET_ADMIN` so that
 To run a simple test:
 
 ```bash
-docker run --cap-add=NET_ADMIN --rm -v "$(pwd)":/sitespeed.io -e REPLAY=true -e LATENCY=100 sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -n 5 -b chrome https://en.wikipedia.org/wiki/Barack_Obama
+docker run --cap-add=NET_ADMIN --rm -v "$(pwd):/sitespeed.io" -e REPLAY=true -e LATENCY=100 sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -n 5 -b chrome https://en.wikipedia.org/wiki/Barack_Obama
 ```
 
 Remember to verify the HAR files produced so that it looks like it should: Verify that WebPageReplay replays your website correct. If it does, then use it :)
@@ -64,7 +64,7 @@ Using WebPageReplay in Docker and your Android phone only works on Linux. This i
 Using sitespeed.io:
 
 ```bash
-docker run --privileged -v /dev/bus/usb:/dev/bus/usb -e START_ADB_SERVER=true --cap-add=NET_ADMIN --shm-size=1g --rm -v "$(pwd)":/sitespeed.io -e REPLAY=true -e LATENCY=100 sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://en.m.wikipedia.org/wiki/Barack_Obama --browsertime.chrome.android.package com.android.chrome --browsertime.xvfb false --browsertime.chrome.args ignore-certificate-errors-spki-list=PhrPvGIaAMmd29hj8BCZOq096yj7uMpRNHpn5PDxI6I= --browsertime.chrome.args user-data-dir=/data/tmp/chrome -n 11
+docker run --privileged -v /dev/bus/usb:/dev/bus/usb -e START_ADB_SERVER=true --cap-add=NET_ADMIN --shm-size=1g --rm -v "$(pwd):/sitespeed.io" -e REPLAY=true -e LATENCY=100 sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://en.m.wikipedia.org/wiki/Barack_Obama --browsertime.chrome.android.package com.android.chrome --browsertime.xvfb false --browsertime.chrome.args ignore-certificate-errors-spki-list=PhrPvGIaAMmd29hj8BCZOq096yj7uMpRNHpn5PDxI6I= --browsertime.chrome.args user-data-dir=/data/tmp/chrome -n 11
 ```
 
 Using Browsertime:

--- a/docs/documentation/sitespeed.io/webpagetest/index.md
+++ b/docs/documentation/sitespeed.io/webpagetest/index.md
@@ -47,7 +47,7 @@ If you need anything else adding your own CLI parameter will propagate to the We
 Example: So say that you want to change the user agent of your test. In the API you can do that with <code>--useragent</code>. Pass the same to sitespeed.io by prefixing webpagetest like so <code>--webpagetest.useragent</code> in the cli.
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io --webpagetest.host my.wpt.host.com --webpagetest.useragent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36" https://www.sitespeed.io
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io --webpagetest.host my.wpt.host.com --webpagetest.useragent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36" https://www.sitespeed.io
 ~~~
 
 ## Default configurations
@@ -91,7 +91,7 @@ navigate    news.aol.com/world
 Then change your URL you want test (probably the last one) to \{\{\{URL\}\}\} and then all occurrences of \{\{\{URL\}\}\} will then be replaced with the current URL that should be tested. Now run sitespeed.io with the additional parameters:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --webpagetest.file /sitespeed.io/wptScript.txt --webpagetest.host my.wpt.host.com http://example.org
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --webpagetest.file /sitespeed.io/wptScript.txt --webpagetest.host my.wpt.host.com http://example.org
 ~~~
 
 It is also possible to pass the WebPageTest script as a string into the `--webpagetest.script` flag. You can use the `scriptToString()` method provided in [webpagetest-api](https://github.com/marcelduran/webpagetest-api/#module-1) to create a string from a JSON object.
@@ -99,7 +99,7 @@ It is also possible to pass the WebPageTest script as a string into the `--webpa
 {% assign bashURLString = '{{{URL}}}}' %}
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --webpagetest.script "navigate \t www.aol.com \n navigate \t {{bashURLString}}" --webpagetest.host my.wpt.host.com http://example.org
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --webpagetest.script "navigate \t www.aol.com \n navigate \t {{bashURLString}}" --webpagetest.host my.wpt.host.com http://example.org
 ~~~
 
 ### Custom metrics
@@ -128,7 +128,7 @@ return viewport;
 You can then run sitespeed.io to pick up the new custom metrics:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --webpagetest.custom /sitespeed.io/myScriptFile.txt --webpagetest.host my.wpt.host.com https://www.sitespeed.io
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --webpagetest.custom /sitespeed.io/myScriptFile.txt --webpagetest.host my.wpt.host.com https://www.sitespeed.io
 ~~~
 
 ## Run WebPageTest without Browsertime
@@ -136,5 +136,5 @@ docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include ve
 Sometimes you want to only collect data from WebPageTest and not from Browsertime. The best way to do that is to disable the Browsertime plugin with *--plugins.remove browsertime*
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --webpagetest.host my.wpt.host.com --plugins.remove browsertime https://www.sitespeed.io
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --webpagetest.host my.wpt.host.com --plugins.remove browsertime https://www.sitespeed.io
 ~~~

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -18,7 +18,7 @@ image: https://www.sitespeed.io/img/sitespeed-2.0-twitter.png
 Sitespeed.io uses Browsertime, the Coach and PageXray to collect and generate the result, so looking at result pages from sitespeed.io will give you a idea of what you can get from all tools. Analysing two pages using Chrome looks like this:
 
 ~~~bash
-docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome --cpu https://en.wikipedia.org/wiki/Main_Page https://en.wikipedia.org/wiki/Barack_Obama
+docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} -b chrome --cpu https://en.wikipedia.org/wiki/Main_Page https://en.wikipedia.org/wiki/Barack_Obama
 ~~~
 
 Gives the following [report](https://examples.sitespeed.io/13.x/2020-05-20-08-47-56/index.html). The standard use case for sitespeed.io is to run it continuously and send the data to Graphite/Grafana and create dashboards looking like this:


### PR DESCRIPTION
### Description
Moving the quote to the end of the bind mount command makes it work with both Bash and PowerShell.

I don't think such a trivial change requires opening an issue. Please correct me if I'm wrong.

This could also be changed in the website quick start guide for docker. Please point me in the right direction to submit the fix.

```powershell
PS docker run --rm -v "$(pwd)":/sitespeed.io sitespeedio/sitespeed.io:14.1.0 https://www.sitespeed.io/
docker: invalid reference format.
See 'docker run --help'.
PS docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:14.1.0 https://www.sitespeed.io/
Google Chrome 84.0.4147.89
{...}
```