### PR TITLE
Fix HTML plugin when using "browsertime.chrome.visualMetricsUsingTrace"

### DIFF
--- a/lib/plugins/html/templates/pages.pug
+++ b/lib/plugins/html/templates/pages.pug
@@ -43,7 +43,7 @@ mixin rows(pages)
 
 block content
   - headings = ['URL']
-  if options.browsertime.visualMetrics && !hasPageSummaryMetricInput
+  if (options.browsertime.visualMetrics || (options.cpu && options.browsertime.chrome && options.browsertime.chrome.visualMetricsUsingTrace && options.browsertime.chrome.enableTraceScreenshots)) && !hasPageSummaryMetricInput
     - headings.push('First Visual Change', 'Speed Index', 'Last Visual Change')
   - metricList = html.pageSummaryMetrics
   each kv in metricList

--- a/lib/plugins/html/templates/url/metrics/index.pug
+++ b/lib/plugins/html/templates/url/metrics/index.pug
@@ -6,7 +6,7 @@ if  browsertime
   - baseHelpURL = rootPath + 'help.html#';
 
   - const defaultVisualMetrics = ['SpeedIndex','FirstVisualChange','LastVisualChange','VisualProgress', 'PerceptualSpeedIndexProgress', 'ContentfulSpeedIndexProgress', 'videoRecordingStart', 'PerceptualSpeedIndex', 'ContentfulSpeedIndex', 'LastMeaningfulPaint', 'LargestImage', 'Heading' ,'VisualReadiness','VisualComplete85', 'VisualComplete95','VisualComplete99'];
-  if options.browsertime.visualMetrics && visualMetrics
+  if (options.browsertime.visualMetrics || (options.cpu && options.browsertime.chrome && options.browsertime.chrome.visualMetricsUsingTrace && options.browsertime.chrome.enableTraceScreenshots)) && visualMetrics
     a#visualmetrics
     h3 Visual Metrics
     .row


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
  - Not a big change IMO
- [ ] Check that your change/fix has corresponding unit tests (if applicable)
  - I can't find any tests for the HTML plugin
- [X] Squash commits so it looks sane
- [ ] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/main/docs in another PR
  - N/A
- [X] Verify that the test works by running `npm test` and test linting by `npm run lint`
  - Note: I get 4 test failures for the `test/slackTests.js`, but they fail on the "main" branch too, so it's not related to my change

### Description
The `browsertime.chrome.visualMetricsUsingTrace` option is a great way of speeding up test runs, but it causes some problems with the HTML report. For example, the "pages.pug" template won't show table headers for the visual metrics gathered, yet they're present in the table rows, causing a mismatch between the header and rows. Example:
![Screenshot_20200816_124029](https://user-images.githubusercontent.com/651224/90342768-8452fc00-dfbf-11ea-807b-52937accd66c.png)

The above screenshot was generated by running `/bin/sitespeed.js  --cpu --browsertime.chrome.visualMetricsUsingTrace --browsertime.chrome.enableTraceScreenshots --outputFolder sitespeed-result -n1 https://sitespeed.io`
    
This fixes the affected templates to recognize when "browsertime.chrome.visualMetricsUsingTrace" is enabled.