### PR TITLE
Add prepareToRender message that fixes the timing of the budget message.

### DIFF
--- a/lib/core/queueHandler.js
+++ b/lib/core/queueHandler.js
@@ -169,6 +169,7 @@ class QueueHandler {
    setup - plugins chance to talk to each other or setup what they need.
    url - urls passed around to analyse
    summarize - all analyse is finished and we can summarize all data
+   prepareToRender - prepare evertything to render, send messages after things been summarized etc
    render - plugin store data to disk
    final - is there anything you wanna do before sitespeed exist? upload files to the S3?
    */
@@ -182,6 +183,8 @@ class QueueHandler {
       })
       .then(() => this.drainAllQueues())
       .then(() => this.postMessage(make('sitespeedio.summarize')))
+      .then(() => this.drainAllQueues())
+      .then(() => this.postMessage(make('sitespeedio.prepareToRender')))
       .then(() => this.drainAllQueues())
       .then(() => this.postMessage(make('sitespeedio.render')))
       .then(() => this.drainAllQueues())

--- a/lib/plugins/analysisstorer/index.js
+++ b/lib/plugins/analysisstorer/index.js
@@ -7,6 +7,7 @@ function shouldIgnoreMessage(message) {
       'browsertime.navigationScripts',
       'error',
       'sitespeedio.summarize',
+      'sitespeedio.prepareToRender',
       'sitespeedio.render',
       'html.finished',
       'browsertime.har',

--- a/lib/plugins/budget/index.js
+++ b/lib/plugins/budget/index.js
@@ -48,6 +48,32 @@ module.exports = {
           break;
         }
 
+        case 'sitespeedio.prepareToRender': {
+          let failing = 0;
+          let working = 0;
+          for (const url of Object.keys(this.result.failing)) {
+            for (const result of this.result.failing[url]) {
+              log.error(
+                'Failing budget %s for %s with value %s %s limit %s',
+                result.metric,
+                url,
+                result.friendlyValue || result.value,
+                result.limitType,
+                result.friendlyLimit || result.limit
+              );
+              failing = failing + 1;
+            }
+          }
+
+          queue.postMessage(this.make('budget.result', this.result));
+
+          for (const url of Object.keys(this.result.working)) {
+            working = working + this.result.working[url].length;
+          }
+          log.info('Budget: %d working and %d failing tests', working, failing);
+          break;
+        }
+
         case 'sitespeedio.render': {
           if (this.options.budget) {
             if (this.options.budget.output === 'json') {
@@ -56,33 +82,6 @@ module.exports = {
               tap.writeTap(this.result, this.storageManager.getBaseDir());
             } else if (this.options.budget.output === 'junit') {
               junit.writeJunit(this.result, this.storageManager.getBaseDir());
-            } else {
-              let failing = 0;
-              let working = 0;
-              for (const url of Object.keys(this.result.failing)) {
-                for (const result of this.result.failing[url]) {
-                  log.error(
-                    'Failing budget %s for %s with value %s %s limit %s',
-                    result.metric,
-                    url,
-                    result.friendlyValue || result.value,
-                    result.limitType,
-                    result.friendlyLimit || result.limit
-                  );
-                  failing = failing + 1;
-                }
-              }
-
-              queue.postMessage(this.make('budget.result', this.result));
-
-              for (const url of Object.keys(this.result.working)) {
-                working = working + this.result.working[url].length;
-              }
-              log.info(
-                'Budget: %d working and %d failing tests',
-                working,
-                failing
-              );
             }
           }
         }

--- a/lib/plugins/html/dataCollector.js
+++ b/lib/plugins/html/dataCollector.js
@@ -118,6 +118,14 @@ class DataCollector {
       set(this.summaryPages, name, merge({}, data));
     }
   }
+
+  addBudget(budget) {
+    this.budget = budget;
+  }
+
+  getBudget() {
+    return this.budget;
+  }
 }
 
 module.exports = DataCollector;

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -29,7 +29,6 @@ class HTMLBuilder {
     this.timestamp = context.timestamp.format(TIME_FORMAT);
     this.options = options;
     this.summary = {};
-    this.budget = context.budget;
     this.context = context;
     this.pageRuns = [];
     this.pageSummaries = [];
@@ -142,18 +141,19 @@ class HTMLBuilder {
     }
 
     if (options.budget) {
+      const budget = dataCollector.getBudget();
       let totalFailing = 0;
       let totalWorking = 0;
-      for (const url of Object.keys(this.budget.failing)) {
-        totalFailing = totalFailing + this.budget.failing[url].length;
+      for (const url of Object.keys(budget.failing)) {
+        totalFailing = totalFailing + budget.failing[url].length;
       }
-      for (const url of Object.keys(this.budget.working)) {
-        totalWorking = totalWorking + this.budget.working[url].length;
+      for (const url of Object.keys(budget.working)) {
+        totalWorking = totalWorking + budget.working[url].length;
       }
       this.summary.budget = {
         pageTitle: `Performance budget for ${name} with ${totalWorking} working and ${totalFailing} failing budgets.`,
         pageDescription: 'The list of failing and working performance budgets.',
-        budget: this.budget,
+        budget,
         totalFailing,
         totalWorking
       };

--- a/lib/plugins/html/index.js
+++ b/lib/plugins/html/index.js
@@ -100,6 +100,11 @@ module.exports = {
           break;
         }
 
+        case 'budget.result': {
+          dataCollector.addBudget(message.data);
+          break;
+        }
+
         case 'aggregateassets.summary': {
           if (message.group === 'total') {
             const assetList = reduce(


### PR DESCRIPTION
One long term "bug/feature" has been that the budget message was passed late
(in the render phase). By adding a phase "prepareToRender", we can pass on
te budget message in that phase and the HTML plugin can use that message instead
of the old "context" hack. This also opens up for some really cool features
coming soon :)

