### PR TITLE
Make sure cli-alias is propagated to Browsertime.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1564,6 +1564,21 @@ module.exports.parseCommandLine = function parseCommandLine() {
 
   let urlsMetaData = cliUtil.getAliases(argv._, argv.urlAlias, argv.groupAlias);
 
+  // Copy the alias so it is also used by Browsertime
+  if (argv.urlAlias) {
+    // Browsertime has it own way of handling alias
+    // We could probably hack this better next year
+    let urls = argv._;
+    let meta = {};
+
+    if (!Array.isArray(argv.urlAlias)) argv.urlAlias = [argv.urlAlias];
+
+    for (let i = 0; i < urls.length; i++) {
+      meta[urls[i]] = argv.urlAlias[i];
+    }
+    set(argv, 'browsertime.urlMetaData', meta);
+  }
+
   return {
     urls: argv.multi ? argv._ : cliUtil.getURLs(argv._),
     urlsMetaData,


### PR DESCRIPTION
I've made a mistake in the stable release and didn't add the
right alias to Browsertime when you run sitspeed.io.

https://github.com/sitespeedio/sitespeed.io/issues/3226

