### PR TITLE
Show "marked as failure" messages from Browsertime.

### DIFF
--- a/lib/plugins/browsertime/default/metricsPageSummary.js
+++ b/lib/plugins/browsertime/default/metricsPageSummary.js
@@ -31,5 +31,6 @@ module.exports = [
   'statistics.pageinfo.layoutShift',
   'statistics.pageinfo.domElements',
   'statistics.extras.*',
-  'statistics.android.batteryTemperature.*'
+  'statistics.android.batteryTemperature.*',
+  'markedAsFailure'
 ];

--- a/lib/plugins/html/templates/url/summary/index.pug
+++ b/lib/plugins/html/templates/url/summary/index.pug
@@ -15,6 +15,13 @@ block content
     b #{d.browsertime.pageSummary.info.title}
     p !{d.browsertime.pageSummary.info.description}
 
+  if d.browsertime && d.browsertime.pageSummary && d.browsertime.pageSummary.markedAsFailure
+    .errors
+      b This test was marked as a failure with the following #{h.plural(d.browsertime.pageSummary.failureMessages.length, 'message')}:
+      ul
+        each failureMessage in d.browsertime.pageSummary.failureMessages
+          li #{failureMessage}
+
   p
     .large All runs:&nbsp;
       each val, index in runPages


### PR DESCRIPTION
https://github.com/sitespeedio/sitespeed.io/issues/3262