### PR TITLE
#2758 - fix: keep selected tab open across runs

### DIFF
--- a/lib/plugins/html/templates/url/includes/tabScripts.js
+++ b/lib/plugins/html/templates/url/includes/tabScripts.js
@@ -1,7 +1,24 @@
 window.addEventListener('DOMContentLoaded', function() {
   let tabsRoot = document.querySelector('#tabs');
 
-  let currentTab = tabsRoot.querySelector(location.hash || 'a');
+  let navigationLinks = document.querySelectorAll('#pageNavigation a');
+  for (let i = 0; i < navigationLinks.length; ++i) {
+    navigationLinks[i].addEventListener('click', event => {
+      if (!location.hash) return;
+      event.preventDefault();
+      location.href = `${event.target.href}${location.hash}_ref`;
+    });
+  }
+
+  let currentTab;
+  if (location.hash.endsWith('_ref')) {
+    const targetHash = location.hash.slice(0, -4);
+    currentTab = tabsRoot.querySelector(targetHash);
+    setTimeout(() => history.replaceState({}, location.hash, targetHash));
+  } else {
+    currentTab = tabsRoot.querySelector(location.hash || 'a');
+  }
+
   if (!currentTab) currentTab = tabsRoot.querySelector('a');
 
   let sections = document.querySelectorAll('#tabSections section');

--- a/lib/plugins/html/templates/url/iteration/index.pug
+++ b/lib/plugins/html/templates/url/iteration/index.pug
@@ -17,7 +17,7 @@ block content
     p !{d.browsertime.run.description}
 
   p
-    .large All runs:&nbsp;
+    .large#pageNavigation All runs:&nbsp;
       each val, index in runPages
         - value = Number(index) + 1
         if (runNumber === value)

--- a/lib/plugins/html/templates/url/summary/index.pug
+++ b/lib/plugins/html/templates/url/summary/index.pug
@@ -23,7 +23,7 @@ block content
           li #{failureMessage}
 
   p
-    .large All runs:&nbsp;
+    .large#pageNavigation All runs:&nbsp;
       each val, index in runPages
         - value = Number(index) + 1
         a(href='./' + value + '.html') #{value}


### PR DESCRIPTION
#2758 stated the issue of resetting the tab upon page change. This pull request adds a proxy over the navigation links and specifies new page to open with proper tab.

![](https://i.giphy.com/media/54G2Yq18zRq75NX8Ip/giphy.webp)