### PR TITLE
Add better tags to InfluxDB for GPSI data.

### DIFF
--- a/lib/plugins/influxdb/data-generator.js
+++ b/lib/plugins/influxdb/data-generator.js
@@ -207,6 +207,16 @@ class InfluxDBDataGenerator {
         tags.experience = keyArray[0];
         tags.formFactor = keyArray[1];
         tags.metric = keyArray[2];
+      } else if (type === 'gpsi.pageSummary') {
+        if (key.indexOf('googleWebVitals') > -1) {
+          tags.testType = 'googleWebVitals';
+        } else if (key.indexOf('score') > -1) {
+          tags.testType = 'score';
+        } else if (key.indexOf('loadingExperience') > -1) {
+          tags.experience = keyArray[0];
+          tags.metric = keyArray[1];
+          tags.testType = 'crux';
+        }
       } else {
         // console.log('Missed added tags to ' + key + ' ' + type);
       }


### PR DESCRIPTION
As reported in https://github.com/sitespeedio/sitespeed.io/issues/3415#issuecomment-886460545 the current setup is pretty unusable with data from GSPI and sending them to influx db.

This PR add tags like this:
```
performance,testType=score,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=100
seo,testType=score,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0
accessibility,testType=score,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0
pwa,testType=score,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=45
best-practices,testType=score,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=93
percentile,experience=loadingExperience,metric=FIRST_CONTENTFUL_PAINT_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=1543
fast,experience=loadingExperience,metric=FIRST_CONTENTFUL_PAINT_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.7954341987466508
moderate,experience=loadingExperience,metric=FIRST_CONTENTFUL_PAINT_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.10944494180841649
slow,experience=loadingExperience,metric=FIRST_CONTENTFUL_PAINT_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.09512085944494343
percentile,experience=loadingExperience,metric=FIRST_INPUT_DELAY_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=3
fast,experience=loadingExperience,metric=FIRST_INPUT_DELAY_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.9652864910079467
moderate,experience=loadingExperience,metric=FIRST_INPUT_DELAY_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.016311166875784197
slow,experience=loadingExperience,metric=FIRST_INPUT_DELAY_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.018402342116269406
percentile,experience=loadingExperience,metric=CUMULATIVE_LAYOUT_SHIFT_SCORE,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0
fast,experience=loadingExperience,metric=CUMULATIVE_LAYOUT_SHIFT_SCORE,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.9964133602331311
moderate,experience=loadingExperience,metric=CUMULATIVE_LAYOUT_SHIFT_SCORE,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.0031383097960098615
slow,experience=loadingExperience,metric=CUMULATIVE_LAYOUT_SHIFT_SCORE,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.00044832997085855167
percentile,experience=loadingExperience,metric=LARGEST_CONTENTFUL_PAINT_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=1599
fast,experience=loadingExperience,metric=LARGEST_CONTENTFUL_PAINT_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.8646590909090981
moderate,experience=loadingExperience,metric=LARGEST_CONTENTFUL_PAINT_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.07556818181818245
slow,experience=loadingExperience,metric=LARGEST_CONTENTFUL_PAINT_MS,testType=crux,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0.05977272727272795
firstContentfulPaint,testType=googleWebVitals,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=426
largestContentfulPaint,testType=googleWebVitals,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=441
totalBlockingTime,testType=googleWebVitals,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0
cumulativeLayoutShift,testType=googleWebVitals,category=default,origin=gpsi,summaryType=pageSummary,strategy=desktop,page=_,group=www_wikipedia_org,testName=www_wikipedia_org time=1627484589258,value=0
```