### PR TITLE
Add cli for keeping the original video.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -470,6 +470,14 @@ module.exports.parseCommandLine = function parseCommandLine() {
         'Convert the original video to a viewable format (for most video players). Turn that off to make a faster run.',
       group: 'Browser'
     })
+    .option('browsertime.videoParams.keepOriginalVideo', {
+      alias: 'videoParams.keepOriginalVideo',
+      type: 'boolean',
+      default: false,
+      describe:
+        'Keep the original video. Use it when you have a Visual Metrics bug and want to create an issue at GitHub. Supply the original video in the issue and we can reproduce your issue.',
+      group: 'video'
+    })
     .option('browsertime.cpu', {
       alias: 'cpu',
       type: 'boolean',


### PR DESCRIPTION
That option already exists but it was hidden in sitespeed.io.

