### PR TITLE
Metrics per run side by side

### DIFF
--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -342,7 +342,6 @@ class HTMLBuilder {
         const pageRuns = this.pageRuns.filter(
           run => !!get(pageInfo.data, [run.id, 'run'])
         );
-
         let rootPath = this.storageManager.rootPathFromUrl(url, daurlAlias);
         let data = {
           daurl: url,
@@ -380,6 +379,7 @@ class HTMLBuilder {
           headers: this.summary,
           version: packageInfo.version,
           timestamp: runTimestamp,
+          friendlyNames,
           context: this.context,
           pageRuns
         };
@@ -387,10 +387,19 @@ class HTMLBuilder {
         for (const run of pageRuns) {
           pugs[run.id] = renderer.renderTemplate(run.id, data);
         }
+
         data.pugs = pugs;
         urlPageRenders.push(
           this._renderUrlRunPage(url, parseInt(runIndex) + 1, data, daurlAlias)
         );
+
+        // Do only once per URL
+        if (parseInt(runIndex) === 0) {
+          console.log(data.runPages[0].data.browsertime);
+          urlPageRenders.push(
+            this._renderMetricSummaryPage(url, 'metrics', data, daurlAlias)
+          );
+        }
       }
     }
 
@@ -480,6 +489,16 @@ class HTMLBuilder {
     log.debug('Render URL run page %s', name);
     return this.storageManager.writeHtmlForUrl(
       renderer.renderTemplate('url/iteration/index', locals),
+      name + '.html',
+      url,
+      alias
+    );
+  }
+
+  async _renderMetricSummaryPage(url, name, locals, alias) {
+    log.debug('Render URL metric page %s', name);
+    return this.storageManager.writeHtmlForUrl(
+      renderer.renderTemplate('url/summary/metrics/index', locals),
       name + '.html',
       url,
       alias

--- a/lib/plugins/html/templates/url/summary/index.pug
+++ b/lib/plugins/html/templates/url/summary/index.pug
@@ -27,9 +27,12 @@ block content
       each val, index in runPages
         - value = Number(index) + 1
         a(href='./' + value + '.html') #{value}
-        if (value !== Object.keys(runPages).length)
+        if (value === Object.keys(runPages).length)
           | &nbsp;-
-          |
+          a(href='metrics.html') (metrics per run)
+        else 
+            | &nbsp;-
+            |  
 
   if pageInfo.errors
     .errors

--- a/lib/plugins/html/templates/url/summary/index.pug
+++ b/lib/plugins/html/templates/url/summary/index.pug
@@ -29,7 +29,7 @@ block content
         a(href='./' + value + '.html') #{value}
         if (value === Object.keys(runPages).length)
           | &nbsp;-
-          a(href='metrics.html') (metrics per run)
+          a(href='metrics.html') (side by side)
         else 
             | &nbsp;-
             |  

--- a/lib/plugins/html/templates/url/summary/metrics/index.pug
+++ b/lib/plugins/html/templates/url/summary/metrics/index.pug
@@ -1,7 +1,7 @@
 extends ../layout.pug
 
 block content
-    h1 Metrics 
+    h1 Metrics  per run
     - const daTitle = daurlAlias ? daurlAlias : daurl
     h5.url
         a(href=daurl) #{decodeURIComponent(daTitle)}
@@ -16,7 +16,7 @@ block content
     -    }
     - }
 
-    h3 Metrics per run
+    h3 Side by side
     .responsive
         table
             tr

--- a/lib/plugins/html/templates/url/summary/metrics/index.pug
+++ b/lib/plugins/html/templates/url/summary/metrics/index.pug
@@ -2,7 +2,7 @@ extends ../layout.pug
 
 block content
     h1 Metrics 
-
+    - const daTitle = daurlAlias ? daurlAlias : daurl
     h5.url
         a(href=daurl) #{decodeURIComponent(daTitle)}
 

--- a/lib/support/friendlynames.js
+++ b/lib/support/friendlynames.js
@@ -7,23 +7,27 @@ module.exports = {
       firstContentfulPaint: {
         path: "statistics.timings.paintTiming['first-contentful-paint'].median",
         summaryPath: "paintTiming['first-contentful-paint']",
+        runPath: "timings.paintTiming['first-contentful-paint']",
         name: 'First Contentful Paint',
         format: time.ms
       },
       largestContentfulPaint: {
         path: 'statistics.timings.largestContentfulPaint.renderTime.median',
         summaryPath: 'timings.largestContentfulPaint',
+        runPath: 'timings.largestContentfulPaint.renderTime',
         name: 'Largest Contentful Paint',
         format: time.ms
       },
       totalBlockingTime: {
         path: 'statistics.cpu.longTasks.totalBlockingTime.median',
         summaryPath: 'cpu.longTasks.totalBlockingTime',
+        runPath: 'cpu.longTasks.totalBlockingTime',
         name: 'Total Blocking Time',
         format: time.ms
       },
       cumulativeLayoutShift: {
         path: 'statistics.pageinfo.cumulativeLayoutShift.median',
+        runPath: 'pageinfo.cumulativeLayoutShift',
         summaryPath: 'pageinfo.cumulativeLayoutShift',
         name: 'Cumulative Layout Shift',
         format: noop
@@ -33,102 +37,119 @@ module.exports = {
       firstPaint: {
         path: 'statistics.timings.firstPaint.median',
         summaryPath: 'firstPaint',
+        runPath: 'timings.firstPaint',
         name: 'First Paint',
         format: time.ms
       },
       firstContentfulPaint: {
         path: "statistics.timings.paintTiming['first-contentful-paint'].median",
         summaryPath: "paintTiming['first-contentful-paint']",
+        runPath: "timings.paintTiming['first-contentful-paint']",
         name: 'First Contentful Paint',
         format: time.ms
       },
       largestContentfulPaint: {
         path: 'statistics.timings.largestContentfulPaint.renderTime.median',
         summaryPath: 'timings.largestContentfulPaint',
+        runPath: 'timings.largestContentfulPaint.renderTime',
         name: 'Largest Contentful Paint',
         format: time.ms
       },
       loadEventEnd: {
         path: 'statistics.timings.loadEventEnd.median',
         summaryPath: 'loadEventEnd',
+        runPath: 'timings.loadEventEnd',
         name: 'Load Event End',
         format: time.ms
       },
       fullyLoaded: {
         path: 'statistics.timings.fullyLoaded.median',
         summaryPath: 'timings.fullyLoaded',
+        runPath: 'timings.fullyLoaded',
         name: 'Fully Loaded',
         format: time.ms
       },
       serverResponseTime: {
         path: 'statistics.timings.pageTimings.serverResponseTime.median',
         summaryPath: 'pageTimings.serverResponseTime',
+        runPath: 'timings.pageTimings.serverResponseTime',
         name: 'Server Response Time',
         format: time.ms
       },
       backEndTime: {
         path: 'statistics.timings.pageTimings.backEndTime.median',
         summaryPath: 'pageTimings.backEndTime',
+        runPath: 'timings.pageTimings.backEndTime',
         name: 'TTFB',
         format: time.ms
       },
       pageLoadTime: {
         path: 'statistics.timings.pageTimings.pageLoadTime.median',
         summaryPath: 'pageTimings.pageLoadTime',
+        runPath: 'timings.pageTimings.pageLoadTime',
         name: 'Page Load Time',
         format: time.ms
       },
       FirstVisualChange: {
         path: 'statistics.visualMetrics.FirstVisualChange.median',
         summaryPath: 'visualMetrics.FirstVisualChange',
+        runPath: 'visualMetrics.FirstVisualChange',
         name: 'First Visual Change',
         format: time.ms
       },
       LastVisualChange: {
         path: 'statistics.visualMetrics.LastVisualChange.median',
-        name: 'Last Visual Change',
         summaryPath: 'visualMetrics.LastVisualChange',
+        runPath: 'visualMetrics.LastVisualChange',
+        name: 'Last Visual Change',
         format: time.ms
       },
       SpeedIndex: {
         path: 'statistics.visualMetrics.SpeedIndex.median',
         summaryPath: 'visualMetrics.SpeedIndex',
+        runPath: 'visualMetrics.SpeedIndex',
         name: 'Speed Index',
         format: time.ms
       },
       ContentfulSpeedIndex: {
         path: 'statistics.visualMetrics.ContentfulSpeedIndex.median',
         summaryPath: 'visualMetrics.ContentfulSpeedIndex',
+        runPath: 'visualMetrics.ContentfulSpeedIndex',
         name: 'Contentful Speed Index',
         format: time.ms
       },
       PerceptualSpeedIndex: {
         path: 'statistics.visualMetrics.PerceptualSpeedIndex.median',
         summaryPath: 'visualMetrics.PerceptualSpeedIndex',
+        runPath: 'visualMetrics.PerceptualSpeedIndex',
         name: 'Perceptual Speed Index',
         format: time.ms
       },
       VisualReadiness: {
         path: 'statistics.visualMetrics.VisualReadiness.median',
         summaryPath: 'visualMetrics.VisualReadiness',
+        runPath: 'visualMetrics.VisualReadiness',
         name: 'Visual Readiness',
         format: time.ms
       },
       VisualComplete95: {
         path: 'statistics.visualMetrics.VisualComplete95.median',
         summaryPath: 'visualMetrics.VisualComplete95',
+        runPath: 'visualMetrics.VisualComplete95',
         name: 'Visual Complete 95',
         format: time.ms
       },
       VisualComplete99: {
         path: 'statistics.visualMetrics.VisualComplete99.median',
         summaryPath: 'visualMetrics.VisualComplete99',
+        runPath: 'visualMetrics.VisualComplete99',
         name: 'Visual Complete 99',
         format: time.ms
       },
       VisualComplete: {
         path: 'statistics.visualMetrics.VisualComplete.median',
         summaryPath: 'visualMetrics.VisualComplete',
+        runPath: 'visualMetrics.VisualComplete',
         name: 'Visual Complete',
         format: time.ms
       }
@@ -137,25 +158,38 @@ module.exports = {
       totalBlockingTime: {
         path: 'statistics.cpu.longTasks.totalBlockingTime.median',
         summaryPath: 'cpu.longTasks.totalBlockingTime',
+        runPath: 'cpu.longTasks.totalBlockingTime',
         name: 'Total Blocking Time',
         format: time.ms
       },
       maxPotentialFid: {
         path: 'statistics.cpu.longTasks.maxPotentialFid.median',
         summaryPath: 'cpu.longTasks.maxPotentialFid',
+        runPath: 'cpu.longTasks.maxPotentialFid',
         name: 'Max Potential FID',
         format: time.ms
       },
       longTasks: {
         path: 'statistics.cpu.longTasks.tasks.median',
         summaryPath: 'cpu.longTasks.tasks',
+        runPath: 'cpu.longTasks.tasks',
         name: 'Number of Long Tasks',
         format: noop
       },
       longTasksTotalDuration: {
         path: 'statistics.cpu.longTasks.totalDuration.median',
         summaryPath: 'cpu.longTasks.totalDuration',
+        runPath: 'cpu.longTasks.totalDuration',
         name: 'Total Duration of Long Tasks',
+        format: time.ms
+      }
+    },
+    browser: {
+      cpuBenchmark: {
+        path: 'statistics.browser.cpuBenchmark.median',
+        summaryPath: 'browser.cpuBenchmark',
+        runPath: 'browser.cpuBenchmark',
+        name: 'CPU benchmark score',
         format: time.ms
       }
     },
@@ -163,6 +197,7 @@ module.exports = {
       cumulativeLayoutShift: {
         path: 'statistics.pageinfo.cumulativeLayoutShift.median',
         summaryPath: 'pageinfo.cumulativeLayoutShift',
+        runPath: 'pageinfo.cumulativeLayoutShift',
         name: 'Cumulative Layout Shift',
         format: noop
       }

--- a/lib/support/friendlynames.js
+++ b/lib/support/friendlynames.js
@@ -1,5 +1,5 @@
 'use strict';
-const { noop, size, time, co2, httpcodes, decimals } = require('./helpers');
+const { noop, size, time, co2, httpErrors, decimals } = require('./helpers');
 
 module.exports = {
   browsertime: {
@@ -248,7 +248,7 @@ module.exports = {
       httpErrors: {
         path: 'responseCodes',
         name: 'HTTP Errors',
-        format: httpcodes
+        format: httpErrors
       }
     },
     transferSize: {

--- a/lib/support/helpers/decimals.js
+++ b/lib/support/helpers/decimals.js
@@ -1,5 +1,8 @@
 'use strict';
 
 module.exports = function(decimals) {
-  return Number(decimals).toFixed(3);
+  let number = Number(decimals).toFixed(3);
+  if (number === '0.000') {
+    return 0;
+  } else return number;
 };

--- a/lib/support/helpers/httpErrors.js
+++ b/lib/support/helpers/httpErrors.js
@@ -7,5 +7,5 @@ module.exports = function(httpCodes) {
       data += `${code}: ${httpCodes[code]} `;
     }
   }
-  return data;
+  return data === '' ? '0' : data;
 };

--- a/lib/support/helpers/index.js
+++ b/lib/support/helpers/index.js
@@ -13,6 +13,6 @@ module.exports = {
   co2: require('./co2'),
   noop: require('./noop'),
   percent: require('./percent'),
-  httpcodes: require('./httpcodes'),
+  httpErrors: require('./httpErrors'),
   decimals: require('./decimals')
 };


### PR DESCRIPTION
Adds a new page that show metrics (that exists as friendly names) side by side for all runs. Helpful to use to see the spread of the metrics.