### PR TITLE
Allow crawler to also send the configured cookies

### DIFF
--- a/lib/plugins/crawler/index.js
+++ b/lib/plugins/crawler/index.js
@@ -18,6 +18,9 @@ module.exports = {
     this.basicAuth = options.browsertime
       ? options.browsertime.basicAuth
       : undefined;
+    this.cookie = options.browsertime.cookie
+      ? options.browsertime.cookie
+      : undefined;
   },
   processMessage(message, queue) {
     const make = this.make;
@@ -42,6 +45,23 @@ module.exports = {
         if (this.options.ignoreRobotsTxt) {
           log.info('Crawler: Ignoring robots.txt');
           crawler.respectRobotsTxt = false;
+        }
+
+        function addCookie(cookie) {
+          const cookieSplit = cookie.split('=');
+          if (cookieSplit.length === 2) {
+            crawler.cookies.add(cookieSplit[0], cookieSplit[1]);
+          }
+        }
+
+        if (this.cookie) {
+          if (Array.isArray(this.cookie)) {
+            for (let e of this.cookie) {
+              addCookie(e);
+            }
+          } else if (typeof this.cookie === 'string') {
+            addCookie(this.cookie);
+          }
         }
 
         crawler.addFetchCondition(queueItem => {


### PR DESCRIPTION
The crawler should open pages with the same setup in order to get full results. In my case an authentication cookie is needed, to properly open the page and see its full content (including crawlable links).
