### PR TITLE
Support user timing marks/measurements in the budget

### DIFF
--- a/lib/plugins/budget/verify.js
+++ b/lib/plugins/budget/verify.js
@@ -7,6 +7,7 @@ const get = require('lodash.get');
 const merge = require('lodash.merge');
 const log = require('intel').getLogger('sitespeedio.plugin.budget');
 const friendlyNames = require('../../support/friendlynames');
+const time = require('../../support/helpers/time');
 
 function getItem(friendlyName, type, metric, value, limit, limitType) {
   return {
@@ -51,9 +52,44 @@ module.exports = {
       for (let metric of Object.keys(budgetForThisURL[metricType])) {
         if (friendlyNames[tool][metricType]) {
           if (!friendlyNames[tool][metricType][metric]) {
-            log.error(
-              `It seems like you configure a metric ${metric} that we do not have a friendly name. Please check the docs if it is right.`
-            );
+            if (metricType === 'usertimings') {
+              const budgetValue = budgetForThisURL[metricType][metric];
+              let value =
+                get(
+                  message.data,
+                  'statistics.timings.userTimings.marks.' + metric + '.median'
+                ) ||
+                get(
+                  message.data,
+                  'statistics.timings.userTimings.measures.' +
+                    metric +
+                    '.median'
+                );
+              if (value) {
+                const item = getItem(
+                  { name: metric, format: time.ms },
+                  metricType,
+                  metric,
+                  value,
+                  budgetValue,
+                  'max'
+                );
+                if (value > budgetValue) {
+                  item.status = 'failing';
+                  failing.push(item);
+                } else {
+                  working.push(item);
+                }
+                continue;
+              } else {
+                log.error(`Could not find the user timin ${metric}`);
+                continue;
+              }
+            } else {
+              log.error(
+                `It seems like you configure a metric ${metric} that we do not have a friendly name. Please check the docs if it is right.`
+              );
+            }
           }
           const fullPath = friendlyNames[tool][metricType][metric].path;
           let value = get(message.data, fullPath);


### PR DESCRIPTION
https://github.com/sitespeedio/sitespeed.io/issues/3475

Next step is to add measurements from scripting using https://www.sitespeed.io/documentation/sitespeed.io/scripting/#measureaddname-value