### PR TITLE
Show alias in result budget json.

### DIFF
--- a/lib/plugins/budget/verify.js
+++ b/lib/plugins/budget/verify.js
@@ -166,14 +166,18 @@ module.exports = {
     }
     // group working/failing per URL
     if (failing.length > 0) {
-      result.failing[message.url] = result.failing[message.url]
-        ? result.failing[message.url].concat(failing)
+      result.failing[alias || message.url] = result.failing[
+        alias || message.url
+      ]
+        ? result.failing[alias || message.url].concat(failing)
         : failing;
     }
 
     if (working.length > 0) {
-      result.working[message.url] = result.working[message.url]
-        ? result.working[message.url].concat(working)
+      result.working[alias || message.url] = result.working[
+        alias || message.url
+      ]
+        ? result.working[alias || message.url].concat(working)
         : working;
     }
   }

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -160,13 +160,17 @@ class HTMLBuilder {
       for (const url of Object.keys(budget.working)) {
         totalWorking = totalWorking + budget.working[url].length;
       }
+      const aliasToUrl = {};
+      for (let url of Object.keys(options.urlsMetaData)) {
+        aliasToUrl[options.urlsMetaData[url].urlAlias] = url;
+      }
       this.summary.budget = {
         pageTitle: `Performance budget for ${name} with ${totalWorking} working and ${totalFailing} failing budgets.`,
         pageDescription: 'The list of failing and working performance budgets.',
         budget,
         totalFailing,
         totalWorking,
-        alias: options.urlsMetaData
+        aliasToUrl
       };
     }
 

--- a/lib/plugins/html/templates/budget.pug
+++ b/lib/plugins/html/templates/budget.pug
@@ -2,12 +2,15 @@ extends ./layout.pug
 include _tableMixins
 
 mixin row(budget)
-  each results, url in budget
+  each results, urlOrAlias in budget
     each result in results
       tr
         td
-          a(href=url)= alias[url] ? alias[url].urlAlias  : url
-          p #{alias[url] ? url : ''}
+          if (urlOrAlias &&  urlOrAlias.startsWith('http')) 
+            a(href=urlOrAlias)= urlOrAlias
+          else 
+            a(href=aliasToUrl[urlOrAlias])= urlOrAlias 
+            p #{aliasToUrl[urlOrAlias]}
         td #{result.metric} with value #{result.friendlyValue || result.value} limit #{result.limitType} #{result.friendlyLimit || result.limit}
 
 block content


### PR DESCRIPTION
One thing that do not work 100% correct is if we have multiple URLs
with the same alias, then it could be that we do not show the correct
URL in the budget HTML file.

https://github.com/sitespeedio/sitespeed.io/issues/3570
