### PR TITLE
Make sure visual metrics exists for a run before it is used

### DIFF
--- a/lib/plugins/html/metricHelper.js
+++ b/lib/plugins/html/metricHelper.js
@@ -4,7 +4,7 @@ module.exports = {
   pickMedianRun(runs, pageInfo) {
     // Choose the median run. Early first version, in the future we can make
     // this configurable through the CLI
-    // If we have SpeedIndex use that else backup with RUM SpeedIndex
+    // If we have SpeedIndex use that else backup with loadEventEnd
 
     const speedIndexMedian = get(
       pageInfo,
@@ -17,6 +17,8 @@ module.exports = {
     if (speedIndexMedian) {
       for (let run of runs) {
         if (
+          // https://github.com/sitespeedio/sitespeed.io/issues/3618
+          run.data.browsertime.run.visualMetrics &&
           speedIndexMedian === run.data.browsertime.run.visualMetrics.SpeedIndex
         ) {
           return {


### PR DESCRIPTION
See https://github.com/sitespeedio/sitespeed.io/issues/3618