### PR TITLE
Check if the user uses --firstParty.

### DIFF
--- a/lib/plugins/html/templates/url/thirdparty/index.pug
+++ b/lib/plugins/html/templates/url/thirdparty/index.pug
@@ -14,7 +14,7 @@ small
     if pagexray.cookieNamesThirdParties.length > 0
         a(href='#third-party-cookies') Cookies |
         | &nbsp;|&nbsp;
-    if pagexray.firstParty.requests
+    if pagexray.firstParty.requests || options.firstParty
         a(href='#first-vs-third') First vs third
         | &nbsp;|&nbsp;
 a#third-party
@@ -87,5 +87,5 @@ if  thirdparty.possibileMissedThirdPartyDomains && thirdparty.possibileMissedThi
 
 include ./thirdPartyCookies.pug
 
-if pagexray.firstParty.requests
+if pagexray.firstParty.requests || options.firstParty
   include ./firstParty.pug


### PR DESCRIPTION
This catches if the user use --firstParty but actually
do not match any requests.

https://github.com/sitespeedio/sitespeed.io/issues/3642

