### PR TITLE
plugins/html: Fix typo with inline CSS handling

### DIFF
--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -61,7 +61,7 @@ class HTMLBuilder {
   }
 
   addInlineCSS(css) {
-    this.inlineCss.push(css);
+    this.inlineCSS.push(css);
   }
 
   async render(dataCollector) {


### PR DESCRIPTION
This fixes a minor typo in `HTMLBuilder` that prevents plugins from adding custom CSS to the rendered HTML output. 