### PR TITLE
Make it easy to send run data to Graphite in a sane way

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     grafana:
-      image: grafana/grafana:9.0.2
+      image: grafana/grafana:9.1.3
       hostname: grafana
       depends_on:
         - graphite
@@ -20,7 +20,7 @@ services:
         - grafana:/var/lib/grafana
       restart: always
     graphite:
-      image: sitespeedio/graphite:1.1.7-9
+      image: sitespeedio/graphite:1.1.10-3
       hostname: graphite
       ports:
         - "2003:2003"

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -270,6 +270,12 @@ module.exports.parseCommandLine = function parseCommandLine() {
         'Run Browsertime in debug mode. Use commands.breakpoint(name) to set btreakpoints in your script. Debug mode works for Firefox/Chrome/Edge on desktop.',
       group: 'Browser'
     })
+    .option('browsertime.limitedRunData', {
+      type: 'boolean',
+      default: false,
+      describe: 'Send only limited metrics from one run to the datasource.',
+      group: 'Browser'
+    })
     .option('browsertime.gnirehtet', {
       alias: 'gnirehtet',
       type: 'boolean',

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -272,7 +272,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
     })
     .option('browsertime.limitedRunData', {
       type: 'boolean',
-      default: false,
+      default: true,
       describe: 'Send only limited metrics from one run to the datasource.',
       group: 'Browser'
     })

--- a/lib/plugins/browsertime/default/metricsRun.js
+++ b/lib/plugins/browsertime/default/metricsRun.js
@@ -1,0 +1,16 @@
+module.exports = [
+  'fullyLoaded',
+  'timings.ttfb',
+  'timings.firstPaint',
+  'timings.elementTimings.*.renderTime',
+  'timings.pageTimings.*',
+  'timings.largestContentfulPaint.renderTime',
+  'visualMetrics.*',
+  'googleWebVitals.*',
+  'cpu.longTasks.*',
+  'timings.mainDocumentTimings.*',
+  'browser.cpuBenchmark',
+  'android.batteryTemperature.*',
+  'deltaToTFFB.*',
+  'timings.userTimings.*'
+];

--- a/lib/plugins/browsertime/default/metricsRunLimited.js
+++ b/lib/plugins/browsertime/default/metricsRunLimited.js
@@ -1,0 +1,9 @@
+module.exports = [
+  'fullyLoaded',
+  'timings.ttfb',
+  'timings.paintTiming.first-contentful-paint',
+  'cpu.longTasks.totalBlockingTime',
+  'cpu.longTasks.lastLongTask',
+  'visualMetrics.*',
+  'googleWebVitals.largestContentfulPaint'
+];

--- a/lib/plugins/browsertime/default/metricsRunLimited.js
+++ b/lib/plugins/browsertime/default/metricsRunLimited.js
@@ -5,5 +5,6 @@ module.exports = [
   'cpu.longTasks.totalBlockingTime',
   'cpu.longTasks.lastLongTask',
   'visualMetrics.*',
+  'browser.cpuBenchmark',
   'googleWebVitals.largestContentfulPaint'
 ];

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -16,6 +16,8 @@ const statsHelpers = require('../../support/statsHelpers');
 const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 const DEFAULT_METRICS_PAGE_SUMMARY = require('./default/metricsPageSummary');
 const DEFAULT_METRICS_SUMMARY = require('./default/metricsSummary');
+const DEFAULT_METRICS_RUN = require('./default/metricsRun');
+const DEFAULT_METRICS_RUN_LIMITED = require('./default/metricsRunLimited');
 const ConsoleLogAggregator = require('./consoleLogAggregator');
 const AxeAggregator = require('./axeAggregator');
 const filmstrip = require('./filmstrip');
@@ -63,7 +65,9 @@ module.exports = {
       'browsertime.summary'
     );
     context.filterRegistry.registerFilterForType(
-      DEFAULT_METRICS_SUMMARY,
+      this.options.limitedRunData
+        ? DEFAULT_METRICS_RUN_LIMITED
+        : DEFAULT_METRICS_RUN,
       'browsertime.run'
     );
     this.axeAggregatorTotal = new AxeAggregator(this.options);
@@ -392,6 +396,7 @@ module.exports = {
                   url,
                   group,
                   runIndex,
+                  runTime: run.timestamp,
                   iteration: runIndex + 1
                 })
               );

--- a/lib/plugins/coach/index.js
+++ b/lib/plugins/coach/index.js
@@ -2,6 +2,8 @@
 const aggregator = require('./aggregator');
 const log = require('intel').getLogger('plugin.coach');
 
+const DEFAULT_METRICS_RUN = [];
+
 const DEFAULT_METRICS_SUMMARY = [
   'score.*',
   'performance.score.*',
@@ -32,7 +34,7 @@ module.exports = {
       'coach.summary'
     );
     context.filterRegistry.registerFilterForType(
-      DEFAULT_METRICS_SUMMARY,
+      DEFAULT_METRICS_RUN,
       'coach.run'
     );
     context.filterRegistry.registerFilterForType(

--- a/lib/plugins/graphite/cli.js
+++ b/lib/plugins/graphite/cli.js
@@ -96,18 +96,9 @@ module.exports = {
     describe: 'Break up number of metrics to send with each request.',
     group: 'Graphite'
   },
-  skipSummary: {
-    default: false,
-    type: 'boolean',
-    describe:
-      'Skip sending summary messages data to Graphite (summaries over a domain).',
-    group: 'Graphite'
-  },
-  perIteration: {
-    default: false,
-    type: 'boolean',
-    describe:
-      'Send each iteration of metrics to Graphite. By default we only send page summaries (the summaries of all runs) but you can also send all the runs. Make sure to setup statsd or Graphite correctly to handle it.',
+  messages: {
+    default: ['pageSummary', 'summary'],
+    options: ['pageSummary', 'summary', 'run'],
     group: 'Graphite'
   }
 };

--- a/lib/plugins/graphite/data-generator.js
+++ b/lib/plugins/graphite/data-generator.js
@@ -53,15 +53,6 @@ function keyPathFromMessage(message, options, includeQueryParams, alias) {
     // add the group of the summary message
     typeParts.splice(1, 0, graphiteUtil.toSafeKey(message.group));
   }
-  // if we are sending run metrics and we have an iteration
-  if (
-    options.graphite &&
-    options.graphite.perIteration &&
-    message.type.endsWith('run') &&
-    message.iteration
-  ) {
-    typeParts.splice(0, 1, 'run-' + message.iteration);
-  }
 
   if (options.graphite && options.graphite.addSlugToKey) {
     typeParts.unshift(options.slug);
@@ -91,37 +82,35 @@ class GraphiteDataGenerator {
     return reduce(
       flatten.flattenMessageData(message),
       (entries, value, key) => {
-        if (this.options.graphite && this.options.graphite.perIteration) {
-          if (message.type === 'browsertime.run') {
-            if (key.includes('timings') && key.includes('marks')) {
-              key = key.replace(/marks\.(\d+)/, function (match, idx) {
-                return (
-                  'marks.' + message.data.timings.userTimings.marks[idx].name
-                );
-              });
-            }
-
-            if (key.includes('timings') && key.includes('measures')) {
-              key = key.replace(/measures\.(\d+)/, function (match, idx) {
-                return (
-                  'measures.' +
-                  message.data.timings.userTimings.measures[idx].name
-                );
-              });
-            }
-          }
-          if (message.type === 'pagexray.run') {
-            if (key.includes('assets')) {
-              key = key.replace(
-                /assets\.(\d+)/,
-                function (match, idx) {
-                  let url = new URL(message.data.assets[idx].url);
-                  url.search = '';
-                  return 'assets.' + graphiteUtil.toSafeKey(url.toString());
-                },
-                {}
+        if (message.type === 'browsertime.run') {
+          if (key.includes('timings') && key.includes('marks')) {
+            key = key.replace(/marks\.(\d+)/, function (match, idx) {
+              return (
+                'marks.' + message.data.timings.userTimings.marks[idx].name
               );
-            }
+            });
+          }
+
+          if (key.includes('timings') && key.includes('measures')) {
+            key = key.replace(/measures\.(\d+)/, function (match, idx) {
+              return (
+                'measures.' +
+                message.data.timings.userTimings.measures[idx].name
+              );
+            });
+          }
+        }
+        if (message.type === 'pagexray.run') {
+          if (key.includes('assets')) {
+            key = key.replace(
+              /assets\.(\d+)/,
+              function (match, idx) {
+                let url = new URL(message.data.assets[idx].url);
+                url.search = '';
+                return 'assets.' + graphiteUtil.toSafeKey(url.toString());
+              },
+              {}
+            );
           }
         }
 

--- a/lib/plugins/graphite/index.js
+++ b/lib/plugins/graphite/index.js
@@ -5,6 +5,7 @@ const GraphiteSender = require('./graphite-sender');
 const StatsDSender = require('./statsd-sender');
 const merge = require('lodash.merge');
 const get = require('lodash.get');
+const dayjs = require('dayjs');
 const log = require('intel').getLogger('sitespeedio.plugin.graphite');
 const sendAnnotations = require('./send-annotation');
 const DataGenerator = require('./data-generator');
@@ -12,6 +13,7 @@ const graphiteUtil = require('../../support/tsdbUtil');
 const isStatsd = require('./helpers/is-statsd');
 const throwIfMissing = require('../../support/util').throwIfMissing;
 const cliUtil = require('../../cli/util');
+const toArray = require('../../support/util').toArray;
 
 module.exports = {
   name() {
@@ -64,6 +66,7 @@ module.exports = {
     this.alias = {};
     this.wptExtras = {};
     this.usingBrowsertime = false;
+    this.types = toArray(options.graphite.messages);
   },
 
   processMessage(message, queue) {
@@ -97,21 +100,12 @@ module.exports = {
       this.alias[message.url] = message.data;
     }
 
-    const filterRegistry = this.filterRegistry;
-    if (
-      !(
-        message.type.endsWith('.summary') ||
-        message.type.endsWith('.pageSummary') ||
-        (this.perIteration && message.type.endsWith('.run'))
-      )
-    ) {
-      return;
-    }
-
-    // If you don't want to send summary information about all pages for a domain
-    if (this.skipSummary && message.type.endsWith('.summary')) {
-      return;
-    }
+    const types = message.type.split('.');
+    if (types.length > 1) {
+      if (!this.types.includes(types[1])) {
+        return;
+      }
+    } else return;
 
     if (this.messageTypesToFireAnnotations.includes(message.type)) {
       this.receivedTypesThatFireAnnotations[message.url]
@@ -134,6 +128,7 @@ module.exports = {
     if (message.group === 'total') {
       return;
     }
+    const filterRegistry = this.filterRegistry;
     message = filterRegistry.filterMessage(message);
     if (isEmpty(message.data)) return;
 
@@ -142,7 +137,9 @@ module.exports = {
     // run
     const dataPoints = this.dataGenerator.dataFromMessage(
       message,
-      this.timestamp,
+      message.type === 'browsertime.run'
+        ? dayjs(message.runTime)
+        : this.timestamp,
       this.alias
     );
 

--- a/lib/plugins/pagexray/index.js
+++ b/lib/plugins/pagexray/index.js
@@ -31,6 +31,8 @@ const DEFAULT_PAGEXRAY_SUMMARY_METRICS = [
   'cookies'
 ];
 
+const DEFAULT_PAGEXRAY_RUN_METRICS = [];
+
 module.exports = {
   open(context, options) {
     this.options = options;
@@ -45,7 +47,7 @@ module.exports = {
       'pagexray.summary'
     );
     context.filterRegistry.registerFilterForType(
-      DEFAULT_PAGEXRAY_SUMMARY_METRICS,
+      DEFAULT_PAGEXRAY_RUN_METRICS,
       'pagexray.run'
     );
 

--- a/lib/plugins/thirdparty/index.js
+++ b/lib/plugins/thirdparty/index.js
@@ -11,6 +11,8 @@ const DEFAULT_THIRDPARTY_PAGESUMMARY_METRICS = [
   'cookies.*'
 ];
 
+const DEFAULT_THIRDPARTY_RUN_METRICS = [];
+
 module.exports = {
   open(context, options) {
     this.metrics = {};
@@ -29,7 +31,7 @@ module.exports = {
       'thirdparty.pageSummary'
     );
     context.filterRegistry.registerFilterForType(
-      DEFAULT_THIRDPARTY_PAGESUMMARY_METRICS,
+      DEFAULT_THIRDPARTY_RUN_METRICS,
       'thirdparty.run'
     );
   },

--- a/lib/support/flattenMessage.js
+++ b/lib/support/flattenMessage.js
@@ -63,6 +63,15 @@ module.exports = {
         return;
       }
 
+      // Hack to remove visual progress from default metrics
+      if (keyPrefix.indexOf('visualMetrics.VisualProgress') > -1) {
+        return;
+      }
+
+      if (keyPrefix.indexOf('visualMetrics.videoRecordingStart') > -1) {
+        return;
+      }
+
       const valueType = typeof value;
 
       switch (valueType) {


### PR DESCRIPTION
**Breaking** but **better** changes coming up:

Sending metrics per run to Graphite:
* The default setup did miss a lot of important performance metrics, so you needed to set them up yourself. That is fixed in this PR.
* There where a lot of data sent from PageXray, third party and the coach per run. That was not smart since those metrics rarely change between runs and take a lot of space. This PR sets default so none of those metrics are sent
* We introduce a limited set of run metrics from Browsertime (visual metrics and Google Web Vitals and a couple of more) that can be used when sending data per run. This will help you keep track of those metrics together with the default median/min/max values. More info coming up. It's enabled by default, disable it with `--browsertime.limitedRunData false`
* Sending data per run to Graphite was broken: We sent a new key per run meaning it will take up a lot of extra space in Graphite. With this fix we send them under the run key. That way we can configure Graphite to keep data under that key that happened every 20 s (or however fast it takes to do one run) and then automatically remove the data after a week.
* Graphite configuration `--graphite.perIteration` and `--graphite.skipSummary` is removed. You can now configure which data to send to Graphite by using `--graphite.messages`. By default we send _pageSummary_ (data summarised per URL) and _summary_ (data summarised per domain). If you want to send _pageSummary_ and _run_ data (data for each run) you can do that with by adding `--graphite.messages run`  `--graphite.messages pageSummary`.
* We removed the possibility to send VisualProgress and videoRecordingStart data to the datasource since that is something you do not need there.
* We updated Grafana and the Graphite container to latest versions. The Graphite container contains _storage-schemas.conf_ configuration that is a good default:
```
[sitespeed_crux]
pattern = ^sitespeed_io\.crux\.
retentions = 1d:1y

[sitespeed_run]
pattern = ^sitespeed_io\.(.*)\.(.*)\.run\.
retentions = 20s:8d

[sitespeed]
pattern = ^sitespeed_io\.
retentions = 30m:40d
```

When you send data per run to Graphite it is stored every 20 second (do not make runs more often than that) and saved for 8 days. If you test many URLs this can still be a lot of data so use https://m30m.github.io/whisper-calculator/ to calculate how much space you need.