### PR TITLE
api: fix text and change guard for not supplying URLs

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -149,6 +149,11 @@ function validateInput(argv) {
     return 'There is no benefit running debug mode inside a Docker container.';
   }
 
+  // If we ask the API for finished test, we don't need a URL
+  if (argv._.length === 0 && !argv.api.id) {
+    return 'You need to supply one/multiple URLs or scripts';
+  }
+
   // validate URLs/files
   const urlOrFiles = argv._;
   for (let urlOrFile of urlOrFiles) {
@@ -208,7 +213,6 @@ export async function parseCommandLine() {
     .parserConfiguration({ 'deep-merge-config': true })
     .env('SITESPEED_IO')
     .usage('$0 [options] <url>/<file>')
-    .require(1, 'One or multiple URLs or scripts')
 
     .option('debugMessages', {
       default: false,
@@ -1814,8 +1818,9 @@ export async function parseCommandLine() {
     });
 
   parsed
-    .option('api.type', {
-      describe: 'The type of API call you want to do: S',
+    .option('api.action', {
+      describe:
+        'The type of API call you want to do: You get add a test and wait for the result, just add a test or get the result. To get the result, make sure you add the id using --api.id',
       default: 'addAndGetResult',
       choices: ['add', 'addAndGetResult', 'get'],
       group: 'API'
@@ -1838,7 +1843,8 @@ export async function parseCommandLine() {
     })
     .option('api.id', {
       describe:
-        'The id of the test. You it when you want to get the test result.',
+        'The id of the test. Use it when you want to get the test result.',
+      type: 'string',
       group: 'API'
     })
     .option('api.json', {


### PR DESCRIPTION
If you as an API user just want to get the result, you don't need a URL.

