### PR TITLE
add proxyPath config for graphite web endpoint

### DIFF
--- a/docs/documentation/sitespeed.io/configuration/config.md
+++ b/docs/documentation/sitespeed.io/configuration/config.md
@@ -166,6 +166,7 @@ Graphite
       --graphite.auth                        The Graphite user and password used for authentication. Format: user:password
       --graphite.httpPort                    The Graphite port used to access the user interface and send annotations event  [default: 8080]
       --graphite.webHost                     The graphite-web host. If not specified graphite.host will be used.
+      --graphite.proxyPath                   The added path to graphite-web api when behind a proxy. [default: ""]
       --graphite.namespace                   The namespace key added to all captured metrics.  [default: "sitespeed_io.default"]
       --graphite.includeQueryParams          Whether to include query parameters from the URL in the Graphite keys or not  [boolean] [default: false]
       --graphite.arrayTags                   Send the tags as Array or a String. In Graphite 1.0 the tags is a array. Before a String  [boolean] [default: true]

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1227,8 +1227,7 @@ export async function parseCommandLine() {
       group: 'Graphite'
     })
     .option('graphite.proxyPath', {
-      describe:
-        'The added path to graphite-web when behind a proxy.',
+      describe: 'The added path to graphite-web when behind a proxy.',
       default: '',
       group: 'Graphite'
     })

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1226,6 +1226,12 @@ export async function parseCommandLine() {
         'The graphite-web host. If not specified graphite.host will be used.',
       group: 'Graphite'
     })
+    .option('graphite.proxyPath', {
+      describe:
+        'The added path to graphite-web when behind a proxy.',
+      default: '',
+      group: 'Graphite'
+    })
     .option('graphite.namespace', {
       default: 'sitespeed_io.default',
       describe: 'The namespace key added to all captured metrics.',

--- a/lib/plugins/graphite/index.js
+++ b/lib/plugins/graphite/index.js
@@ -60,6 +60,7 @@ export default class GraphitePlugin extends SitespeedioPlugin {
     this.receivedTypesThatFireAnnotations = {};
     this.make = context.messageMaker('graphite').make;
     this.sendAnnotation = options_.sendAnnotation;
+    this.proxyPath = options_.proxyPath;
     this.alias = {};
     this.wptExtras = {};
     this.usingBrowsertime = false;

--- a/lib/plugins/graphite/send-annotation.js
+++ b/lib/plugins/graphite/send-annotation.js
@@ -95,7 +95,7 @@ export function send(
   const postOptions = {
     hostname: options.graphite.webHost || options.graphite.host,
     port: options.graphite.httpPort || 8080,
-    path: '/events/',
+    path: options.graphite.proxyPath + '/events/',
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
### Description
Add support to alter the URL path to graphite-web events endpoint when behind a proxy.

Tested with my own instance of graphite-web running behind a proxy.
