### PR TITLE
Use browsertime runTime for Graphite/Influx and Grafana annotations and data.

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -519,6 +519,7 @@ export default class BrowsertimePlugin extends SitespeedioPlugin {
 
             result[resultIndex].statistics.errors = summarizeStats(errorStats);
 
+            console.log(result.timestamp);
             // Post the result on the queue so other plugins can use it
             super.sendMessage('browsertime.pageSummary', result[resultIndex], {
               url,

--- a/lib/plugins/grafana/index.js
+++ b/lib/plugins/grafana/index.js
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 
 import { send } from './send-annotation.js';
@@ -90,13 +92,19 @@ export default class GrafanaPlugin extends SitespeedioPlugin {
             this.alias[message.url]
           );
           this.receivedTypesThatFireAnnotations[message.url] = 0;
+
+          const timestamp =
+            message.type === 'browsertime.pageSummary'
+              ? dayjs(message.runTime)
+              : this.timestamp;
+
           return send(
             message.url,
             message.group,
             absolutePagePath,
             this.useScreenshots,
             this.screenshotType,
-            this.timestamp,
+            timestamp,
             this.tsdbType,
             this.alias,
             this.wptExtras[message.url],

--- a/lib/plugins/graphite/index.js
+++ b/lib/plugins/graphite/index.js
@@ -149,11 +149,16 @@ export default class GraphitePlugin extends SitespeedioPlugin {
     // TODO Here we could add logic to either create a new timestamp or
     // use the one that we have for that run. Now just use the one for the
     // run
+    let timestamp = this.timestamp;
+    if (
+      message.type === 'browsertime.run' ||
+      message.type === 'browsertime.pageSummary'
+    ) {
+      timestamp = dayjs(message.runTime);
+    }
     const dataPoints = this.dataGenerator.dataFromMessage(
       message,
-      message.type === 'browsertime.run'
-        ? dayjs(message.runTime)
-        : this.timestamp,
+      timestamp,
       this.alias
     );
 
@@ -176,13 +181,19 @@ export default class GraphitePlugin extends SitespeedioPlugin {
             message.url,
             this.alias[message.url]
           );
+
+          const timestamp =
+            message.type === 'browsertime.pageSummary'
+              ? dayjs(message.runTime)
+              : this.timestamp;
+
           return send(
             message.url,
             message.group,
             absolutePagePath,
             this.useScreenshots,
             this.screenshotType,
-            this.timestamp,
+            timestamp,
             this.alias,
             this.wptExtras[message.url],
             this.usingBrowsertime,

--- a/lib/plugins/influxdb/index.js
+++ b/lib/plugins/influxdb/index.js
@@ -1,5 +1,7 @@
 import isEmpty from 'lodash.isempty';
 import intel from 'intel';
+import dayjs from 'dayjs';
+
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 import { InfluxDBSender as Sender } from './sender.js';
 import { InfluxDB2Sender as SenderV2 } from './senderV2.js';
@@ -125,7 +127,9 @@ export default class InfluxDBPlugin extends SitespeedioPlugin {
 
     let data = this.dataGenerator.dataFromMessage(
       message,
-      this.timestamp,
+      message.type === 'browsertime.pageSummary'
+        ? dayjs(message.runTime)
+        : this.timestamp,
       this.alias
     );
 


### PR DESCRIPTION
The old implementation always used the start time for all metrics sent except browsertime.run metrics (data for each run).

This fix instead makes sure that if metrics (and annotations) uses the browsertime.pageSummary runTime (when the actual first iteration happen).

This makes more sense if you test multiple pages within the same test.

This fix needs testing before merging :=)

