### PR TITLE
Try/catch coach/third party tools errors

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -477,51 +477,58 @@ export default class BrowsertimePlugin extends SitespeedioPlugin {
 
               // If the coach is turned on, collect the coach result
               if (options.coach) {
-                const coachAdvice = browserScriptsData.coach.coachAdvice;
-                // check if the coach has error(s)
-                if (!isEmpty(coachAdvice.errors)) {
-                  log.error(
-                    '%s generated the following errors in the coach %:2j',
-                    url,
-                    coachAdvice.errors
-                  );
-                  super.sendMessage(
-                    'error',
-                    'The coach got the following errors: ' +
-                      JSON.stringify(coachAdvice.errors),
-                    {
+                try {
+                  const coachAdvice = browserScriptsData.coach.coachAdvice;
+                  // check if the coach has error(s)
+                  if (!isEmpty(coachAdvice.errors)) {
+                    log.error(
+                      '%s generated the following errors in the coach %:2j',
                       url,
-                      runIndex,
-                      iteration: runIndex + 1
-                    }
-                  );
+                      coachAdvice.errors
+                    );
+                    super.sendMessage(
+                      'error',
+                      'The coach got the following errors: ' +
+                        JSON.stringify(coachAdvice.errors),
+                      {
+                        url,
+                        runIndex,
+                        iteration: runIndex + 1
+                      }
+                    );
+                  }
+
+                  let advice = coachAdvice;
+                  // If we run without HAR
+                  if (result.har) {
+                    // make sure to get the right run in the HAR
+                    const myHar = pickAPage(result.har, harIndex);
+
+                    const harResult = await analyseHar(
+                      myHar,
+                      undefined,
+                      coachAdvice,
+                      options
+                    );
+                    advice = merge(coachAdvice, harResult);
+                  }
+                  const thirdPartyWebVersion = getThirdPartyWebVersion();
+                  const wappalyzerVersion = getWappalyzerCoreVersion();
+                  advice.thirdPartyWebVersion = thirdPartyWebVersion;
+                  advice.wappalyzerVersion = wappalyzerVersion;
+
+                  super.sendMessage('coach.run', advice, {
+                    url,
+                    group,
+                    runIndex,
+                    iteration: runIndex + 1
+                  });
+                } catch (error) {
+                  // Lets be extra careful with coach and third party
+                  // tools
+                  super.sendMessage('error', error, _merge({ url }));
+                  log.error('Caught error from the Coach', error);
                 }
-
-                let advice = coachAdvice;
-                // If we run without HAR
-                if (result.har) {
-                  // make sure to get the right run in the HAR
-                  const myHar = pickAPage(result.har, harIndex);
-
-                  const harResult = await analyseHar(
-                    myHar,
-                    undefined,
-                    coachAdvice,
-                    options
-                  );
-                  advice = merge(coachAdvice, harResult);
-                }
-                const thirdPartyWebVersion = getThirdPartyWebVersion();
-                const wappalyzerVersion = getWappalyzerCoreVersion();
-                advice.thirdPartyWebVersion = thirdPartyWebVersion;
-                advice.wappalyzerVersion = wappalyzerVersion;
-
-                super.sendMessage('coach.run', advice, {
-                  url,
-                  group,
-                  runIndex,
-                  iteration: runIndex + 1
-                });
               }
 
               this.browsertimeAggregator.addToAggregate(run, group);


### PR DESCRIPTION
The reason for this fix is that the bidhar broke with Firefox 117, but maybe this is still a good idea.