### PR TITLE
Only set exit code if you haven't set it already.

### DIFF
--- a/bin/sitespeed.js
+++ b/bin/sitespeed.js
@@ -157,8 +157,9 @@ async function start() {
       }
 
       if (
-        !budgetFailing ||
-        (parsed.options.budget && parsed.options.budget.suppressExitCode)
+        (!budgetFailing ||
+          (parsed.options.budget && parsed.options.budget.suppressExitCode)) &&
+        process.exitCode === undefined
       ) {
         process.exitCode = 0;
       }


### PR DESCRIPTION
https://github.com/sitespeedio/sitespeed.io/issues/3667

This makes it possible to set the exit code in your script.