### PR TITLE
Fix broken check for -c cable on Mac/Linux.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -2234,7 +2234,7 @@ export async function parseCommandLine() {
     set(argv, 'browsertime.connectivity.engine', 'throttle');
   } else if (
     (platform() === 'darwin' || platform() === 'linux') &&
-    !argv.browsertime.android &&
+    !argv.browsertime.android.enabled &&
     !argv.browsertime.safari.ios &&
     !argv.browsertime.docker &&
     get(explicitOptions, 'browsertime.connectivity.engine', '') === '' &&


### PR DESCRIPTION
We used to automatically choose throttle as network emulator on Mac and Linux but that was broken when Android functionality was restructured.

