### PR TITLE
Add CLI params to turn off LCP/LS screenshots.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1466,6 +1466,22 @@ export async function parseCommandLine() {
     })
 
     /** Screenshot */
+    .option('browsertime.screenshotLCP', {
+      alias: 'screenshotLCP',
+      type: 'boolean',
+      default: false,
+      describe:
+        'Save one screenshot per iteration that shows the largest contentful paint element (if the browser supports LCP).',
+      group: 'Screenshot'
+    })
+    .option('browsertime.screenshotLS', {
+      alias: 'screenshotLS',
+      type: 'boolean',
+      default: false,
+      describe:
+        'Save one screenshot per iteration that shows the layout shift elements (if the browser supports layout shift).',
+      group: 'Screenshot'
+    })
     .option('browsertime.screenshot', {
       type: 'boolean',
       describe: 'Set to false to disable screenshots',
@@ -2042,6 +2058,8 @@ export async function parseCommandLine() {
     .alias('help', 'h')
     .config(config)
     .hide('disableAPI')
+    .hide('browsertime.screenshotLCP')
+    .hide('browsertime.screenshotLS')
     .alias('version', 'V')
     .version(version)
     .coerce('budget', function (argument) {


### PR DESCRIPTION
They already exists in Browsertime.

https://github.com/sitespeedio/sitespeed.io/issues/4189

