### PR TITLE
Show correct image for LCP and CLS.

### DIFF
--- a/lib/plugins/html/templates/url/metrics/layoutShift.pug
+++ b/lib/plugins/html/templates/url/metrics/layoutShift.pug
@@ -22,7 +22,7 @@ if browsertime.pageinfo && browsertime.pageinfo.cumulativeLayoutShift!== undefin
               tr 
                 td.url.pagesurl(colspan='2') #{info.domPath}
         .one-half.column
-          - const screenshotNo = medianRun ? medianRun.runIndex : 1
+          - const screenshotNo = medianRun ? medianRun.runIndex : (Number(runIndex) + 1)
           - const screenshotName = 'data/screenshots/' + screenshotNo + '/layoutShift.' + screenShotType
           a(href=screenshotName)
             img.screenshot(src=screenshotName, alt='Layout shift', style='max-width:100%; height: auto')

--- a/lib/plugins/html/templates/url/metrics/lcp.pug
+++ b/lib/plugins/html/templates/url/metrics/lcp.pug
@@ -59,7 +59,7 @@ if timings.largestContentfulPaint
               td.url.pagesurl(colspan='2')
                 #{timings.largestContentfulPaint.domPath}
     .one-half.column
-      - const screenshotNo = medianRun ? medianRun.runIndex : 1
+      - const screenshotNo = medianRun ? medianRun.runIndex : (Number(runIndex) + 1)
       - const screenshotName = 'data/screenshots/' + screenshotNo + '/largestContentfulPaint.' + screenShotType
       a(href=screenshotName)
         img.screenshot(src=screenshotName, alt='LCP', style='max-width:100%; height: auto')


### PR DESCRIPTION
On the indivisual run page, it always showed the first image instead of the image from that specific run.

https://github.com/sitespeedio/sitespeed.io/issues/4218

