### PR TITLE
Fix. InfluxDB 2.x, annotations: missed 'slug' key

### DIFF
--- a/lib/plugins/influxdb/send-annotationV2.js
+++ b/lib/plugins/influxdb/send-annotationV2.js
@@ -44,7 +44,7 @@ export function sendV2(
   ];
 
   if (options.slug) {
-    tags.push(options.slug);
+    tags.push(`slug=${options.slug}`);
   }
 
   const message = getAnnotationMessage(


### PR DESCRIPTION
Fix for this changes - https://github.com/sitespeedio/sitespeed.io/commit/94854aad48e8c906bd288d61494b1b637ecff46d
Missed add a key for `slug`