### PR TITLE
WebPageReplay: Deep merge configuration and skip camel case.

### DIFF
--- a/bin/browsertimeWebPageReplay.js
+++ b/bin/browsertimeWebPageReplay.js
@@ -24,6 +24,7 @@ let config;
 
 try {
   config = configPath ? JSON.parse(readFileSync(configPath)) : {};
+
 } catch (e) {
   if (e instanceof SyntaxError) {
     /* eslint no-console: off */
@@ -150,6 +151,7 @@ async function runBrowsertime() {
         ' to increase the level of detail.',
       type: 'count'
     })
+    .parserConfiguration({ 'camel-case-expansion': false, 'deep-merge-config': true  })
     .config(config);
 
   const defaultConfig = {


### PR DESCRIPTION
The camel case is evil since it makes some metrics becoming arrays.

