### PR TITLE
Fix error on warning msg

### DIFF
--- a/lib/plugins/compare/index.js
+++ b/lib/plugins/compare/index.js
@@ -129,7 +129,7 @@ export default class ComparePlugin extends SitespeedioPlugin {
             )
               log.warning(
                 'The baseline test has %s runs and you current have %s. You should make sure you test the same amount of runs',
-                baseline.timestamps.length,
+                baseline.browsertime.timestamps.length,
                 this.options.browsertime.iterations
               );
             log.info('Got a baseline:' + id + '-' + this.page);


### PR DESCRIPTION
### Your checklist for a pull request to sitespeed.io
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] I'm making a big change or adding functionality so I've already opened an issue proposing the change to other contributors, so I got feedback on the idea before took the time to write precious code
- [ ] Check that your change/fix has corresponding unit tests (if applicable)
- [ ] Squash commits so it looks sane
- [ ] Update the documentation https://github.com/sitespeedio/sitespeed.io/tree/main/docs in another PR
- [x] Verify that the test works by running `npm test` and test linting by `npm run lint`


### Description
I ran into an error on this line while playing around with the compare plugin, where timestamps is undefined.

