### PR TITLE
Fix broken --android parsing.

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -25,20 +25,8 @@ const version = require('../../package.json').version;
 
 const configFiles = ['.sitespeed.io.json'];
 
-function fixAndroidArgs() {
-  const original = hideBin(process.argv);
-  // We need to replave --android, else
-  // we end up with the android object becoming
-  // an array
-  const fixed = [];
-  for (const arg of original) {
-    if (arg === '--android') {
-      fixed.push('--android.enabled', 'true');
-    } else {
-      fixed.push(arg);
-    }
-  }
-  return fixed;
+function fixAndroidArgs(args) {
+  return args.map(arg => (arg === '--android' ? '--android.enabled' : arg));
 }
 
 if (process.argv.includes('--config')) {
@@ -230,8 +218,8 @@ function validateInput(argv) {
 }
 
 export async function parseCommandLine() {
-  const argvFix = fixAndroidArgs();
-  let yargsInstance = yargs(hideBin(argvFix));
+  const fixedArgs = fixAndroidArgs(hideBin(process.argv));
+  const yargsInstance = yargs(fixedArgs);
   let parsed = yargsInstance
     .parserConfiguration({
       'camel-case-expansion': false,
@@ -2207,7 +2195,7 @@ export async function parseCommandLine() {
 
   if (argv.ios) {
     set(argv, 'safari.ios', true);
-  } else if (argv.android && argv.browser === 'chrome') {
+  } else if (argv.android.enabled === true && argv.browser === 'chrome') {
     // Default to Chrome Android.
     set(
       argv,

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -25,6 +25,22 @@ const version = require('../../package.json').version;
 
 const configFiles = ['.sitespeed.io.json'];
 
+function fixAndroidArgs() {
+  const original = hideBin(process.argv);
+  // We need to replave --android, else
+  // we end up with the android object becoming
+  // an array
+  const fixed = [];
+  for (const arg of original) {
+    if (arg === '--android') {
+      fixed.push('--android.enabled', 'true');
+    } else {
+      fixed.push(arg);
+    }
+  }
+  return fixed;
+}
+
 if (process.argv.includes('--config')) {
   const index = process.argv.indexOf('--config');
   configFiles.unshift(process.argv[index + 1]);
@@ -214,10 +230,7 @@ function validateInput(argv) {
 }
 
 export async function parseCommandLine() {
-  let argvFix = process.argv.map(arg =>
-    arg === '--android' ? '--android.enabled' : arg
-  );
-
+  const argvFix = fixAndroidArgs();
   let yargsInstance = yargs(hideBin(argvFix));
   let parsed = yargsInstance
     .parserConfiguration({
@@ -860,8 +873,8 @@ export async function parseCommandLine() {
         'Process name of the Activity hosting the WebView. If not given, the process name is assumed to be the same as chrome.android.package.',
       group: 'Chrome'
     })
-    .option('browsertime.android', {
-      alias: 'android',
+    .option('browsertime.android.enabled', {
+      alias: ['android.enabled'],
       type: 'boolean',
       default: false,
       describe:


### PR DESCRIPTION
After this --android will work but will not be showed as an alias. The problem was that we had issues with the android configuration object becoming an array instead of an object.

