### PR TITLE
Fixed issue with failing sanitizing

### DIFF
--- a/lib/plugins/html/templates/url/waterfall/includeHARinHTML.pug
+++ b/lib/plugins/html/templates/url/waterfall/includeHARinHTML.pug
@@ -1,10 +1,16 @@
 #output
 //- When we inline the data, we cut the HAR to just be one
 //- specific run (the median run) in summaryPageHAR.
-//- Inline script tags breaks the output
-- dahar = h.get(pageInfo.data, 'browsertime.run.har', summaryPageHAR)
-- dahar = JSON.stringify(dahar.log).split('</script>').join('&lt;/script&gt;')
-
+//- Inline script tags break the output
+- var dahar = h.get(pageInfo.data, 'browsertime.run.har', summaryPageHAR)
+- if (dahar && dahar.log && Array.isArray(dahar.log.entries)) {
+-    dahar.log.entries.forEach(function(entry) {
+-      if (entry && entry.response && entry.response.content && entry.response.content.text) {
+-         entry.response.content.text = "replaced";
+-      }
+-    });
+- }
+- dahar = JSON.stringify(dahar.log)
 script(src= assetsPath + 'js/perf-cascade.min.js')
 script(type='text/javascript').
   const outputHolderEl = document.getElementById("output");


### PR DESCRIPTION
This PR is intended to solve that waterfall tab in page summary sometimes crashes when using:
`--browsertime.chrome.includeResponseBodies all`

When waterfall tab breaks, it also breaks all tabs on the right of it making it impossible to view plugin reports.

This PR changes the blacklisting approach of sanitizing browsertime.har file to instead removing/replacing problematic text property entirely. 

You can reproduce this error (before and after PR) by calling sitespeed.io with following command:
`node bin\sitespeed.js -b edge -n 1 --browsertime.chrome.includeResponseBodies all https://bollnas.se`
