### PR TITLE
blog: Improve RSS feed

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -41,7 +41,7 @@ layout: compress
 	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{site.baseurl}}/img/ico/sitespeed.io-72.png">
 	<link rel="apple-touch-icon-precomposed" href="{{site.baseurl}}/img/ico/sitespeed.io-57.png">
 	<link rel="shortcut icon" href="{{site.baseurl}}/img/ico/sitespeed.io.ico">
-	<link type="application/atom+xml" href="https://www.sitespeed.io/feed/index.xml" rel="alternate" />
+	<link type="application/atom+xml" href="https://www.sitespeed.io/feed/blog.xml" rel="alternate" />
 
 	<style>
 		{% include css/default.css %}

--- a/docs/feed/blog.xml
+++ b/docs/feed/blog.xml
@@ -3,10 +3,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>The sitespeed.io blog</title>
+    <title>Sitespeed.io Blog</title>
     <description>The latest news from the sitespeed.io world.</description>
     <link>https://www.sitespeed.io</link>
-    <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ site.url }}/feed/blog.xml" rel="self" type="application/rss+xml" />
     {% for post in site.posts limit:10 %}
     <item>
       <title>{{ post.title | xml_escape }}</title>


### PR DESCRIPTION
* [x] Please describe your pull request

### Description

* Point rss discovery to canonical URL.
  Update discovery link to the current canonical URL for where the blog RSS feed lives. The redirect is kept for compatibility. This avoids feed readers from becoming unsure about the feed location by not re-crawling and re-fixing the redirect repeatedly.

* Fix 404 from https://www.sitespeed.io/feed/blog.xml to `https://www.sitespeed.io/feed.xml` which may confuse feed readers if they replace their link with the preferred self location, but then lose the subscription to an HTTP 404 error.

* Shorten the feed title and start with "Sitespeed.io" so that it sorts well alongside other blogs in a feed reader under the default suggested name.