### PR TITLE
Fix relative URL resolution in HTML page reports

### DIFF
--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -300,9 +300,12 @@ export class HTMLBuilder {
             )
           : [];
       let rootPath = this.storageManager.rootPathFromUrl(url, daurlAlias);
-      const baseHref =
-        rootPath +
-        this.context.resultUrls.relativeSummaryPageUrl(url, daurlAlias);
+      const summaryPagePath =
+        this.context.resultUrls.relativeSummaryPageUrl(url, daurlAlias) +
+        'index.html';
+      const baseHref = options.useSameDir
+        ? undefined
+        : rootPath + summaryPagePath;
       let data = {
         daurl: url,
         daurlAlias,
@@ -374,9 +377,12 @@ export class HTMLBuilder {
           run => !!get(pageInfo.data, [run.id, 'run'])
         );
         let rootPath = this.storageManager.rootPathFromUrl(url, daurlAlias);
-        const baseHref =
-          rootPath +
-          this.context.resultUrls.relativeSummaryPageUrl(url, daurlAlias);
+        const runPagePath =
+          this.context.resultUrls.relativeSummaryPageUrl(url, daurlAlias) +
+          `${iteration}.html`;
+        const baseHref = options.useSameDir
+          ? undefined
+          : rootPath + runPagePath;
         let data = {
           daurl: url,
           daurlAlias,

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -300,6 +300,9 @@ export class HTMLBuilder {
             )
           : [];
       let rootPath = this.storageManager.rootPathFromUrl(url, daurlAlias);
+      const baseHref =
+        rootPath +
+        this.context.resultUrls.relativeSummaryPageUrl(url, daurlAlias);
       let data = {
         daurl: url,
         daurlAlias,
@@ -322,6 +325,7 @@ export class HTMLBuilder {
         get,
         markdown: markdown,
         rootPath,
+        baseHref,
         resultUrls: this.context.resultUrls,
         assetsPath: assetsBaseURL || rootPath,
         sitespeedioURL: options.html.homeurl,
@@ -370,6 +374,9 @@ export class HTMLBuilder {
           run => !!get(pageInfo.data, [run.id, 'run'])
         );
         let rootPath = this.storageManager.rootPathFromUrl(url, daurlAlias);
+        const baseHref =
+          rootPath +
+          this.context.resultUrls.relativeSummaryPageUrl(url, daurlAlias);
         let data = {
           daurl: url,
           daurlAlias,
@@ -395,6 +402,7 @@ export class HTMLBuilder {
           get,
           markdown: markdown,
           rootPath,
+          baseHref,
           resultUrls: this.context.resultUrls,
           assetsPath: assetsBaseURL || rootPath,
           sitespeedioURL: options.html.homeurl,

--- a/lib/plugins/html/templates/layout.pug
+++ b/lib/plugins/html/templates/layout.pug
@@ -3,6 +3,8 @@ html(lang='en')
     head
         meta(charset='utf-8')
         meta(name='viewport', content='width=device-width, initial-scale=1')
+        if baseHref
+          base(href=baseHref)
         title= pageTitle
         meta(name='description', content=pageDescription)
         meta(name='robots', content='noindex')


### PR DESCRIPTION
## Summary
Fix relative URL resolution in generated HTML page reports by adding a `<base>` tag for per-page summary/run pages.

This makes page reports work whether they are opened as:

- `/pages/example_com/path`
- `/pages/example_com/path/`
- `/pages/example_com/path/index.html`

Without this, relative URLs like `data/browsertime.har.gz` and `data/screenshots/...` can resolve to the wrong parent path when the page is opened without a trailing slash.

## Problem
Generated page report HTML uses relative paths such as:

- `data/browsertime.har.gz`
- `data/screenshots/...`
- `./1.html`
- `metrics.html`

When a report page is opened at a slashless directory URL, the browser resolves those relative paths against the parent path, which can produce 404s for the HAR and screenshots. The waterfall then stays loading forever because the fetch/decompression never succeeds.

## Fix
- Add optional `baseHref` support in the shared HTML layout template.
- Pass `baseHref` for URL summary and URL run pages from `htmlBuilder.js`.

The computed base href points to the generated page directory, so all existing relative URLs continue to work correctly.

## Related
Fixes #4608
