### PR TITLE
Add Coach score to the detailed-summary hero band

### DIFF
--- a/lib/plugins/html/templates/detailed.pug
+++ b/lib/plugins/html/templates/detailed.pug
@@ -14,13 +14,15 @@ block content
   - const fcpClass = (v) => v == null ? '' : (v >= 3000 ? 'error' : (v >= 1800 ? 'warning' : 'ok'))
   - const clsClass = (v) => v == null ? '' : (v >= 0.25 ? 'error' : (v >= 0.1 ? 'warning' : 'ok'))
   - const inpClass = (v) => v == null ? '' : (v >= 500 ? 'error' : (v >= 200 ? 'warning' : 'ok'))
+  - const perfClass = (v) => v == null ? '' : (typeof h.scoreLabel === 'function' ? h.scoreLabel(v) : 'info')
   - const findMetric = (name) => metrics.find(m => m.name === name)
   - const lcpMetric = findMetric('Largest Contentful Paint')
   - const fcpMetric = findMetric('First Contentful Paint')
   - const clsMetric = findMetric('Cumulative Layout Shift')
   - const inpMetric = findMetric('Interaction to Next Paint')
+  - const coachMetric = findMetric('Coach performance score')
 
-  if (lcpMetric && lcpMetric.node) || (fcpMetric && fcpMetric.node) || (clsMetric && clsMetric.node) || (inpMetric && inpMetric.node)
+  if (lcpMetric && lcpMetric.node) || (fcpMetric && fcpMetric.node) || (clsMetric && clsMetric.node) || (inpMetric && inpMetric.node) || (coachMetric && coachMetric.node)
     .detailed-kpis
       if fcpMetric && fcpMetric.node
         .detailed-kpi(class=fcpClass(fcpMetric.node.median))
@@ -37,6 +39,11 @@ block content
           span.detailed-kpi-label CLS
           span.detailed-kpi-value #{clsMetric.h(clsMetric.node.median)}
           span.detailed-kpi-sub p90 #{clsMetric.h(clsMetric.node.p90)}
+      if coachMetric && coachMetric.node
+        .detailed-kpi(class=perfClass(coachMetric.node.median))
+          span.detailed-kpi-label Coach
+          span.detailed-kpi-value #{coachMetric.h(coachMetric.node.median)}
+          span.detailed-kpi-sub p90 #{coachMetric.h(coachMetric.node.p90)}
       if inpMetric && inpMetric.node
         .detailed-kpi(class=inpClass(inpMetric.node.median))
           span.detailed-kpi-label INP


### PR DESCRIPTION
  The detailed-summary page leads with a hero band of the headline metrics (FCP, LCP, CLS, INP), but Coach performance score — the same fourth tile that anchors the
  executive-summary index page and the per-iteration summary tab — was missing. Pages where INP isn't collected (most non-interactive runs) ended up with only three tiles in
  the band, breaking the consistency users rely on across pages.

  Pull Coach performance score from the metrics list via findMetric and render it between CLS and INP using the same h.scoreLabel thresholding the rest of the report uses, so
  detailed.html now leads with FCP / LCP / CLS / Coach (and INP if present) just like the other hero bands.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com

