### PR TITLE
Only show the limited-metrics Safari warning for desktop Safari

### DIFF
--- a/lib/plugins/html/templates/runInfo.pug
+++ b/lib/plugins/html/templates/runInfo.pug
@@ -10,5 +10,5 @@ if usingBrowsertime
         | .
     a(href= rootPath + 'settings.html')= '(runtime settings).'
   
-  if options.browsertime.browser === 'safari'
-        p At the moment we get limited metrics from Safari. Transfer sizes and number of requests are missing.
+  if options.browsertime.browser === 'safari' && !(options.safari && options.safari.ios)
+        p At the moment we get limited metrics from Safari on macOS. Transfer sizes and number of requests are missing. Run with #[code --safari.ios] for the full HAR on iOS Safari.


### PR DESCRIPTION
  The "limited metrics from Safari" notice in runInfo.pug fired for any Safari run, including iOS Safari. But Browsertime 27 records the full HAR for iOS Safari over
  ios_webkit_debug_proxy (--safari.ios), so transfer sizes and request counts are present there — only desktop Safari on macOS is still missing them. Showing the warning on
  iOS runs misled users into thinking their HAR was incomplete.

  Gate the notice on !(options.safari && options.safari.ios) so it only shows for the actual macOS Safari case, and reword to call out --safari.ios as the path that records
  the full HAR.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com

