### PR TITLE
Guard the LCP card against undefined url and id

### DIFF
--- a/lib/plugins/html/templates/url/metrics/lcp.pug
+++ b/lib/plugins/html/templates/url/metrics/lcp.pug
@@ -35,14 +35,14 @@ if timings.largestContentfulPaint
             dt Element type
             dd
               code &lt;#{lcp.tagName.toLowerCase()}&gt;
-          if lcp.id !== ''
+          if lcp.id
             dt Element id
             dd
               code= lcp.id
           if lcp.size
             dt Size (w × h)
             dd #{lcp.size}
-          if lcp.url !== ''
+          if lcp.url
             dt URL
             dd
               a(href=lcp.url) #{h.shortAsset(lcp.url)}
@@ -63,7 +63,7 @@ if timings.largestContentfulPaint
         a(href=screenshotName)
           img.screenshot.lcp-screenshot(src=screenshotName, alt='LCP')
         p.small The LCP element is highlighted in the screenshot. If nothing is highlighted the element was removed before the screenshot or the LCP API couldn't find it.
-        if lcp.url !== ''
+        if lcp.url
           p.small The Largest Contentful Paint API matched this image:
           a(href=lcp.url)
             img.screenshot.lcp-element-image(src=lcp.url, alt='LCP element')


### PR DESCRIPTION
  On SPA navigations the Largest Contentful Paint API can fire an entry whose element has been removed from the DOM by the time browsertime reads it ("No element attached to
  the entry in largest-contentful-paint" in the log). The element-tied fields — lcp.url, lcp.id — come back as undefined rather than empty strings.

  The pug card guarded those with !== '', which is true for undefined, so the body still ran and h.shortAsset(undefined) failed on .length. The whole url/iteration and
  url/summary HTML render aborted for that iteration, leaving the report missing pages.

  Switch the three !== '' checks to truthy checks (if lcp.url, if lcp.id) so an undefined value is treated the same as an empty string and the section is skipped.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com

