### PR TITLE
Modernise the Budget, CPU and PageXray pages

### DIFF
--- a/lib/plugins/html/templates/budget.pug
+++ b/lib/plugins/html/templates/budget.pug
@@ -6,25 +6,37 @@ mixin row(budget)
     each result in results
       tr
         td
-          if (urlOrAlias &&  urlOrAlias.startsWith('http')) 
+          if (urlOrAlias && urlOrAlias.startsWith('http'))
             a(href=urlOrAlias)= urlOrAlias
-          else 
-            a(href=aliasToUrl[urlOrAlias])= urlOrAlias 
+          else
+            a(href=aliasToUrl[urlOrAlias])= urlOrAlias
             p #{aliasToUrl[urlOrAlias]}
-        td #{result.metric} with value #{result.friendlyValue || result.value} limit #{result.limitType} #{result.friendlyLimit || result.limit}
+        td #{result.metric} with value #{result.friendlyValue || result.value} limit #{result.limitType} #{result.friendlyLimit || result.limit}
 
 block content
-    h2 The budget
-    p The result of the performance budget. We got #{totalFailing} failing and #{totalWorking} working.
+  h2 The budget
+  p The result of the performance budget. We got #{totalFailing} failing and #{totalWorking} working.
 
-    h3 Failing budgets [#{totalFailing}]
-    if totalFailing > 0 
-      table
+  //- Failing first because that's what the reader actually came here
+  //- to find. Each list lives in a card with a count chip in the
+  //- header — the bare `h3 Failing budgets [N]` syntax was carrying
+  //- both the title and the count, the chip splits them visually.
+  if totalFailing > 0
+    .listing-card
+      .listing-card-header
+        h3.listing-card-title Failing budgets
+        span.listing-card-meta #{totalFailing} #{totalFailing === 1 ? 'failure' : 'failures'}
+      .responsive
+        table(data-sortable, id='budget-failing')
           +rowHeading(['url', 'result'])
           +row(budget.failing)
 
-    h3 Working budgets [#{totalWorking}]
-    if totalWorking > 0 
-      table
+  if totalWorking > 0
+    .listing-card
+      .listing-card-header
+        h3.listing-card-title Working budgets
+        span.listing-card-meta #{totalWorking} passing
+      .responsive
+        table(data-sortable, id='budget-working')
           +rowHeading(['url', 'result'])
           +row(budget.working)

--- a/lib/plugins/html/templates/url/cpu/index.pug
+++ b/lib/plugins/html/templates/url/cpu/index.pug
@@ -2,22 +2,26 @@
 - const cpu = medianRun ? (pageInfo.data.browsertime ? pageInfo.data.browsertime.pageSummary.cpu[medianRun.runIndex - 1]: undefined) : pageInfo.data.browsertime.run.cpu
 
 if cpu
-  small
+  //- Quicklinks to the named sections lower on this tab — chip-style
+  //- list replaces the old `| Long tasks | First Input Delay | ...`
+  //- separator strip so the entry point matches the rest of the
+  //- modernised report.
+  ul.listing-quicklinks
     if cpu.longTasks
-      a(href='#long-tasks') Long tasks
-      | &nbsp;|&nbsp;
+      li
+        a(href='#long-tasks') Long tasks
     if browsertime && browsertime.timings && browsertime.timings.firstInput !== undefined
-      a(href='#first-input-delay') First Input Delay
-      | &nbsp;|&nbsp;
+      li
+        a(href='#first-input-delay') First Input Delay
     if cpu.categories
-      a(href='#cpu-time-spent') CPU time spent
-      | &nbsp;|&nbsp;
+      li
+        a(href='#cpu-time-spent') CPU time spent
     if cpu.urls && cpu.urls.length > 0
-      a(href='#cpu-time-spent-per-request') Per request
-      | &nbsp;|&nbsp;
+      li
+        a(href='#cpu-time-spent-per-request') Per request
     if pageInfo.data.thirdparty
-      a(href='#cpu-time-per-tool') Per tool
-      | &nbsp;|&nbsp;
+      li
+        a(href='#cpu-time-per-tool') Per tool
 
 a#cpu
 h2 CPU
@@ -99,26 +103,29 @@ if cpu && cpu.longTasks
         span.cpu-phase-time #{h.time.ms(cpu.longTasks.afterLoadEventEnd.totalDuration.toFixed(0))}
 
     if browsertime && browsertime.pageinfo && browsertime.pageinfo.longTask
-      h4.cpu-section-heading Individual long tasks
-      .responsive
-        table(data-sortable)
-          thead
-            tr
-              th Name
-              th.number Start
-              th.number Duration
-              th Container
-              th Container src
-              th Type
-          tbody
-            each task in browsertime.pageinfo.longTask
+      .listing-card
+        .listing-card-header
+          h4.listing-card-title Individual long tasks
+          span.listing-card-meta #{browsertime.pageinfo.longTask.length} #{browsertime.pageinfo.longTask.length === 1 ? 'task' : 'tasks'}
+        .responsive
+          table(data-sortable)
+            thead
               tr
-                td #{task.name}
-                td.number #{task.startTime.toFixed(0)}
-                td.number #{task.duration.toFixed(0)}
-                td #{task.attribution[0].containerName}
-                td.url.assetsurl #{task.attribution[0].containerSrc}
-                td #{task.attribution[0].containerType}
+                th Name
+                th.number Start
+                th.number Duration
+                th Container
+                th Container src
+                th Type
+            tbody
+              each task in browsertime.pageinfo.longTask
+                tr
+                  td #{task.name}
+                  td.number #{task.startTime.toFixed(0)}
+                  td.number #{task.duration.toFixed(0)}
+                  td #{task.attribution[0].containerName}
+                  td.url.assetsurl #{task.attribution[0].containerSrc}
+                  td #{task.attribution[0].containerType}
   else
     p.cpu-no-tasks ✓ No long tasks observed during this run.
 

--- a/lib/plugins/html/templates/url/pagexray/index.pug
+++ b/lib/plugins/html/templates/url/pagexray/index.pug
@@ -2,27 +2,29 @@ include ../../_tableMixins
 
 - const pagexray = pageInfo.data.pagexray.run || pageInfo.data.pagexray.pageSummary;
 
-small
-  ||
-  a(href='#pagexray-summary') Summary
-  | &nbsp;|&nbsp;
-  a(href='#largest-assets') Largest responses
-  | &nbsp;|&nbsp;
-  a(href='#requests-and-sizes-per-content-type') Per content type
-  | &nbsp;|&nbsp;
-  a(href='#data-per-domain') Per domain
-  | &nbsp;|&nbsp;
-  a(href='#expires-and-last-modified-stats') Expires & last-modified
-  | &nbsp;|&nbsp;
+//- Quicklinks to the named sections in this tab — chip-style list
+//- replaces the old `| A | B |` separator strip so the entry point
+//- matches the rest of the modernised report.
+ul.listing-quicklinks
+  li
+    a(href='#pagexray-summary') Summary
+  li
+    a(href='#largest-assets') Largest responses
+  li
+    a(href='#requests-and-sizes-per-content-type') Per content type
+  li
+    a(href='#data-per-domain') Per domain
+  li
+    a(href='#expires-and-last-modified-stats') Expires & last-modified
   if pageInfo.data.browsertime && pageInfo.data.browsertime.console
-    a(href='#console-log') Console
-    | &nbsp;|&nbsp;
+    li
+      a(href='#console-log') Console
   if pagexray.afterOnLoad.requests > 0
-    a(href='#requests-after-onload') After onLoad
-    | &nbsp;|&nbsp;
+    li
+      a(href='#requests-after-onload') After onLoad
   if pagexray.renderBlocking
-    a(href='#requests-render-blocking') Render-blocking
-    | &nbsp;|&nbsp;
+    li
+      a(href='#requests-render-blocking') Render-blocking
 
 a
 h2 PageXray
@@ -82,24 +84,26 @@ include ./perContentType.pug
 include ./perDomain.pug
 
 a#expires-and-last-modified-stats
-h3 Expires & last-modified statistics
 - expire = pagexray.expireStats
 - lastModified = pagexray.lastModifiedStats
-.responsive
-  table
-    +rowHeading(['type', 'min', 'median', 'max'])
-    if expire
-      tr
-        td(data-title='Type') Expires
-        +durationCell('min', expire.min)
-        +durationCell('median', expire.median)
-        +durationCell('max', expire.max)
-    if lastModified
-      tr
-        td(data-title='Type') Last modified
-        +durationCell('min', lastModified.min)
-        +durationCell('median', lastModified.median)
-        +durationCell('max', lastModified.max)
+.listing-card
+  .listing-card-header
+    h3.listing-card-title Expires & last-modified statistics
+  .responsive
+    table(data-sortable)
+      +rowHeading(['type', 'min', 'median', 'max'])
+      if expire
+        tr
+          td(data-title='Type') Expires
+          +durationCell('min', expire.min)
+          +durationCell('median', expire.median)
+          +durationCell('max', expire.max)
+      if lastModified
+        tr
+          td(data-title='Type') Last modified
+          +durationCell('min', lastModified.min)
+          +durationCell('median', lastModified.median)
+          +durationCell('max', lastModified.max)
 
 if pageInfo.data.browsertime && pageInfo.data.browsertime.console
   include ./console.pug


### PR DESCRIPTION
Budget was still using bare h2/h3/table markup, and the CPU and PageXray tabs had modern KPI tiles up top but bare quicklinks and tables underneath that didn't match the rest of the modernised report.

Wraps the budget tables in .listing-card, swaps the old | A | B | quicklinks strips for chip-style .listing-quicklinks rows, and frames the lingering bare tables (CPU "Individual long tasks", PageXray "Expires & last-modified") in the same card shell.

Co-authored-by: Claude Opus 4.7 noreply@anthropic.com
