### PR TITLE
Modernise PageXray, third-party, filmstrip and First Input layouts

### DIFF
--- a/lib/plugins/html/templates/url/filmstrip/index.pug
+++ b/lib/plugins/html/templates/url/filmstrip/index.pug
@@ -1,44 +1,47 @@
 mixin frame(filmstrip, iteration)
-    - const frameClass =  filmstrip[iteration].timings.length > 0 ? 'videoframe blue' : 'videoframe'
-    a(href=path + filmstrip[iteration].file)
-        img(src=path + filmstrip[iteration].file, alt='', class=frameClass)
-    span.videoframetime #{filmstrip[iteration].time} s
-    each timing in filmstrip[iteration].timings
-        span.videoframetext !{timing.name ? timing.name : timing.metric}
-            b &nbsp;#{h.time.ms(timing.duration || timing.value)}
+  - const frameClass =  filmstrip[iteration].timings.length > 0 ? 'videoframe blue' : 'videoframe'
+  a(href=path + filmstrip[iteration].file)
+    img(src=path + filmstrip[iteration].file, alt='', class=frameClass)
+  span.videoframetime #{filmstrip[iteration].time} s
+  each timing in filmstrip[iteration].timings
+    span.videoframetext !{timing.name ? timing.name : timing.metric}
+      b &nbsp;#{h.time.ms(timing.duration || timing.value)}
 
-small
-    | |&nbsp;
-    a(href='#filmstrip') Filmstrip
-    | &nbsp;|&nbsp;
 a#filmstrip
-h2 Filmstrip
- 
-- const videoIndex = medianRun ? medianRun.runIndex : iteration;
-- const path = 'data/filmstrip/' + videoIndex +'/';
+- const videoIndex = medianRun ? medianRun.runIndex : iteration
+- const path = 'data/filmstrip/' + videoIndex + '/'
+- const filmstripCount = filmstrip ? filmstrip.length : 0
 
-if (options.filmstrip && options.filmstrip.showAll)
-    p
-        | Showing all the filmstrips. Set
-        code  --filmstrip.showAll
-        | to false to only show the ones that contains a change.
-else
-    p
-        | Use
-        code --filmstrip.showAll
-        |  to show all filmstrips.
+//- Wrapping the filmstrip grid in the same .listing-card shell the rest
+//- of the report uses: title + frame-count chip in the header, the
+//- --filmstrip.showAll hint as the help line, and the existing 4-up grid
+//- preserved below.
+.listing-card
+  .listing-card-header
+    h3.listing-card-title Filmstrip
+    span.listing-card-meta #{filmstripCount} #{filmstripCount === 1 ? 'frame' : 'frames'}
+  if (options.filmstrip && options.filmstrip.showAll)
+    p.listing-card-help
+      | Showing all filmstrips. Set&nbsp;
+      code --filmstrip.showAll
+      | &nbsp;to false to only show the ones that contain a change.
+  else
+    p.listing-card-help
+      | Use&nbsp;
+      code --filmstrip.showAll
+      | &nbsp;to show all filmstrips.
 
-if filmstrip
- - for (let i=0; i<filmstrip.length; i=i+4)
-    .row
-     .three.columns.filmstrip
+  if filmstrip
+    - for (let i=0; i<filmstrip.length; i=i+4)
+      .row
+        .three.columns.filmstrip
           +frame(filmstrip, i)
-     if filmstrip[i+1]
-         .three.columns.filmstrip
-             +frame(filmstrip, i+1)
-     if filmstrip[i+2]
-         .three.columns.filmstrip
-             +frame(filmstrip, i+2)
-     if filmstrip[i+3]
-         .three.columns.filmstrip
-             +frame(filmstrip, i+3)
+        if filmstrip[i+1]
+          .three.columns.filmstrip
+            +frame(filmstrip, i+1)
+        if filmstrip[i+2]
+          .three.columns.filmstrip
+            +frame(filmstrip, i+2)
+        if filmstrip[i+3]
+          .three.columns.filmstrip
+            +frame(filmstrip, i+3)

--- a/lib/plugins/html/templates/url/metrics/firstInput.pug
+++ b/lib/plugins/html/templates/url/metrics/firstInput.pug
@@ -1,24 +1,24 @@
 if browsertime.timings.firstInput !== undefined
-    - const fi = browsertime.timings.firstInput
-    a#firstInput
-    h3 First Input Delay
-    p Measured First Input Delay.
-    details.iter-group(open)
-        summary.iter-group-summary
-            span.iter-group-title #{fi.name}
-        .metric-tiles
-            .metric-tile
-                span.metric-tile-label Delay
-                span.metric-tile-value #{h.time.ms(fi.delay)}
-            .metric-tile
-                span.metric-tile-label Duration
-                span.metric-tile-value #{h.time.ms(fi.duration)}
-            .metric-tile
-                span.metric-tile-label Start time
-                span.metric-tile-value #{h.time.ms(fi.startTime)}
-            .metric-tile
-                span.metric-tile-label Processing start
-                span.metric-tile-value #{h.time.ms(fi.processingStart)}
-            .metric-tile
-                span.metric-tile-label Processing end
-                span.metric-tile-value #{h.time.ms(fi.processingEnd)}
+  - const fi = browsertime.timings.firstInput
+  a#firstInput
+  .listing-card
+    .listing-card-header
+      h3.listing-card-title First Input Delay
+      span.listing-card-meta Event: #{fi.name}
+    p.listing-card-help Time from the first user interaction to when the browser could respond.
+    .metric-tiles
+      .metric-tile
+        span.metric-tile-label Delay
+        span.metric-tile-value #{h.time.ms(fi.delay)}
+      .metric-tile
+        span.metric-tile-label Duration
+        span.metric-tile-value #{h.time.ms(fi.duration)}
+      .metric-tile
+        span.metric-tile-label Start time
+        span.metric-tile-value #{h.time.ms(fi.startTime)}
+      .metric-tile
+        span.metric-tile-label Processing start
+        span.metric-tile-value #{h.time.ms(fi.processingStart)}
+      .metric-tile
+        span.metric-tile-label Processing end
+        span.metric-tile-value #{h.time.ms(fi.processingEnd)}

--- a/lib/plugins/html/templates/url/pagexray/after.pug
+++ b/lib/plugins/html/templates/url/pagexray/after.pug
@@ -1,35 +1,42 @@
 if pagexray.afterOnLoad.requests > 0
-    a#requests-after-onload
-    h3 Requests loaded after onLoad event
-    p.small Included requests done after 
-        a(href='https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event') load event end
-        | . 
-        
-    table(data-sortable, id='contentSizeAfterOnload')
+  a#requests-after-onload
+  .listing-card
+    .listing-card-header
+      h3.listing-card-title Requests loaded after onLoad event
+      span.listing-card-meta #{pagexray.afterOnLoad.requests} #{pagexray.afterOnLoad.requests === 1 ? 'request' : 'requests'}
+    p.listing-card-help Includes requests done after&nbsp;
+      a(href='https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event') load event end
+      | .
+    .responsive
+      table(data-sortable, id='contentSizeAfterOnload')
         +rowHeading(['Content', 'Transfer Size', 'Requests'])
         each data, type in pagexray.afterOnLoad.contentTypes
-            tr
-                td(data-title='Content Type') #{type}
-                +sizeCell('transferSize', data.transferSize)
-                +numberCell('requests', data.requests)
+          tr
+            td(data-title='Content Type') #{type}
+            +sizeCell('transferSize', data.transferSize)
+            +numberCell('requests', data.requests)
         tr
-                td(data-title='Total') Total
-                +sizeCell('transferSize', pagexray.afterOnLoad.transferSize)
-                +numberCell('requests', pagexray.afterOnLoad.requests)        
+          td(data-title='Total') Total
+          +sizeCell('transferSize', pagexray.afterOnLoad.transferSize)
+          +numberCell('requests', pagexray.afterOnLoad.requests)
 
 if pagexray.afterOnContentLoad.requests > 0
-    h3 Requests loaded after onContentLoad 
-    p.small Includes requests done after 
-        a(href='https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event') DOM content loaded
-        | . 
-    table(data-sortable, id='contentSizeAfterOnContentload')
+  .listing-card
+    .listing-card-header
+      h3.listing-card-title Requests loaded after onContentLoad
+      span.listing-card-meta #{pagexray.afterOnContentLoad.requests} #{pagexray.afterOnContentLoad.requests === 1 ? 'request' : 'requests'}
+    p.listing-card-help Includes requests done after&nbsp;
+      a(href='https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event') DOM content loaded
+      | .
+    .responsive
+      table(data-sortable, id='contentSizeAfterOnContentload')
         +rowHeading(['Content', 'Transfer Size', 'Requests'])
         each data, type in pagexray.afterOnContentLoad.contentTypes
-            tr
-                td(data-title='Content Type') #{type}
-                +sizeCell('transferSize', data.transferSize)
-                +numberCell('requests', data.requests)
+          tr
+            td(data-title='Content Type') #{type}
+            +sizeCell('transferSize', data.transferSize)
+            +numberCell('requests', data.requests)
         tr
-                td(data-title='Total') Total
-                +sizeCell('transferSize', pagexray.afterOnContentLoad.transferSize)
-                +numberCell('requests', pagexray.afterOnContentLoad.requests)
+          td(data-title='Total') Total
+          +sizeCell('transferSize', pagexray.afterOnContentLoad.transferSize)
+          +numberCell('requests', pagexray.afterOnContentLoad.requests)

--- a/lib/plugins/html/templates/url/pagexray/blocking.pug
+++ b/lib/plugins/html/templates/url/pagexray/blocking.pug
@@ -1,22 +1,29 @@
 if pagexray.renderBlocking
-    a#requests-render-blocking
-    h3 Render blocking requests
-    p Render blocking information directly from Chrome.
+  a#requests-render-blocking
+  - const renderBlockingAssets = pagexray.assets.filter(a => a.renderBlocking)
+  .listing-card
+    .listing-card-header
+      h3.listing-card-title Render blocking requests
+      span.listing-card-meta #{renderBlockingAssets.length} #{renderBlockingAssets.length === 1 ? 'asset' : 'assets'}
+    p.listing-card-help Render blocking information directly from Chrome.
     .responsive
-        table(data-sortable, id='contentSizeAfterOnload')
-            +rowHeading(['Blocking', 'In body parser blocking', 'Potentially blocking'])
-            tr
-                +numberCell('blocking', pagexray.renderBlocking.blocking)   
-                +numberCell('in_body_parser_blocking', pagexray.renderBlocking.in_body_parser_blocking)   
-                +numberCell('potentiallyBlocking', pagexray.renderBlocking.potentiallyBlocking)    
+      table(data-sortable, id='renderBlockingSummary')
+        +rowHeading(['Blocking', 'In body parser blocking', 'Potentially blocking'])
+        tr
+          +numberCell('blocking', pagexray.renderBlocking.blocking)
+          +numberCell('in_body_parser_blocking', pagexray.renderBlocking.in_body_parser_blocking)
+          +numberCell('potentiallyBlocking', pagexray.renderBlocking.potentiallyBlocking)
 
-    h4 Render information 
-    .responsive
+  if renderBlockingAssets.length > 0
+    .listing-card
+      .listing-card-header
+        h4.listing-card-title Render blocking assets
+        span.listing-card-meta #{renderBlockingAssets.length} #{renderBlockingAssets.length === 1 ? 'asset' : 'assets'}
+      .responsive
         table(data-sortable, id='renderBlockingAssets')
-            +rowHeading(['URL', 'Type'])
-            each asset in pagexray.assets
-                if asset.renderBlocking
-                    tr
-                        td.url.assetsurl(data-title='URL')
-                            a(href=asset.url)= h.shortAsset(asset.url)
-                        td(data-title='Render Blocking Type') #{asset.renderBlocking}
+          +rowHeading(['URL', 'Type'])
+          each asset in renderBlockingAssets
+            tr
+              td.url.assetsurl(data-title='URL')
+                a(href=asset.url)= h.shortAsset(asset.url)
+              td(data-title='Render Blocking Type') #{asset.renderBlocking}

--- a/lib/plugins/html/templates/url/pagexray/console.pug
+++ b/lib/plugins/html/templates/url/pagexray/console.pug
@@ -1,15 +1,19 @@
-h3 Console log
 if pageInfo.data.browsertime.console.length > 0
-    a#console-log
-    p The page logs the following messages to the console.
+  a#console-log
+  .listing-card
+    .listing-card-header
+      h3.listing-card-title Console log
+      - const consoleCount = pageInfo.data.browsertime.console.length
+      span.listing-card-meta #{consoleCount} #{consoleCount === 1 ? 'message' : 'messages'}
+    p.listing-card-help The page logs the following messages to the console.
     .responsive
-        table
+      table(data-sortable, id='consoleLog')
+        thead
+          tr
+            th Level
+            th Message
+        tbody
+          each consoleLog in pageInfo.data.browsertime.console
             tr
-                th Level
-                th Message     
-            each consoleLog in pageInfo.data.browsertime.console
-                tr
-                    td(data-title='Level') #{consoleLog.level} 
-                    td.url(data-title='Message') #{consoleLog.message}
-else 
-    p No console log messages.
+              td(data-title='Level') #{consoleLog.level}
+              td.url(data-title='Message') #{consoleLog.message}

--- a/lib/plugins/html/templates/url/pagexray/largest.pug
+++ b/lib/plugins/html/templates/url/pagexray/largest.pug
@@ -1,20 +1,27 @@
-
 include ../../_tableMixins
 
 - pagexray.assets.sort(function(a, b){return b.transferSize-a.transferSize})
+- const largestCap = 20
+- const largestShown = Math.min(largestCap, pagexray.assets.length)
 
 a#largest-assets
-h3 Largest assets on the page (by transfer size)
-.responsive
-  table(data-sortable, id='largestAssetsOnThePage')
-    +rowHeading(['URL', 'Type', 'Transfer Size', 'Content Size'])
-    - let n = 0;
-    each asset in pagexray.assets
-     tr
-      td.url.assetsurl(data-title='URL')
-        a(href=asset.url)= h.shortAsset(asset.url)
-      td(data-title='Content Type') #{asset.type}
-      +sizeCell('transferSize', asset.transferSize)
-      +sizeCell('contentSize', asset.contentSize)
-      - n++
-      - if (n>19) break
+.listing-card
+  .listing-card-header
+    h3.listing-card-title Largest assets on the page (by transfer size)
+    if pagexray.assets.length > largestCap
+      span.listing-card-meta Top #{largestCap} of #{pagexray.assets.length}
+    else
+      span.listing-card-meta #{largestShown} #{largestShown === 1 ? 'asset' : 'assets'}
+  .responsive
+    table(data-sortable, id='largestAssetsOnThePage')
+      +rowHeading(['URL', 'Type', 'Transfer Size', 'Content Size'])
+      - let n = 0
+      each asset in pagexray.assets
+        tr
+          td.url.assetsurl(data-title='URL')
+            a(href=asset.url)= h.shortAsset(asset.url)
+          td(data-title='Content Type') #{asset.type}
+          +sizeCell('transferSize', asset.transferSize)
+          +sizeCell('contentSize', asset.contentSize)
+        - n++
+        - if (n >= largestCap) break

--- a/lib/plugins/html/templates/url/pagexray/perContentType.pug
+++ b/lib/plugins/html/templates/url/pagexray/perContentType.pug
@@ -2,35 +2,39 @@
 - totalTransferSize = 0
 - totalHeaderSize = 0
 - totalRequests = 0
-a#requests-and-sizes-per-content-type
-h3 Requests and sizes per content type
+- const contentTypeCount = Object.values(pagexray.contentTypes).filter(d => d.requests > 0).length
 
-.responsive
-  table(data-sortable, id='contentSize')
-    +rowHeading(['Content', 'Header Size', 'Transfer Size', 'Content Size', 'Requests'])
-    - numberOfRequestsLabels = []
-    - numberOfRequests = []
-    - transferSizeOfRequests = []
-    - contentSizeOfRequests = []
-    each data, type in pagexray.contentTypes
-      - totalContentSize += data.contentSize
-      - totalTransferSize += data.transferSize
-      - totalHeaderSize += data.headerSize > 0 ? data.headerSize : 0
-      - totalRequests += data.requests
-      if data.requests > 0
-        - numberOfRequestsLabels.push(type)
-        - numberOfRequests.push({meta: type, value: data.requests})
-        - transferSizeOfRequests.push({meta: type + ' transfer size (kb)', value: h.size.asKb(data.transferSize)})
-        - contentSizeOfRequests.push({meta: type + ' content size (kb)', value: h.size.asKb(data.contentSize)})
-        tr
-          td(data-title='Content Type') #{type}
-          +sizeCell('headerSize', data.headerSize)
-          +sizeCell('transferSize', data.transferSize)
-          +sizeCell('contentSize', data.contentSize)
-          +numberCell('requests', data.requests)
-    tr
-      td(data-title='Total') Total
-      +sizeCell('headerSize', totalHeaderSize)
-      +sizeCell('transferSize', totalTransferSize)
-      +sizeCell('contentSize', totalContentSize)
-      +numberCell('requests', totalRequests)
+a#requests-and-sizes-per-content-type
+.listing-card
+  .listing-card-header
+    h3.listing-card-title Requests and sizes per content type
+    span.listing-card-meta #{contentTypeCount} #{contentTypeCount === 1 ? 'type' : 'types'}
+  .responsive
+    table(data-sortable, id='contentSize')
+      +rowHeading(['Content', 'Header Size', 'Transfer Size', 'Content Size', 'Requests'])
+      - numberOfRequestsLabels = []
+      - numberOfRequests = []
+      - transferSizeOfRequests = []
+      - contentSizeOfRequests = []
+      each data, type in pagexray.contentTypes
+        - totalContentSize += data.contentSize
+        - totalTransferSize += data.transferSize
+        - totalHeaderSize += data.headerSize > 0 ? data.headerSize : 0
+        - totalRequests += data.requests
+        if data.requests > 0
+          - numberOfRequestsLabels.push(type)
+          - numberOfRequests.push({meta: type, value: data.requests})
+          - transferSizeOfRequests.push({meta: type + ' transfer size (kb)', value: h.size.asKb(data.transferSize)})
+          - contentSizeOfRequests.push({meta: type + ' content size (kb)', value: h.size.asKb(data.contentSize)})
+          tr
+            td(data-title='Content Type') #{type}
+            +sizeCell('headerSize', data.headerSize)
+            +sizeCell('transferSize', data.transferSize)
+            +sizeCell('contentSize', data.contentSize)
+            +numberCell('requests', data.requests)
+      tr
+        td(data-title='Total') Total
+        +sizeCell('headerSize', totalHeaderSize)
+        +sizeCell('transferSize', totalTransferSize)
+        +sizeCell('contentSize', totalContentSize)
+        +numberCell('requests', totalRequests)

--- a/lib/plugins/html/templates/url/pagexray/perDomain.pug
+++ b/lib/plugins/html/templates/url/pagexray/perDomain.pug
@@ -1,12 +1,17 @@
+- const perDomainCount = Object.keys(pagexray.domains).length
+
 a#data-per-domain
-h3 Data per domain
-.responsive
-  table(data-sortable, id='contentSizePerDomain')
-    +rowHeading(['Domain', 'Total download time', 'Transfer Size', 'Content Size', 'Requests'])
-    each data, domain in pagexray.domains
-      tr
-        td(data-title='Domain') #{domain}
-        +timeCell('totalTime', data.totalTime)
-        +sizeCell('transferSize', data.transferSize)
-        +sizeCell('contentSize', data.contentSize)
-        +numberCell('requests', data.requests)
+.listing-card
+  .listing-card-header
+    h3.listing-card-title Data per domain
+    span.listing-card-meta #{perDomainCount} #{perDomainCount === 1 ? 'domain' : 'domains'}
+  .responsive
+    table(data-sortable, id='contentSizePerDomain')
+      +rowHeading(['Domain', 'Total download time', 'Transfer Size', 'Content Size', 'Requests'])
+      each data, domain in pagexray.domains
+        tr
+          td(data-title='Domain') #{domain}
+          +timeCell('totalTime', data.totalTime)
+          +sizeCell('transferSize', data.transferSize)
+          +sizeCell('contentSize', data.contentSize)
+          +numberCell('requests', data.requests)

--- a/lib/plugins/html/templates/url/thirdparty/firstParty.pug
+++ b/lib/plugins/html/templates/url/thirdparty/firstParty.pug
@@ -1,40 +1,49 @@
+- const fpContentTypeCount = Object.values(pagexray.firstParty.contentTypes).filter(d => d.requests > 0).length
+- const tpContentTypeCount = Object.values(pagexray.thirdParty.contentTypes).filter(d => d.requests > 0).length
+
 a#first-vs-third
-h3 First party requests and sizes per content type
-p Calculated using #{pagexray.firstPartyRegEx} (use 
-    code --firstParty 
-    | to configure).
-.responsive
+.listing-card
+  .listing-card-header
+    h3.listing-card-title First party requests and sizes per content type
+    span.listing-card-meta #{pagexray.firstParty.requests} #{pagexray.firstParty.requests === 1 ? 'request' : 'requests'}
+  p.listing-card-help Calculated using #{pagexray.firstPartyRegEx} (use&nbsp;
+    code --firstParty
+    | &nbsp;to configure).
+  .responsive
     table(data-sortable, id='contentSizeFirstParty')
-        +rowHeading(['Content', 'Header Size', 'Transfer Size', 'Content Size', 'Requests'])
-        each data, type in pagexray.firstParty.contentTypes
-            tr
-                td(data-title='Content Type') #{type}
-                +sizeCell('headerSize', data.headerSize)
-                +sizeCell('transferSize', data.transferSize)
-                +sizeCell('contentSize', data.contentSize)
-                +numberCell('requests', data.requests)
+      +rowHeading(['Content', 'Header Size', 'Transfer Size', 'Content Size', 'Requests'])
+      each data, type in pagexray.firstParty.contentTypes
         tr
-            td(data-title='Total') Total
-            +sizeCell('headerSize', pagexray.firstParty.headerSize)
-            +sizeCell('transferSize', pagexray.firstParty.transferSize)
-            +sizeCell('contentSize', pagexray.firstParty.contentSize)
-            +numberCell('requests', pagexray.firstParty.requests)
+          td(data-title='Content Type') #{type}
+          +sizeCell('headerSize', data.headerSize)
+          +sizeCell('transferSize', data.transferSize)
+          +sizeCell('contentSize', data.contentSize)
+          +numberCell('requests', data.requests)
+      tr
+        td(data-title='Total') Total
+        +sizeCell('headerSize', pagexray.firstParty.headerSize)
+        +sizeCell('transferSize', pagexray.firstParty.transferSize)
+        +sizeCell('contentSize', pagexray.firstParty.contentSize)
+        +numberCell('requests', pagexray.firstParty.requests)
 
 a#third-party
-h3 Third party requests and sizes per content type
-.responsive
+.listing-card
+  .listing-card-header
+    h3.listing-card-title Third party requests and sizes per content type
+    span.listing-card-meta #{pagexray.thirdParty.requests} #{pagexray.thirdParty.requests === 1 ? 'request' : 'requests'}
+  .responsive
     table(data-sortable, id='contentSizeThirdParty')
-        +rowHeading(['Content', 'Header Size', 'Transfer Size', 'Content Size', 'Requests'])
-        each data, type in pagexray.thirdParty.contentTypes
-            tr
-                td(data-title='Content Type') #{type}
-                +sizeCell('headerSize', data.headerSize)
-                +sizeCell('transferSize', data.transferSize)
-                +sizeCell('contentSize', data.contentSize)
-                +numberCell('requests', data.requests)
+      +rowHeading(['Content', 'Header Size', 'Transfer Size', 'Content Size', 'Requests'])
+      each data, type in pagexray.thirdParty.contentTypes
         tr
-            td(data-title='Total') Total
-            +sizeCell('headerSize', pagexray.thirdParty.headerSize)
-            +sizeCell('transferSize', pagexray.thirdParty.transferSize)
-            +sizeCell('contentSize', pagexray.thirdParty.contentSize)
-            +numberCell('requests', pagexray.thirdParty.requests)
+          td(data-title='Content Type') #{type}
+          +sizeCell('headerSize', data.headerSize)
+          +sizeCell('transferSize', data.transferSize)
+          +sizeCell('contentSize', data.contentSize)
+          +numberCell('requests', data.requests)
+      tr
+        td(data-title='Total') Total
+        +sizeCell('headerSize', pagexray.thirdParty.headerSize)
+        +sizeCell('transferSize', pagexray.thirdParty.transferSize)
+        +sizeCell('contentSize', pagexray.thirdParty.contentSize)
+        +numberCell('requests', pagexray.thirdParty.requests)

--- a/lib/plugins/html/templates/url/thirdparty/index.pug
+++ b/lib/plugins/html/templates/url/thirdparty/index.pug
@@ -66,64 +66,74 @@ if pageInfo.data.coach
     //- Categories as a horizontal bar list (replaces two tiny side-by-side
     //- tables). Each row shows requests share + tool count for the category.
     if tpHasCategories
-        h3 Categories
         - const tpCatEntries = Object.entries(thirdparty.category).filter(e => e[0] !== 'unknown').map(e => ({name: e[0], requests: (e[1] && e[1].requests ? e[1].requests.median : e[1])})).sort((a, b) => b.requests - a.requests)
         - const tpCatMax = tpCatEntries.length > 0 ? tpCatEntries[0].requests : 0
-        .tp-bars
-            each entry in tpCatEntries
-                - const pct = tpCatMax > 0 ? (entry.requests / tpCatMax * 100) : 0
-                - const toolCount = thirdparty.toolsByCategory && thirdparty.toolsByCategory[entry.name] ? Object.keys(thirdparty.toolsByCategory[entry.name]).length : 0
-                .tp-bar-row
-                    span.tp-bar-label #{entry.name}
-                    .tp-bar-track
-                        span.tp-bar-fill(style='width: ' + pct.toFixed(2) + '%')
-                    span.tp-bar-value #{entry.requests} req · #{toolCount} #{toolCount === 1 ? 'tool' : 'tools'}
+        .listing-card
+            .listing-card-header
+                h3.listing-card-title Categories
+                span.listing-card-meta #{tpCatEntries.length} #{tpCatEntries.length === 1 ? 'category' : 'categories'}
+            .tp-bars
+                each entry in tpCatEntries
+                    - const pct = tpCatMax > 0 ? (entry.requests / tpCatMax * 100) : 0
+                    - const toolCount = thirdparty.toolsByCategory && thirdparty.toolsByCategory[entry.name] ? Object.keys(thirdparty.toolsByCategory[entry.name]).length : 0
+                    .tp-bar-row
+                        span.tp-bar-label #{entry.name}
+                        .tp-bar-track
+                            span.tp-bar-fill(style='width: ' + pct.toFixed(2) + '%')
+                        span.tp-bar-value #{entry.requests} req · #{toolCount} #{toolCount === 1 ? 'tool' : 'tools'}
 
     //- Tools per category as <details> cards. Replaces the old
     //- toggleRow() JS with native disclosure: collapsed by default,
     //- expand to see the deduped tool list and the underlying URLs.
     if tpHasAssets
         a#third-party-tools
-        h3 Third party requests and tools
-        .tp-tools
-            each category in Object.keys(thirdparty.assets)
-                - const assets = thirdparty.assets[category]
-                - const seen = new Set()
-                - const tools = []
-                each asset in assets
-                    if !seen.has(asset.entity.name)
-                        - seen.add(asset.entity.name)
-                        - tools.push(asset.entity)
-                details.tp-tool-card
-                    summary.tp-tool-summary
-                        span.tp-tool-category #{category}
-                        span.tp-tool-meta #{assets.length} requests · #{tools.length} #{tools.length === 1 ? 'tool' : 'tools'}
-                    .tp-tool-body
-                        ul.tp-tool-entities
-                            each tool in tools
-                                li
-                                    if tool.homepage
-                                        a(href=tool.homepage) #{tool.name}
-                                    else
-                                        span #{tool.name}
-                        ul.tp-tool-urls
-                            each asset in assets
-                                li
-                                    a(href=asset.url) #{h.shortAsset(asset.url, true)}
-                                    span.tp-tool-urls-entity (#{asset.entity.name})
+        .listing-card
+            .listing-card-header
+                h3.listing-card-title Third party requests and tools
+                span.listing-card-meta #{Object.keys(thirdparty.assets).length} #{Object.keys(thirdparty.assets).length === 1 ? 'category' : 'categories'}
+            .tp-tools
+                each category in Object.keys(thirdparty.assets)
+                    - const assets = thirdparty.assets[category]
+                    - const seen = new Set()
+                    - const tools = []
+                    each asset in assets
+                        if !seen.has(asset.entity.name)
+                            - seen.add(asset.entity.name)
+                            - tools.push(asset.entity)
+                    details.tp-tool-card
+                        summary.tp-tool-summary
+                            span.tp-tool-category #{category}
+                            span.tp-tool-meta #{assets.length} requests · #{tools.length} #{tools.length === 1 ? 'tool' : 'tools'}
+                        .tp-tool-body
+                            ul.tp-tool-entities
+                                each tool in tools
+                                    li
+                                        if tool.homepage
+                                            a(href=tool.homepage) #{tool.name}
+                                        else
+                                            span #{tool.name}
+                            ul.tp-tool-urls
+                                each asset in assets
+                                    li
+                                        a(href=asset.url) #{h.shortAsset(asset.url, true)}
+                                        span.tp-tool-urls-entity (#{asset.entity.name})
 
     //- Unmatched third-party domains: short, scannable list rather than a
     //- full-width table.
     if tpUnmatched
-        h3 Unmatched third party domains
-        p Domains that didn't match any tool in&nbsp;
-            a(href='https://github.com/patrickhulce/third-party-web') Third party web
-            | . If you are sure they are third party domains, please do a PR to that project. You can also fine tune the list using
-            code --firstParty
-            | .
-        ul.tp-unmatched
-            each domain in thirdparty.possibileMissedThirdPartyDomains
-                li.tp-unmatched-item #{domain}
+        .listing-card
+            .listing-card-header
+                h3.listing-card-title Unmatched third party domains
+                span.listing-card-meta #{thirdparty.possibileMissedThirdPartyDomains.length} #{thirdparty.possibileMissedThirdPartyDomains.length === 1 ? 'domain' : 'domains'}
+            p.listing-card-help
+                | Domains that didn't match any tool in&nbsp;
+                a(href='https://github.com/patrickhulce/third-party-web') Third party web
+                | . If you are sure they are third party domains, please do a PR to that project. You can also fine tune the list using&nbsp;
+                code --firstParty
+                | .
+            ul.tp-unmatched
+                each domain in thirdparty.possibileMissedThirdPartyDomains
+                    li.tp-unmatched-item #{domain}
 
     include ./thirdPartyCookies.pug
 


### PR DESCRIPTION
The remaining "old" pages all had the same shape: a modern hero band on top (KPI tiles, scoreboards) followed by bare h3/table markup that looked stuck a few releases behind. Each tab now ends in the same .listing-card shell the rest of the report uses.

Co-authored-by: Claude Opus 4.7 noreply@anthropic.com
