### PR TITLE
Filter, theme and label the waterfall

### DIFF
--- a/lib/plugins/html/templates/url/waterfall/_waterfallRender.pug
+++ b/lib/plugins/html/templates/url/waterfall/_waterfallRender.pug
@@ -46,10 +46,51 @@ script(type='text/javascript').
       showLongtasks: document.getElementById('wt-show-longtasks'),
       connectionView: document.getElementById('wt-connection-view')
     };
+    const filterEl = document.getElementById('wt-req-filter');
+    const filterCountEl = document.getElementById('wt-req-filter-count');
+    let currentPageId = initialPageId;
+    // waterfall-tools `reqFilter` accepts a comma-separated list of 1-based
+    // request indices (within the active page), not a URL substring. To make
+    // the search box behave the obvious way, we resolve the user's substring
+    // against the page's entries here and hand the renderer the matching
+    // indices. Empty input → renderer sees '' → all requests visible.
+    // Substring with zero matches → '0' → renderer filters everything out
+    // (1-based indices never include 0), which is what the user asked for.
+    const resolveReqFilter = query => {
+      const q = (query || '').trim().toLowerCase();
+      if (!q) return { value: '', count: null, total: null };
+      const pageEntries = ((har.log && har.log.entries) || [])
+        .filter(e => e.pageref === currentPageId);
+      const matched = [];
+      pageEntries.forEach((e, i) => {
+        const url = ((e.request && e.request.url) || e._URL || '').toLowerCase();
+        if (url.includes(q)) matched.push(i + 1);
+      });
+      return {
+        value: matched.length === 0 ? '0' : matched.join(','),
+        count: matched.length,
+        total: pageEntries.length
+      };
+    };
+    const updateFilterCount = info => {
+      if (!filterCountEl) return;
+      if (info.count === null) {
+        filterCountEl.hidden = true;
+        filterCountEl.textContent = '';
+      } else {
+        filterCountEl.hidden = false;
+        filterCountEl.textContent = info.count + ' of ' + info.total;
+      }
+    };
     const readOptions = () => {
       const o = {};
       for (const k of Object.keys(controls)) {
         if (controls[k]) o[k] = controls[k].checked;
+      }
+      if (filterEl) {
+        const info = resolveReqFilter(filterEl.value);
+        o.reqFilter = info.value;
+        updateFilterCount(info);
       }
       return o;
     };
@@ -453,10 +494,27 @@ script(type='text/javascript').
       openDetail();
     };
 
+    // Theme the canvas to match the surrounding sitespeed.io card. The
+    // renderer's defaults are tuned for the standalone WPT-style viewer
+    // (pure black border, neutral grey stripes); inside our card those
+    // read as visually heavy. Slate text + softened border + slightly
+    // cooler stripe align the canvas with the card chrome. Functional
+    // colours (`longTask`, `userTimingMark`, MIME-type bars, page-event
+    // markers) are intentionally left at their defaults — those carry
+    // semantic meaning we don't want to override.
+    const palette = {
+      text: '#0f172a',
+      titleText: '#3a4250',
+      rowStripe: '#f4f6fa',
+      border: '#e3e7ed',
+      grid: 'rgb(214, 219, 224)'
+    };
+
     const renderer = await wt.renderTo(container, {
       ...WaterfallTools.getDefaultOptions(),
       ...readOptions(),
       pageId: initialPageId,
+      palette,
       onHover,
       onClick
     });
@@ -585,6 +643,21 @@ script(type='text/javascript').
       }
     }
 
+    // Debounce the URL filter — the renderer rebuilds layout on every
+    // updateOptions, so firing per-keystroke on a thousand-request HAR
+    // jitters the UI badly.
+    if (filterEl) {
+      let filterTimer = null;
+      filterEl.addEventListener('input', () => {
+        if (filterTimer) clearTimeout(filterTimer);
+        filterTimer = setTimeout(() => {
+          const info = resolveReqFilter(filterEl.value);
+          renderer.updateOptions({ reqFilter: info.value });
+          updateFilterCount(info);
+        }, 120);
+      });
+    }
+
     const selector = document.getElementById('page-selector');
     if (selector && pages.length > 1) {
       for (const page of pages) {
@@ -595,9 +668,12 @@ script(type='text/javascript').
         selector.appendChild(opt);
       }
       selector.addEventListener('change', () => {
-        renderer.updateOptions({ pageId: selector.value });
-        populateUserTimings(selector.value);
-        populateExtLegend(selector.value);
+        currentPageId = selector.value;
+        const info = filterEl ? resolveReqFilter(filterEl.value) : { value: '', count: null, total: null };
+        renderer.updateOptions({ pageId: currentPageId, reqFilter: info.value });
+        populateUserTimings(currentPageId);
+        populateExtLegend(currentPageId);
+        updateFilterCount(info);
       });
     }
   })();

--- a/lib/plugins/html/templates/url/waterfall/index.pug
+++ b/lib/plugins/html/templates/url/waterfall/index.pug
@@ -46,10 +46,38 @@ style.
     box-shadow: 0 1px 2px rgba(0, 149, 210, 0.25);
   }
   .waterfall-controls input { margin: 0; accent-color: #fff; }
+  .waterfall-filter {
+    display: inline-flex; align-items: center; gap: 0.5em;
+    flex: 0 1 360px; min-width: 200px;
+  }
+  .waterfall-filter input {
+    width: 100%;
+    padding: 0.35em 0.85em;
+    border: 1px solid #d6dbe0;
+    border-radius: 999px;
+    background: #fff;
+    color: #3a4250;
+    font: inherit; font-size: 0.95em;
+    transition: border-color 120ms, box-shadow 120ms;
+  }
+  .waterfall-filter input::placeholder { color: #9aa3af; }
+  .waterfall-filter input:focus {
+    outline: none;
+    border-color: #0095d2;
+    box-shadow: 0 0 0 3px rgba(0, 149, 210, 0.18);
+  }
+  .waterfall-filter-count {
+    font-size: 0.85em; color: #5b6370; white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .waterfall-legend .marker-x {
+    display: inline-flex; width: 12px; height: 12px;
+  }
   .waterfall-legend { display: flex; flex-wrap: wrap; gap: 0.4em 1.1em; margin: 0 0 0.75em; font-size: 0.9em; color: #5b6370; letter-spacing: 0.01em; }
   .waterfall-legend > span { display: inline-flex; align-items: center; gap: 0.4em; }
   .waterfall-legend .swatch { display: inline-block; width: 10px; height: 10px; border-radius: 3px; }
   .waterfall-legend .swatch.dashed { height: 0; border-top: 2px dashed currentColor; width: 16px; border-radius: 0; }
+  .waterfall-legend .swatch.row { width: 18px; height: 8px; border-radius: 2px; }
   .waterfall-canvas-wrap {
     border-radius: 8px;
     overflow: hidden;
@@ -344,6 +372,10 @@ style.
         input(type='checkbox', id='wt-connection-view')
         span Connection view
 
+    .waterfall-filter
+      input(type='search', id='wt-req-filter', placeholder='Filter requests by URL…', aria-label='Filter requests by URL')
+      span.waterfall-filter-count#wt-req-filter-count(hidden)
+
   .waterfall-legend(aria-label='Page metric colors')
     span(title='First Paint')
       span.swatch(style='background: rgb(40,188,0)')
@@ -363,6 +395,19 @@ style.
     span(title='Load event end')
       span.swatch(style='background: rgb(0,0,255)')
       | Load
+    span(title='Render-blocking resource — blocks first paint until it has loaded')
+      span.marker-x
+        svg(width='12', height='12', viewBox='0 0 14 14', aria-hidden='true')
+          circle(cx='7', cy='7', r='7', fill='#ff9900')
+          line(x1='4', y1='4', x2='10', y2='10', stroke='#fff', stroke-width='1.5', stroke-linecap='round')
+          line(x1='10', y1='4', x2='4', y2='10', stroke='#fff', stroke-width='1.5', stroke-linecap='round')
+      | Render-blocking
+    span(title='Redirect (3xx response)')
+      span.swatch.row(style='background: rgb(255,255,96)')
+      | Redirect
+    span(title='Error response (4xx, 5xx, or failed request)')
+      span.swatch.row(style='background: rgb(255,96,96)')
+      | Error
 
   .waterfall-canvas-wrap
     if options.html.fetchHARFiles

--- a/lib/plugins/html/templates/url/waterfall/index.pug
+++ b/lib/plugins/html/templates/url/waterfall/index.pug
@@ -396,8 +396,12 @@ style.
       span.swatch(style='background: rgb(0,0,255)')
       | Load
     span(title='Render-blocking resource — blocks first paint until it has loaded')
+      //- viewBox is intentionally lowercased — pug-lint rejects camelCase
+      //- attributes, and the HTML5 parser's inline-SVG attribute-adjustment
+      //- table normalises `viewbox` back to the SVG-namespace `viewBox`
+      //- before the renderer sees it, so the output renders identically.
       span.marker-x
-        svg(width='12', height='12', viewBox='0 0 14 14', aria-hidden='true')
+        svg(width='12', height='12', viewbox='0 0 14 14', aria-hidden='true')
           circle(cx='7', cy='7', r='7', fill='#ff9900')
           line(x1='4', y1='4', x2='10', y2='10', stroke='#fff', stroke-width='1.5', stroke-linecap='round')
           line(x1='10', y1='4', x2='4', y2='10', stroke='#fff', stroke-width='1.5', stroke-linecap='round')


### PR DESCRIPTION
Three small follow-ups to the per-request detail panel landed in #4684. A search box in the waterfall card header lets users narrow long pages by URL substring; under the hood it resolves the substring against the active page's entries and feeds waterfall-tools' index-based reqFilter, with a small "N of M" counter so the result count is obvious. The canvas itself gets a palette override so its border, gridlines and row stripes match the slate/blue card chrome around it instead of carrying the standalone-viewer black border into the report. And the legend gains explanations for three visuals that were previously a mystery to anyone reading the report cold: the orange render-blocking circle, the yellow redirect row tint, and the red error row tint.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
