### PR TITLE
docs: refresh stale links and version references

### DIFF
--- a/docs/documentation/browsertime/introduction/index.md
+++ b/docs/documentation/browsertime/introduction/index.md
@@ -35,7 +35,7 @@ It is usually used for two different things:
 To understand how Browsertime does these things, let's talk about how it works. Here's an example of what happens when you give Browsertime a URL to test:
 
 1. You give your configuration to Browsertime.
-2. Browsertime uses the [WebDriver](https://www.w3.org/TR/webdriver/) (through [Selenium](http://seleniumhq.github.io/selenium/docs/api/javascript/index.html)) to start Firefox and Chrome (the implementations for the WebDriver is [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/)/[GeckoDriver](https://github.com/mozilla/geckodriver/)).
+2. Browsertime uses the [WebDriver](https://www.w3.org/TR/webdriver/) (through [Selenium](https://www.selenium.dev/selenium/docs/api/javascript/)) to start Firefox and Chrome (the implementations for the WebDriver is [ChromeDriver](https://developer.chrome.com/docs/chromedriver)/[GeckoDriver](https://github.com/mozilla/geckodriver/)).
 3. Browsertime starts FFMPEG to record a video of the browser screen
 4. The browser access the URL.
 5. When the page is finished loading (you can define yourself when that happens), Browsertime executes the default JavaScript timing metrics and collects:

--- a/docs/documentation/sitespeed.io/alerts/index.md
+++ b/docs/documentation/sitespeed.io/alerts/index.md
@@ -16,7 +16,7 @@ twitterdescription:
 {:toc}
 
 
-One of the best use cases for sending metrics to Graphite/InfluxDB and using Grafana is creating performance alerts that will alert you when SpeedIndex, First Visual Change or other metrics regress on your site. Grafana supports [many different notification types](http://docs.grafana.org/alerting/notifications/) and you can alert on all metrics that you send to Graphite/Grafana or that are in your own storage. This means you can alert on metrics from Browsertime like SpeedIndex and First/Last Visual Change, and from all other plugins that send data to your storage (WebPageTest, Coach, PageXray and [ChromeTrace](https://github.com/betit/chrometrace-sitespeedio-plugin)).
+One of the best use cases for sending metrics to Graphite/InfluxDB and using Grafana is creating performance alerts that will alert you when SpeedIndex, First Visual Change or other metrics regress on your site. Grafana supports [many different notification types](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/) and you can alert on all metrics that you send to Graphite/Grafana or that are in your own storage. This means you can alert on metrics from Browsertime like SpeedIndex and First/Last Visual Change, and from all other plugins that send data to your storage (WebPageTest, Coach, PageXray and [ChromeTrace](https://github.com/betit/chrometrace-sitespeedio-plugin)).
 
 Before you start, read the [Grafana alerts documentation](https://grafana.com/docs/grafana/latest/alerting/rules/).
 

--- a/docs/documentation/sitespeed.io/browsers/index.md
+++ b/docs/documentation/sitespeed.io/browsers/index.md
@@ -92,7 +92,7 @@ docker run --shm-size 2g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io
 ~~~
 
 ## Chrome
-The latest version of Chrome should work out of the box. The latest stable [ChromeDriver](http://chromedriver.chromium.org) is bundled with sitespeed.io.
+The latest version of Chrome should work out of the box. The latest stable [ChromeDriver](https://developer.chrome.com/docs/chromedriver) is bundled with sitespeed.io.
 
 ### Chrome setup
 When we start Chrome it is set up with [these](https://github.com/sitespeedio/browsertime/blob/main/lib/chrome/webdriver/chromeOptions.js) command line switches.
@@ -155,7 +155,7 @@ Our Docker container only contains one version of Chrome, [let us know](https://
 ### Use a newer version of ChromeDriver
 ChromeDriver is the driver that handles the communication with Chrome. By default sitespeed.io and Browsertime come with the ChromeDriver version that matches the Chrome version in the Docker container. If you want to run tests on a different ChromeDriver version, you need to download that version of ChromeDriver.
 
-You download ChromeDriver from [http://chromedriver.chromium.org](http://chromedriver.chromium.org) and then use ```--chrome.chromedriverPath``` to set the path to the new version of the ChromeDriver.
+You download ChromeDriver from the [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) page and then use ```--chrome.chromedriverPath``` to set the path to the new version of the ChromeDriver.
 
 ## Safari
 
@@ -301,7 +301,7 @@ You can then download the TCP dump for each iteration and the SSL key log file f
 Packets will be written when the buffer is flushed. If you want to force packets to be written to the file when they arrive you can do that with `--tcpdumpPacketBuffered`.
 
 ## WebDriver
-We use the WebDriver to drive the browser. We use [Chromedriver](https://chromedriver.chromium.org) for Chrome, [Geckodriver](https://github.com/mozilla/geckodriver/releases) for Firefox, [Edgedriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/) for Edge and [Safaridriver](https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari) for Safari.
+We use the WebDriver to drive the browser. We use [Chromedriver](https://developer.chrome.com/docs/chromedriver) for Chrome, [Geckodriver](https://github.com/mozilla/geckodriver/releases) for Firefox, [Edgedriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/) for Edge and [Safaridriver](https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari) for Safari.
 
 When you install sitespeed.io/Browsertime we also install the latest released driver for Chrome, Edge and Firefox. Safari comes bundled with Safaridriver. For Chrome, the ChromeDriver version needs to match the Chrome version. That can be annoying if you want to test on old browsers, upcoming developer versions, or on Android where that version hasn't been released yet.
 

--- a/docs/documentation/sitespeed.io/developers/index.md
+++ b/docs/documentation/sitespeed.io/developers/index.md
@@ -225,17 +225,16 @@ Do the release:
 7. Commit the updated [version file](https://github.com/sitespeedio/sitespeed.io/blob/main/docs/_includes/version/browsertime.txt) and the [configuration file](https://github.com/sitespeedio/sitespeed.io/blob/main/docs/documentation/browsertime/configuration/config.md) in the sitespeed.io repo. Or make a PR if you do not have commit rights.
 
 ### Contributing to the documentation
-The documentation lives in your cloned directory under *docs/*.
+The documentation lives in your cloned directory under *docs/* and is built with [Eleventy](https://www.11ty.dev/) (search uses [Pagefind](https://pagefind.app/)). You need Node.js (see *docs/package.json* for the supported version).
 
-First make sure you have Bundler: <code>gem install bundler</code>
+To run the documentation server locally, execute the following from within the */docs* directory after cloning the repo:
 
-You should upgrade your ruby gems too: <code>gem update --system</code>
+~~~bash
+npm install
+npm run serve
+~~~
 
-*If you run on a Mac OS make sure you have xcode-select installed: <code>xcode-select --install</code>*
-
-To run the documentation server locally execute the following from within the /docs directory after cloning the repo locally: <code>bundle install && bundle exec jekyll serve --baseurl ''</code>.
-
-Visit http://localhost:4000/ in the browser of your choice.
+Visit the URL Eleventy prints (default `http://localhost:8080/`) in the browser of your choice.
 
 ### Debugging with Chrome
 You can debug sitespeed.io using Chrome and NodeJS > 8. Thanks [@moos](https://github.com/moos) for sharing.

--- a/docs/documentation/sitespeed.io/docker/index.md
+++ b/docs/documentation/sitespeed.io/docker/index.md
@@ -109,13 +109,13 @@ docker pull sitespeedio/sitespeed.io:X.Y.Z
 
 Then change your start script (or where you start your container) to use the new version number.
 
-You can also pin sitespeed.io to stable versions. Say for example that you want to pin your version to version 35. Then you can use the following version:
+{% capture sitespeedVersion %}{% include version/sitespeed.io.txt %}{% endcapture %}{% assign sitespeedMajor = sitespeedVersion | split: "." | first %}You can also pin sitespeed.io to a major version and pull the latest patch and minor releases as they ship. For example, to pin to the current major:
 
 ```bash
-docker pull sitespeedio/sitespeed.io:35
+docker pull sitespeedio/sitespeed.io:{{ sitespeedMajor }}
 ```
 
-Then, as we continuously release new 35 versions, you can just run `docker pull sitespeedio/sitespeed.io:35` and you will get the latest released version of 35.
+Then, as we release new {{ sitespeedMajor }}.x versions, running `docker pull sitespeedio/sitespeed.io:{{ sitespeedMajor }}` will give you the latest released version of {{ sitespeedMajor }}.
 
 
 

--- a/docs/documentation/sitespeed.io/graphite/index.md
+++ b/docs/documentation/sitespeed.io/graphite/index.md
@@ -139,7 +139,7 @@ All default dashboards use Graphite annotations. But you can use Grafana's built
 
 To use Grafana annotations, make sure you set up a *resultBaseURL* and add the host and port to Grafana: <code>--grafana.host</code> and <code>--grafana.port</code>.
 
-Then set up your Grafana API token, follow the instructions at [http://docs.grafana.org/http_api/auth/#authentication-api](http://docs.grafana.org/http_api/auth/#authentication-api) and use the **bearer** code you get with <code>--grafana.auth</code>. Then your annotations will be sent to Grafana instead of Graphite.
+Then set up your Grafana API token, follow the instructions at [https://grafana.com/docs/grafana/latest/developers/http_api/auth/#authentication-api](https://grafana.com/docs/grafana/latest/developers/http_api/auth/#authentication-api) and use the **bearer** code you get with <code>--grafana.auth</code>. Then your annotations will be sent to Grafana instead of Graphite.
 
 You need to create a new annotation setup in Grafana that matches the templates (the dropdowns) in your dashboard (the same way the default "run" Graphite annotation is set up). It will look something like this:
 
@@ -313,7 +313,7 @@ When your volume is mounted on your server that runs Graphite, you need to make 
  - `/path/on/server/whisper:/opt/graphite/storage/whisper`
  - `/path/on/server/graphite.db:/opt/graphite/storage/graphite.db`
 
-If you use Grafana annotations, you should make sure grafana.db is outside of the container. Follow the documentation at [grafana.org](http://docs.grafana.org/installation/docker/#grafana-container-using-bind-mounts).
+If you use Grafana annotations, you should make sure grafana.db is outside of the container. Follow the documentation at [grafana.com](https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/#run-grafana-via-docker-compose).
 
 ## Graphite for production (important!)
 
@@ -323,6 +323,6 @@ If you use Grafana annotations, you should make sure grafana.db is outside of th
 4. Map the Graphite volume to a physical directory outside of Docker to have better control (both Whisper and [graphite.db](https://github.com/sitespeedio/sitespeed.io/blob/main/docker/graphite/graphite.db)). Map them like this on your physical server (make sure to copy the empty [graphite.db](https://github.com/sitespeedio/sitespeed.io/blob/main/docker/graphite/graphite.db) file):
  - /path/on/server/whisper:/opt/graphite/storage/whisper
  - /path/on/server/graphite.db:/opt/graphite/storage/graphite.db
- If you use Grafana annotations, you should make sure grafana.db is outside of the container. Follow the documentation at [grafana.org](http://docs.grafana.org/installation/docker/#grafana-container-using-bind-mounts).
+ If you use Grafana annotations, you should make sure grafana.db is outside of the container. Follow the documentation at [grafana.com](https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/#run-grafana-via-docker-compose).
  5. Run the latest version of Graphite and if you are using Docker, make sure you use a tagged version of the container (like graphiteapp/graphite-statsd:1.1.5-12) and never use the **latest** Docker tag.
  6. Secure your instance with a firewall/security groups so only your servers can send data to the instance.

--- a/docs/documentation/sitespeed.io/mobile-phones/index.md
+++ b/docs/documentation/sitespeed.io/mobile-phones/index.md
@@ -154,7 +154,7 @@ You can choose which Chrome version you want to run on your phone using `--chrom
 
 If you installed Chrome Canary on your phone and want to use it, then add `--chrome.android.package com.chrome.canary` to your run.
 
-Driving different versions requires different versions of ChromeDriver. The Chrome version number needs to match the ChromeDriver version number. Browsertime/sitespeed.io ships with the latest stable version of ChromeDriver. If you want to run other versions, you need to [download from the official ChromeDriver page](https://chromedriver.chromium.org/downloads). Then you specify the version using `--chrome.chromedriverPath`.
+Driving different versions requires different versions of ChromeDriver. The Chrome version number needs to match the ChromeDriver version number. Browsertime/sitespeed.io ships with the latest stable version of ChromeDriver. If you want to run other versions, you need to [download from the Chrome for Testing page](https://googlechromelabs.github.io/chrome-for-testing/). Then you specify the version using `--chrome.chromedriverPath`.
 
 ### Collect trace log
 


### PR DESCRIPTION
The Docker page pinned the example version to 35, which has been wrong for years; the developers contribution guide still asked you to install Bundler and run jekyll serve even though the docs site moved to Eleventy/Pagefind last week; and the ChromeDriver, Selenium and Grafana doc URLs all pointed at http:// paths that have either redirected or rotted (chromedriver.chromium.org has been replaced by Chrome for Testing, seleniumhq.github.io by selenium.dev, docs.grafana.org by grafana.com). The Docker pin example now derives the major version from the existing version include, so it'll track future major releases automatically.

These edits don't change any code paths — they only refresh user-visible documentation that had drifted away from the actual project and ecosystem.

Co-authored-by: Claude noreply@anthropic.co
