### PR TITLE
 docs: restructure the Coach pages around coach-core

### DIFF
--- a/docs/documentation/coach/developers/index.md
+++ b/docs/documentation/coach/developers/index.md
@@ -1,204 +1,182 @@
 ---
 layout: default
 title: Coach for developers.
-description: What you need to know to do changes to the coach.
-keywords: coach, documentation, developers, web performance
+description: How to write or improve a Coach rule.
+keywords: coach, documentation, developers, web performance, coach-core
 author: Peter Hedenskog
 nav: documentation
 category: coach
 image: https://www.sitespeed.io/img/sitespeed-2.0-twitter.png
 twitterdescription:
 ---
-[Documentation]({{site.baseurl}}/documentation/coach/) / Developers guide
+[Documentation]({{site.baseurl}}/documentation/coach/) / Developers
 
-# The Coach - Developers guide
+# The Coach — Developers
 {:.no_toc}
 
 {:toc}
 
-## Prerequisites
+## Where the code lives
 
-You need install [Node.js](https://nodejs.org/en/), [npm](https://nodejs.org/en/), [Firefox](https://www.mozilla.org/en-US/firefox/new/) and [Chrome](https://www.google.com/chrome/browser/desktop/).
-
-When you got them installed you can clone the project (or rather first fork it and clone your fork).
+All Coach rules and the analysis logic live in the [`coach-core`](https://github.com/sitespeedio/coach-core) repository. Fork it, clone your fork, install dependencies, and run the tests:
 
 ```bash
-git clone git@github.com:sitespeedio/coach.git
+git clone git@github.com:<your-fork>/coach-core.git
+cd coach-core
+npm install
+npm test
 ```
 
-Inside your coach folder install the dependencies and run the tests to check that everything works:
+Requires Node.js 20 or later. You'll also need Chrome and Firefox installed to run the DOM tests.
 
-```
-$ cd coach
-$ npm install
-$ npm test
-```
-If the test works you are ready start!
+## The advice schema
 
-## Advice
-The coach helps you with web performance and gives you advice about things you can do better. The advice needs to follow the following structure:
+Every rule — DOM or HAR — produces an object with the same shape:
 
 ```javascript
-return {
-  id: 'uniqueid', // a unique id
-  title: 'The title of the advice',
-  description: 'More information of the advice',
-  advice: 'Information of what the user should do to fix the problem',
-  score:  100, // a number between 0-100, 100 means the page don't need any advice
-  weight: 5, // a number between 0-10, how important is this advice in this category? 10 means super important
-  offending: [], // an array of assets that made the score less than perfect
-  tags: ['performance','html']
-};
+{
+  id: 'uniqueId',           // Unique rule id
+  title: 'Short summary',
+  description: 'Why the rule exists and what to do about it',
+  advice: 'Specific, page-aware text written by the rule when it runs',
+  score: 100,               // 0–100. 100 means nothing to flag.
+  weight: 5,                // 0–10. How much this rule matters in its category.
+  severity: 'warn',         // 'error' | 'warn' | 'info'
+  offending: [],            // Array of asset URLs (or other identifiers) that caused the score
+  tags: ['performance', 'css']
+}
 ```
 
-Does it look familiar? Yep it is almost the same structure as an YSlow rule :)
+`severity` is the at-a-glance triage level. `weight` is how much the rule pulls down its category score when it fails. `score` is what the rule actually produced for the page being analysed.
 
+## DOM advice vs HAR advice
 
-### DOM vs HAR advice
-The coach analyse a page in two steps: First it executes JavaScript in the browser to do checks that are a perfect fit for JavaScript: examine the rendering path, check if images are scaled in the browser and more.
+The Coach analyses a page in two passes. Each rule lives in one of the two.
 
-Then the coach take the HAR file generated from the page and analyse that too. The HAR is good if you want the number of responses, response size and check cache headers.
+- **DOM advice** runs as JavaScript inside the browser and inspects the live page. Use it for things only the live DOM can answer: which scripts blocked the parser, whether `<img>` tags use `decoding="async"`, the size of the document, whether the LCP element has `fetchpriority="high"`.
+- **HAR advice** runs in Node.js and inspects the HAR file produced for the run. Use it for things the network log answers best: cache headers, redirects, render-blocking timing, response counts, third-party usage.
 
-In the last step the  coach merges the advice into one advice list and creates an overall score.
+A HAR rule can also see the DOM result for the same page (`processPage(page, domAdvice, options)`), so a HAR rule can combine network facts with what the DOM rule observed. Rules that share an `id` between the DOM and HAR side are merged — the HAR result wins.
 
-Cool huh? We got one more thing that we [intend to implement](https://github.com/sitespeedio/coach/issues/13): the combination of the two: A HAR advice that takes input from a DOM. This will be cool because the coach will then have the power to know it all.
+### A DOM rule
 
-#### DOM advice
-
-Each DOM advice needs to be a [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression) and return an object that holds the data.
-
-A simple example is the cssPrint advice that looks for a print stylesheet.
+DOM rules are bundled into a single JavaScript file that gets injected into the browser, so each one is an [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) that returns the advice object. Utility helpers are available on the `util` parameter.
 
 ```javascript
-(function(util) {
- 'use strict';
- var offending = [];
+(function (util) {
+  'use strict';
 
- var links = document.getElementsByTagName('link');
- for (var i = 0, len = links.length; i < len; i += 1) {
-   if (links[i].media === 'print') {
-     offending.push(util.getAbsoluteURL(links[i].href));
-   }
- }
+  const offending = [];
+  const links = document.getElementsByTagName('link');
 
- var score = offending.length * 10;
+  for (const link of links) {
+    if (link.media === 'print') {
+      offending.push(util.getAbsoluteURL(link.href));
+    }
+  }
 
- return {
-   id: 'cssPrint',
-   title: 'Do not load print stylesheets, use @media type print instead',
-   description: 'Loading a specific stylesheet for printing slows down the page, even though it is not used',
-   advice: offending.length > 0 ? 'The page has ' + offending.length + ' print stylesheets. You should include that stylesheet using @media type print instead.':'',
-   score: Math.max(0, 100 - score),
-   weight: 1,
-   offending: offending,
-   tags: ['performance', 'css']
- };
+  const score = Math.max(0, 100 - offending.length * 10);
 
+  return {
+    id: 'cssPrint',
+    title: 'Do not load specific print stylesheets.',
+    description:
+      'A separate print stylesheet still costs a request and bytes even though screen readers ignore it. Inline the print rules in your main CSS with @media print instead.',
+    advice:
+      offending.length > 0
+        ? `The page has ${util.plural(offending.length, 'print stylesheet')}. Move them into your main CSS with @media print.`
+        : '',
+    score,
+    weight: 1,
+    severity: 'info',
+    offending,
+    tags: ['performance', 'css']
+  };
 })(util);
 ```
 
+### A HAR rule
 
-#### HAR advice
-We use [PageXray](https://github.com/sitespeedio/pagexray) to convert the HAR file into a Page object that is easier to work with.
-
-Each HAR advice needs to implement a processPage function. The function will be called once for each page.
-
-Lets look at a simple advice that checks if the total page size is too large.
+HAR rules are ESM modules with a static schema and a `processPage` function that runs once per page in the HAR. The function returns the dynamic part of the result (`score`, `advice`, `offending`).
 
 ```javascript
-'use strict';
-let util = require('../util');
+import * as util from '../util.js';
 
-module.exports = {
+export default {
   id: 'pageSize',
-  title: 'Total page size shouldn\'t be too big',
-  description: 'Avoid having pages that have transfer size over the wire of more than 2 MB (desktop) and 1 MB (mobile) because that is really big and will hurt performance. ',
+  title: "Total page size shouldn't be too big",
+  description:
+    'Large pages are slower on every connection. Keep transfer size under 2 MB on desktop and 1 MB on mobile.',
   weight: 3,
+  severity: 'warn',
   tags: ['performance', 'mobile'],
-  processPage: function(page, domAdvice, options) {
-		// in options we have the input parameters
-		// so we can do specific advice for devices like
-    let sizeLimit = options.mobile ? 1000000 : 2000000;
+  processPage(page, domAdvice, options) {
+    const sizeLimit = options.mobile ? 1_000_000 : 2_000_000;
     if (page.transferSize > sizeLimit) {
       return {
         score: 0,
         offending: [],
-        advice: 'The page total transfer size is ' + util.formatBytes(page.transferSize) + ', which is more than the coach limit of ' + util.formatBytes(sizeLimit) + '. That is really big and you should check what you can do to make it smaller.'
+        advice: `The page transfers ${util.formatBytes(page.transferSize)}, more than the ${util.formatBytes(sizeLimit)} limit.`
       };
     }
-
-    // and the domAdvice is the data we got from running the DOM advice
-    // we can get things like what assets are loaded inside of HEAD
-    // knowing which Javascripts that are loaded synchronous
-    // if (domAdvice.coachAdvice.results.info.head.jssync.length > 0)
-
-    return {
-      score: 100,
-      offending: [],
-      advice: ''
-    };
+    return { score: 100, offending: [], advice: '' };
   }
 };
 ```
-What's extra cool is that a HAR advice can both act on input (specific advice for device or browser) and on the result from the DOM advice running in the browser (you can let the HAR advice know which assets are loaded inside of head etc).
 
-#### The best of two worlds
-As an extra feature, the HAR advice override the DOM advice if the advice has the same id. This means you can easily combine data from the two and still output one advice.
+The third argument (`options`) is what the caller passed to `analyseHar` — useful for branching on `mobile`, `browser`, or anything else specific to the run.
 
-There's no advice that use that functionality today, but be rest assured it will soon be.
+## HTTP/2 vs HTTP/1
 
-It also means we can use information from the resource timing API v2 (where we can get response size) making the DOM advice even more powerful, but when you combine the HAR & DOM advice we can get all/some of the values from the HAR.
+Both DOM and HAR helpers expose an `isHTTP2` check so a single rule can give different advice per protocol:
 
-## Testing HTTP/2 vs HTTP/1
-Both DOM and HAR advice have help methods that makes it easy to give different advice depending on the protocol.
-
-### DOM
 ```javascript
+// DOM
 if (util.isHTTP2()) {
-  // special handling for H2 connections
+  // Don't recommend domain sharding, etc.
 }
-```
 
-### HAR
-```javascript
+// HAR
 if (util.isHTTP2(page)) {
-  // special handling for H2 connections
+  // ...
 }
 ```
 
+## Testing
 
-## Test in your browser
-You can and should test your advice in your browser. It's easy. Just copy/paste your advice into the browser console. If you use the [utility methods](https://github.com/sitespeedio/coach/blob/main/lib/dom/util.js)  you need to copy/paste that too inside your console before you test your advice.
+Every rule needs a test. Tests live next to the rule code in the [`test/`](https://github.com/sitespeedio/coach-core/tree/main/test) directory.
 
-## Add a test case
-When you create a new advice you also need to create unit tests. We run the tests in both Firefox & Chrome.
-
-We create a new unique HTML page for each rule (or two if you want to test different behavior). If you only have one page, name it the same as the advice + '.html' and it will be picked up.
-
-A simple test run for the print CSS advice looks like this:
+A DOM test runs the rule against a fixture HTML page from `test/http-server`:
 
 ```javascript
-it('We should find out if we load an print CSS', function() {
-  return runner.run('cssPrint.js')
-    .then((result) => {
-      assert.strictEqual(result.offending.length, 1);
-  });
-});
+it('detects a print stylesheet', () =>
+  runner.run('cssPrint.js').then(result => {
+    assert.strictEqual(result.offending.length, 1);
+  })
+);
 ```
 
-Right now all these tests run in https://github.com/sitespeedio/coach/blob/main/test/dom/performance/indexTest.js
+If you add a new DOM rule, add (or extend) an HTML fixture under `test/http-server` that triggers it. Run the tests with `npm test`.
 
-Each test case runs against a specific HTML page located in `test/http-server` Create a suitable HTML page with the structure you want to test. Create the test case in `test/dom` or `test/har` and run it with <code>npm test</code>
+## Adding a new category
 
-## Test your changes against a web page
-The coach uses Browsertime as runner for browsers. When you finished with a change, make sure to build a new version of the combined Javascript and then test against a URL.
+The Coach has performance, privacy, best practice, accessibility and info categories. Adding a new one is a matter of creating a new folder under `lib/dom/<name>` (and/or `lib/har/<name>`) and dropping rule files into it. If you are unsure whether a new category fits, open an issue first and we can talk it through.
 
-```
+## Trying your changes against a real page
+
+After editing rules, rebuild the bundled DOM script:
+
+```bash
 npm run combine
-bin/index.js https://www.sitespeed.io firefox
 ```
 
-# Add a new category
-When you browse the code you will see that the coach knows more than just performance.
+Then point a sitespeed.io install at your local checkout with `npm link` and run sitespeed.io against a URL — the Coach will use your modified rules.
 
-We have accessibility, web best practice, privacy, performance, and info today. Does the coach need to know something else? Let us know and we can create that category (it's as easy as create a new folder) and we can start add new advice there.
+```bash
+# in coach-core
+npm link
+
+# in your sitespeed.io checkout
+npm link coach-core
+sitespeed.io https://www.sitespeed.io/
+```

--- a/docs/documentation/coach/how-to/index.md
+++ b/docs/documentation/coach/how-to/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: How to use the coach.
-description: Run the coach in Docker or use npm nodejs.
+title: How to use the Coach.
+description: Get Coach advice from sitespeed.io, Browsertime, or the coach-core library.
 keywords: coach, documentation, web performance
 author: Peter Hedenskog
 nav: documentation
@@ -11,177 +11,76 @@ twitterdescription:
 ---
 [Documentation]({{site.baseurl}}/documentation/coach/) / How to
 
-# The Coach - How to use the coach
+# The Coach — How to use it
 {:.no_toc}
 
 {:toc}
 
-You can use the coach in a couple of different ways.
+There are two ways to get Coach advice: run sitespeed.io and let it do the work, or call the [`coach-core`](https://github.com/sitespeedio/coach-core) library directly from your own pipeline.
 
-### Standalone
+## With sitespeed.io
 
-You need Node.js latest LTS. And you need Chrome and/or Firefox installed.
-
-If you want to use Chrome (Chrome is default):
+The Coach is enabled by default. Run sitespeed.io as you normally would — the result page shows the Coach scores and the per-rule advice with no extra flags.
 
 ```bash
-webcoach https://www.sitespeed.io
+sitespeed.io https://www.sitespeed.io/
 ```
 
-Try it with Firefox:
+The HTML report renders the Coach output, and the same data is available in `coach.json` under the result directory. If you send metrics to InfluxDB, Graphite or Prometheus, the Coach scores ship along with them.
+
+## As a library: coach-core
+
+If you have your own browser pipeline (custom WebDriver runner, headless service, internal tool) and you want Coach advice in the result, install `coach-core` and call it directly. `coach-core` is a pure ESM package and requires Node.js 20 or later.
 
 ```bash
-npm install webcoach -g && webcoach https://www.sitespeed.io --browser firefox
+npm install coach-core
 ```
 
-Or if you prefer Docker:
+The library expects two inputs you produce yourself:
 
-```bash
-docker run sitespeedio/coach:{% include version/coach.txt %} https://www.sitespeed.io
-```
+1. The result of running the Coach's DOM script in a browser.
+2. The HAR file for the same page load.
 
-If you also want to show the offending assets/details and the description of the advice:
-
-```bash
-webcoach https://www.sitespeed.io --details --description
-```
-
-By default, the coach only tells you about advice where you don't get the score 100. You can change that. If you want to see all advice, you can do that too:
-
-```bash
-webcoach https://www.sitespeed.io --limit 101
-```
-
-If you want to test as a mobile device, that's possible too, by faking the user-agent.
-
-```bash
-webcoach https://www.sitespeed.io --mobile -b chrome
-```
-
-
-> ... but hey, I want to see the full JSON?
-
-Yes, you can do that!
-
-```bash
-webcoach https://www.sitespeed.io -f json
-```
-This will get you the full JSON, the same as if you integrate the coach into your tool.
-
-### Bookmarklet
-
-We also produce a bookmarklet. The bookmarklet only uses advice that you can run inside the browser (it doesn't have HAR file to analyse even though maybe possible in the future with the Resource Timing API).
-
-The bookmarklet is really rough right now and logs the info to the browser console. Help us make a cool front-end :)
-
-You can generate the bookmarklet by running
-
-```bash
-grunt bookmarklet
-```
-
-and then you will find it in the dist folder.
-
-### Include in your own tool
-The coach uses Browsertime to start the browser, execute the JavaScript and fetch the HAR file. You can use that functionality too inside your tool or you can use the raw scripts if you have your own browser implementation.
-
-#### Use built in browser support
-
-In the simplest version you use the default configuration (default DOM and HAR advice and using Firefox):
+The flow:
 
 ```javascript
-const api = require('webcoach');
-const result = api.run('https://www.sitespeed.io');
+import {
+  getDomAdvice,
+  getHarAdvice,
+  analyseHar,
+  merge,
+  pickAPage
+} from 'coach-core';
+
+// 1. Get the JavaScript that inspects the page and run it in your browser.
+const domScript = await getDomAdvice();
+const domResult = await yourBrowser.evaluate(domScript);
+
+// 2. Take the HAR you produced for the same run. If it has multiple pages,
+//    pick the one you want to analyse.
+const har = await yourBrowser.getHar();
+const page = pickAPage(har, 0);
+
+// 3. Run the HAR rules. Pass the DOM result so HAR rules can use it.
+const harAdvice = await getHarAdvice();
+const harResult = await analyseHar(page, harAdvice, domResult, {
+  // any options you want to forward, for example { mobile: true, browser: 'chrome' }
+});
+
+// 4. Merge the two into the final Coach result.
+const coachResult = merge(domResult, harResult);
 ```
 
-The full API method:
+`coachResult` has the same shape as the `coach.json` written by sitespeed.io: per-category scores, per-rule entries with `score`, `weight`, `severity`, `advice` text and the `offending` list.
 
-```javascript
-// get the API
-const api = require('webcoach');
-const result = api.run(url, domScript, harScript, options);
-```
+The library also exposes a few helpers:
 
-#### Use the scripts
-Say that your tool run on Windows, you start the browsers yourself and you generate your own HAR file. Create your own wrapper to get the coach to help you.
+- `getThirdPartyWeb()` and `getThirdPartyWebVersion()` — the third-party-web data the Coach uses for third-party detection.
+- `getPageXray()` — the [PageXray](/documentation/pagexray/) instance used to convert HAR to a page summary.
+- `getTechnologiesVersion()` and `getWappalyzerCoreVersion()` — versions of the technology-detection data.
 
-First you need the JavaScript advice, you can get the raw script either by generating it yourself or through the API.
+![How the Coach analyses a page]({{site.baseurl}}/img/coach-explained.png)
 
-Generate the script
+## Browser support
 
-```bash
-grunt combine
-```
-and it will be in the dist folder.
-
-Or you just get it from the API:
-
-```javascript
-// get the API
-const api = require('webcoach');
-// get the DOM scripts, it's a promise
-const domScriptPromise = api.getDomAdvice();
-```
-
-Take the <em>domScript</em> and run it in your browser and take care of the result.
-
-To test the HAR you need to generate the HAR yourself and then run it against the advice.
-
-```javascript
-const api = require('webcoach');
-// You read your HAR file from disk or however you get hold of it
-const harJson = //
-// if your har contains multiple pages (multiple runs etc) you can use the API
-// to get the page that you want
-const firstPageHar = api.pickAPage(harJson, 0);
-// the result is a promise
-const myHarAdviceResultPromise = api.runHarAdvice(firstPageHar, api.getHarAdvice());
-
-```
-
-When you got the result from both the DOM and the HAR you need to merge the result to get the full coach result:
-
-```javascript
-// Say that you got the result from the browser in domAdviceResult
-// and the HAR result in harAdviceResult
-const coachResult = api.merge(domAdviceResult, harAdviceResult);
-```
-
-Now you have the full result (as JSON) as a coachResult.
-
-## What do the coach do
-The coach will give you advice on how to make your page better. You will also get a score between 0-100. If you get 100 the page is great, if you get 0 you have some work to do!
-
-## How does it all work?
-
-The coach tests your site in two steps:
-
- * Executes JavaScript in your browser and check for performance, accessibility, best practice and collect general info about your page.
- * analyse the [HAR file](http://www.softwareishard.com/blog/har-12-spec/) for your page together with relevant info from the DOM process.
-
-You can run the different steps standalone but for the best result run them together.
-
-![What the coach do]({{site.baseurl}}/img/coach-explained.png)
-
-## Bonus
-The coach knows more than just performance. She also knows about accessibility and web best practice.
-
-### Accessibility
-Make sure your site is accessible and useable for every one. You can read more about making the web accessible [here](https://www.marcozehe.de/2015/12/14/the-web-accessibility-basics/).
-
-### Best practice
-You want your page to follow best practices, right? Making sure your page is set up for search engines, have good URL structure and so on.
-
-### General information
-The world is complex. Some things are great to know but hard for the coach to give advice about.
-
-The coach will then just tell you how the page is built and you can draw your own conclusions if something should be changed.
-
-### Timings
-The coach has a clock and knows how to use it! You will get timing metrics and know if you are doing better or worse than the last run.
-
-# Developers guide
-Checkout the [developers guide](../developers/) to get a better feeling of how the coach works.
-
-# Browser support
-The coach is automatically tested in the latest Chrome and Firefox. We hope that the coach works in other browsers, but we cannot guarantee it right now.
+The Coach is tested against the latest Chrome and Firefox. Most rules also work in Edge and Safari, but we don't run automated tests against them — file an issue if a rule misbehaves in another browser and we'll take a look.

--- a/docs/documentation/coach/index.md
+++ b/docs/documentation/coach/index.md
@@ -1,20 +1,22 @@
 ---
 layout: default
-title: The coach - Clear Eyes. Full Hearts. Can’t Lose!
-description: Use the coach to find performance problems on your page.
-keywords: tools, documentation, web performance
+title: The Coach - performance, privacy and best-practice advice
+description: Use the Coach to find performance, privacy and best-practice problems on your page.
+keywords: tools, documentation, web performance, core web vitals, coach
 author: Peter Hedenskog
 nav: documentation
 category: coach
 image: https://www.sitespeed.io/img/sitespeed-2.0-twitter.png
 twitterdescription:
 ---
-# The coach - Clear Eyes. Full Hearts. Can’t Lose!
+# The Coach
 
-<img src="{{site.baseurl}}/img/logos/coach.png" class="pull-right img-big" alt="I'm the coach" width="188" height="219">
+<img src="{{site.baseurl}}/img/logos/coach.png" class="pull-right img-big" alt="The Coach" width="188" height="219">
 
-The coach helps you find performance problems on your web page. The coach gives you advice on how your page could be faster, with rules covering Core Web Vitals, modern image best practices and the privacy and security headers that matter today. You can run the coach standalone, include it in your own tool or get the data when you run sitespeed.io.
+The Coach analyses your web page and tells you what to fix. It covers Core Web Vitals (LCP, CLS, INP, FCP), modern image best practices (`decoding="async"`, lazy loading, AVIF/WebP, LCP `fetchpriority`) and the privacy and security headers that matter today (CSP, COOP/COEP/CORP, Permissions-Policy, X-Content-Type-Options, NEL, Reporting-Endpoints, Referrer-Policy).
 
-* [Introduction](introduction/)
-* [How to use the coach](how-to/)
-* [Developers](developers/)
+The Coach is built into [sitespeed.io](/documentation/sitespeed.io/) and [Browsertime](/documentation/browsertime/) — when you run either tool, the Coach runs with it. You can also use the analysis library, [`coach-core`](https://github.com/sitespeedio/coach-core), directly from your own code.
+
+* [Introduction](introduction/) — what the Coach checks and how scoring works.
+* [How to use the Coach](how-to/) — get advice from sitespeed.io, Browsertime or `coach-core`.
+* [Developers](developers/) — write or improve a Coach rule.

--- a/docs/documentation/coach/introduction/index.md
+++ b/docs/documentation/coach/introduction/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Coach Introduction
-description: Why do you need the coach.
+description: What the Coach checks and how it scores your page.
 keywords: coach, documentation, web performance, core web vitals
 author: Peter Hedenskog
 nav: documentation
@@ -11,30 +11,43 @@ twitterdescription:
 ---
 [Documentation]({{site.baseurl}}/documentation/coach/) / Introduction
 
-# The Coach - Introduction
+# The Coach — Introduction
 {:.no_toc}
 
 {:toc}
 
+## What is the Coach?
 
-## Do my page need coaching?
+The Coach is a set of rules that look at a real page in a real browser, plus the HAR file generated for the same run, and tell you what to fix. It runs by default inside [sitespeed.io](/documentation/sitespeed.io/) and [Browsertime](/documentation/browsertime/), and the analysis logic lives in the open-source [`coach-core`](https://github.com/sitespeedio/coach-core) library.
 
-You know, it's hard to get everything right! The world is complex: HTTP/1 vs HTTP/2. Some of the previous performance best practices are now considered bad practice. Luckily for you the coach will detect that the page is accessed using HTTP/2, and adjust its advice accordingly.
+Each Coach rule combines two sources of truth:
 
+- **DOM advice** — JavaScript that runs inside the browser and inspects the live page (which scripts blocked rendering, whether images are scaled in HTML, whether `decoding="async"` is set, and so on).
+- **HAR advice** — analysis of the HAR file produced for the run (request count per content type, cache headers, third-party usage, render-blocking timing).
 
-## Why we love the coach
-Reasons why we love the coach and you will too:
+The two are merged into one result so each rule can use information from both sides.
 
- - The coach gives you advice on how to make your page faster. The coach aims to NEVER give you bad advice. Follow the advice and you will WIN!
- - The coach uses real browsers to see your page exactly like your users do.
- - Every rule carries a **severity tier** (`error` / `warn` / `info`) alongside its score and weight, so you can tell "fix this now" from "good to know" at a glance.
- - The coach has rules for every Core Web Vital (LCP, CLS, INP, FCP), modern image best practices (`decoding="async"`, lazy loading, AVIF/WebP, LCP `fetchpriority`), and the modern privacy / security headers (CSP, COOP/COEP/CORP, Permissions-Policy, X-Content-Type-Options, NEL, Reporting-Endpoints, Referrer-Policy).
- - Every advice has one or more unit-tests to make sure it's easy to change advice in the future.
- - The coach knows about more than just performance: privacy and web best practice are other things that the coach can help you with.
- - You can integrate the coach with your own web performance tool. It's easy: your tool only need to be able to run JavaScript in the browser and produce a HAR file. Or you can use the built-in functionality of the coach to run the browser.
- - The coach is open-source. The advice is public, you can check it, change it, or add to it yourself. Help us make the coach even better!
- - The coach can combine knowledge from the DOM with HAR to give you super powerful advice.
- - The CLI output is pretty nice. You can configure how much you want to see. Use it as a fast way to check the performance of your page.
+## What the Coach checks
 
-## Help us improve the coach
-Have an idea for new advice, or spotted something the coach should catch? Open an issue or send a PR — check out the [issues](https://github.com/sitespeedio/coach/issues), try the project and give us feedback.
+- **Core Web Vitals** — LCP, CLS, INP and FCP, with rule-specific guidance per metric.
+- **Modern image practices** — `decoding="async"`, native lazy loading, AVIF/WebP usage, `fetchpriority` on the LCP image.
+- **Critical rendering path** — render-blocking JavaScript and CSS, inlined CSS, head content.
+- **HTTP and caching** — cache headers, redirects, compression, HTTP/2 and HTTP/3 usage.
+- **Privacy and security headers** — CSP, COOP/COEP/CORP, Permissions-Policy, X-Content-Type-Options, NEL, Reporting-Endpoints, Referrer-Policy.
+- **Third parties** — what third-party scripts the page pulls in and what it costs.
+- **Accessibility and best practice** — basic checks you can act on without extra tooling.
+- **Info** — facts about the page (DOM size, depth, iframes, localStorage size) without an opinion attached. Use them to draw your own conclusions.
+
+## How scoring works
+
+Every rule produces a result with three numbers:
+
+- **score** (0–100) — 100 means the rule has nothing to flag, 0 means there is plenty to do.
+- **weight** (0–10) — how much this rule matters in its category. A failing weight-10 rule pulls the category score down a lot more than a failing weight-1 rule.
+- **severity** (`error` / `warn` / `info`) — at-a-glance triage. `error` means fix it now, `warn` means address it soon, `info` is good to know.
+
+Scores are aggregated into category scores (performance, privacy, best practice, accessibility) and an overall page score, all on the same 0–100 scale.
+
+## Why open source
+
+Every rule is open. You can read the exact check, change it, or add a new one. If a rule misses a case or feels wrong for your site, file an issue or a PR against [`coach-core`](https://github.com/sitespeedio/coach-core/issues). Each rule has unit tests so it stays easy to change.


### PR DESCRIPTION
The Coach pages still pointed at the legacy coach / webcoach project: a standalone CLI, a grunt-built bookmarklet, the require('webcoach') API, plus YSlow comparisons and "Clear Eyes Full Hearts Can't Lose" framing that landed when coach was new. None of that is what we ship today — the analysis lives in coach-core (ESM, Node 20+), runs by default inside sitespeed.io, and uses a score + weight + severity model the docs never described.

Restructured the four pages around what's true now: the landing page sets expectations, the introduction explains scoring and severity tiers and the rule areas Coach actually covers (Core Web Vitals, modern image practices, modern privacy/security headers, third parties), the how-to page covers the two real entry points (sitespeed.io and the coach-core library, with the real ESM API), and the developers page documents the current advice schema with up-to-date DOM and HAR examples taken from the actual coach-core code.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com