### PR TITLE
docs: refresh the sitespeed.io documentation set

### DIFF
--- a/docs/documentation/sitespeed.io/alerts/index.md
+++ b/docs/documentation/sitespeed.io/alerts/index.md
@@ -16,7 +16,7 @@ twitterdescription:
 {:toc}
 
 
-One of the best use cases for sending metrics to Graphite/InfluxDB and using Grafana is creating performance alerts that will alert you when SpeedIndex, First Visual Change or other metrics regress on your site. Grafana supports [many different notification types](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/) and you can alert on all metrics that you send to Graphite/Grafana or that are in your own storage. This means you can alert on metrics from Browsertime like SpeedIndex and First/Last Visual Change, and from all other plugins that send data to your storage (WebPageTest, Coach, PageXray and [ChromeTrace](https://github.com/betit/chrometrace-sitespeedio-plugin)).
+One of the best use cases for sending metrics to Graphite/InfluxDB and using Grafana is creating performance alerts that will alert you when SpeedIndex, First Visual Change or other metrics regress on your site. Grafana supports [many different notification types](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/) and you can alert on all metrics that you send to Graphite/Grafana or that are in your own storage. This means you can alert on metrics from Browsertime like SpeedIndex and First/Last Visual Change, and from all other plugins that send data to your storage (WebPageTest, Coach, PageXray, etc.).
 
 Before you start, read the [Grafana alerts documentation](https://grafana.com/docs/grafana/latest/alerting/rules/).
 

--- a/docs/documentation/sitespeed.io/best-practice/index.md
+++ b/docs/documentation/sitespeed.io/best-practice/index.md
@@ -147,13 +147,13 @@ Can I test the same URLs from different locations, and how do I make sure they d
 You should set different namespaces depending on location (`--graphite.namespace`). If you run one test from London, set the namespace to <code>--graphite.namespace sitespeed_io.london</code>. Then you can choose individual locations in the dropdown in the pre-made dashboards.
 
 ### Google Web Vitals
-To get Google's Web Vitals in your tests you need to use Chrome. Sitespeed.io collects: First Contentful Paint, Largest Contentful Paint, Cumulative Layout Shift, First Input Delay/Total Blocking Time.
+To get Google's Web Vitals in your tests you need to use Chrome. Sitespeed.io collects: First Contentful Paint, Largest Contentful Paint, Cumulative Layout Shift, Interaction to Next Paint, and Total Blocking Time (a lab proxy for INP/FID).
 
 A good thing is to calibrate your test against the Chrome User Experience report data. Do that by running the [CrUx plugin](/documentation/sitespeed.io/crux/), then tuning the connectivity setting you use and comparing First and Largest Contentful Paint.
 
-To calibrate Cumulative Layout Shift, it's good to [use scripting](/documentation/sitespeed.io/scripting/) to go to the page and [scroll the page](/documentation/sitespeed.io/scripting/#scroll-the-page-to-measure-cumulative-layout-shift).
+To calibrate Cumulative Layout Shift, [use scripting](/documentation/sitespeed.io/scripting/interact-with-the-page/) to drive the page (e.g. scroll) so layout shifts that happen post-load are captured.
 
-First Input Delay/Total Blocking Time is harder. The best way is to test on a real mobile phone, preferably an older Android phone like a Moto G5.
+Total Blocking Time is harder. The best way is to test on a real mobile phone, preferably an older Android phone like a Moto G5. INP needs real interactions — drive them via [scripting](/documentation/sitespeed.io/scripting/).
 
 ### Google Page Speed Insights vs Lighthouse vs Chrome User Experience Report plugins
 

--- a/docs/documentation/sitespeed.io/browsers/index.md
+++ b/docs/documentation/sitespeed.io/browsers/index.md
@@ -15,7 +15,7 @@ twitterdescription: You can use Firefox, Safari, Chrome, Edge and Chrome/Firefox
 
 {:toc}
 
-You can fetch timings, run your own JavaScript and record a video of the screen. The following browsers are supported: Firefox, Safari, Edge, Chrome, Chrome and Firefox on Android, and Safari on iOS. If you run our Docker containers, we update them whenever we have tested the latest stable release of Chrome or Firefox. Safari and Safari on iOS need macOS Catalina. Edge needs the corresponding MSEdgeDriver.
+You can fetch timings, run your own JavaScript and record a video of the screen. The following browsers are supported: Firefox, Safari, Edge, Chrome, Chrome and Firefox on Android, and Safari on iOS over USB. If you run our Docker containers, we update the bundled Chrome/Firefox/Edge versions whenever we have verified the latest stable release works. Edge needs the corresponding MSEdgeDriver.
 
 ## Firefox
 The latest version of Firefox should work out of the box, except on Linux when you run Firefox installed via Snap; then you need to [follow the workaround](https://github.com/mozilla/geckodriver/releases/tag/v0.31.0) by setting a TMPDIR that Geckodriver and Firefox will use.
@@ -159,7 +159,7 @@ You download ChromeDriver from the [Chrome for Testing](https://googlechromelabs
 
 ## Safari
 
-You can run Safari on Mac OS X. To run on iOS you need Catalina and iOS 13. To see more what you can do with the SafariDriver you can run `man safaridriver` in your terminal.
+You can run Safari on macOS, and on iOS over USB from a Mac. To see more of what you can do with the SafariDriver you can run `man safaridriver` in your terminal.
 
 ### Limitations
 On macOS Safari we do not support HAR, cookies and request headers. iOS Safari over USB collects HAR + video + visual metrics — see [Run on iOS](#run-on-ios) below.
@@ -305,7 +305,7 @@ We use the WebDriver to drive the browser. We use [Chromedriver](https://develop
 
 When you install sitespeed.io/Browsertime we also install the latest released driver for Chrome, Edge and Firefox. Safari comes bundled with Safaridriver. For Chrome, the ChromeDriver version needs to match the Chrome version. That can be annoying if you want to test on old browsers, upcoming developer versions, or on Android where that version hasn't been released yet.
 
-You can download ChromeDriver yourself from the [Google repo](https://chromedriver.storage.googleapis.com/index.html) and use ```--chrome.chromedriverPath``` to help Browsertime find it. You can also choose which version to install when you install sitespeed.io with an environment variable: ```CHROMEDRIVER_VERSION=81.0.4044.20 npm install```
+You can download ChromeDriver yourself from [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) and use ```--chrome.chromedriverPath``` to help Browsertime find it. You can also choose which version to install when you install sitespeed.io with an environment variable: ```CHROMEDRIVER_VERSION=148.0.7355.0 npm install```
 
 You can also choose versions for Edge and Firefox with `EDGEDRIVER_VERSION` and `GECKODRIVER_VERSION`.
 

--- a/docs/documentation/sitespeed.io/configuration/index.md
+++ b/docs/documentation/sitespeed.io/configuration/index.md
@@ -139,9 +139,9 @@ Mobile testing is always best on actual mobile devices. You can [test on Android
 {: .note .note-warning}
 
 ### Visual metrics and video
-In 4.1 we released support for recording a video of the browser screen and using that to calculate visual metrics like Speed Index. This is one of the main benefits of using our Docker images, since it makes for an easy setup. Without Docker, you would need to install all the [dependencies](https://github.com/WPO-Foundation/visualmetrics).
+Sitespeed.io records a video of the browser screen and uses that to calculate visual metrics like Speed Index. This is one of the main benefits of using our Docker images, since it makes for an easy setup. Without Docker, you would need to install all the [dependencies](https://github.com/WPO-Foundation/visualmetrics).
 
-In 6.0 video and Visual Metrics are turned on by default, and if you want to turn them off you do like this:
+Video and Visual Metrics are on by default. To turn them off:
 
 ~~~bash
 docker run --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} --visualMetrics false https://www.sitespeed.io/

--- a/docs/documentation/sitespeed.io/continuous-integration/index.md
+++ b/docs/documentation/sitespeed.io/continuous-integration/index.md
@@ -59,7 +59,7 @@ jobs:
     name: running sitespeed.io
     steps:
       - name: code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: running sitespeed.io container with arguments and optional Docker options
         run: docker run -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io:{% include version/sitespeed.io.txt %} https://www.sitespeed.io --budget.configPath .github/budget.json -n 1
 ```
@@ -100,9 +100,6 @@ docker run -v ${WORKSPACE}:/sitespeed.io sitespeedio/sitespeed.io --outputFolder
 {: .img-thumbnail}
 
 Remember that you can also send the metrics to Graphite to keep a closer eye on all metrics over time.
-
-## Travis
-We have an example project for setting up Travis [https://github.com/sitespeedio/travis/](https://github.com/sitespeedio/travis/blob/main/.travis.yml). You should not try to use timings in your budget, simply because they tend to vary and be highly unreliable. We suggest using metrics that do not vary greatly and will be the same between runs like Coach score or number of requests.
 
 ## Circle CI
 Setting up your sitespeed tests on Circle is a straightforward process. What works best is to use Circle's [Linux VM](https://circleci.com/build-environments/linux/), which will spin up a pre-configured VM made to run variations of Docker and pre-installed with lots of tools that you may need to get sitespeed up and running.

--- a/docs/documentation/sitespeed.io/developers/index.md
+++ b/docs/documentation/sitespeed.io/developers/index.md
@@ -132,7 +132,7 @@ To run the Docker version:
 
 If you want to test and push to Graphite/InfluxDB:
 
-- Go to *docker/* in the cloned dir and start the container: <code>docker-compose up</code>
+- Go to *docker/* in the cloned dir and start the container: <code>docker compose up</code>
 - Go back one level and run <code>docker build -t sitespeedio/sitespeed.io .</code> in the cloned directory to build the container
 - Run: <code>docker run --shm-size=1g --rm -v "$(pwd):/sitespeed.io" sitespeedio/sitespeed.io https://www.sitespeed.io -n 1 --graphite.host=192.168.65.1</code> to push the data to Graphite. The IP is the localhost IP if you run on a Mac.
 - Check the metrics at [http://127.0.0.1:3000/](http://127.0.0.1:3000/).
@@ -213,12 +213,12 @@ To be able to release a new version you need to have access to our Docker accoun
 
 You also need to have the sitespeed.io repo at the same level as your checked-out Browsertime repo, so that the documentation can be automatically updated.
 
-Before you do a release, make sure the latest commit has a [green light in Travis](https://travis-ci.org/sitespeedio/browsertime).
+Before you do a release, make sure the latest commit is green on the [Browsertime GitHub Actions](https://github.com/sitespeedio/browsertime/actions).
 
 Do the release:
 1. Make sure you have a clean repo: `git status`
 2. Read through the [CHANGELOG](https://github.com/sitespeedio/browsertime/blob/main/CHANGELOG.md) and see that all changes are included and add the version + date at the top for the new release and commit the change.
-3. Run `./release.sh` (if all tests are ok on Travis feel free to run `./release.sh --yolo` to skip the tests)
+3. Run `./release.sh` (if CI is green you can run `./release.sh --yolo` to skip the local tests)
 4. Choose version
 5. Login into Docker, add your 2FA when prompted
 6. When a new browser window opens at GitHub with the release, copy/paste the changes from the Changelog and add it instead of the commits.

--- a/docs/documentation/sitespeed.io/google-page-speed-insights/index.md
+++ b/docs/documentation/sitespeed.io/google-page-speed-insights/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Run Google Page Speed Insights from sitespeed.io
-description: Since 7.5 you can also run Google Page Speed Insights from sitespeed.io
+description: Run Google Page Speed Insights (GPSI) from sitespeed.io and store the result alongside your other metrics.
 keywords: lighthouse, sitespeed.io
 nav: documentation
 category: sitespeed.io

--- a/docs/documentation/sitespeed.io/google-web-vitals/index.md
+++ b/docs/documentation/sitespeed.io/google-web-vitals/index.md
@@ -55,8 +55,12 @@ You can also change the colour of the highlight: `--browsertime.screenshotLSColo
 
 Remember that the API points out the element that has shifted, not the element that actually pushed the other element.
 
-### Total Blocking Time (TBT) / First input delay
-Total blocking time is harder: it really depends on what CPU you use when you run your tests (test on real mobile phones!). Total blocking time uses the [Long Tasks API](https://w3c.github.io/longtasks/) to get long-running tasks. The API has very limited support for showing what causes the long tasks.
+### Interaction to Next Paint (INP)
+
+INP is the Core Web Vital for responsiveness — it measures the latency of every user interaction with the page and reports the worst (or near-worst) one. To get INP you need to actually interact with the page, which means [scripting](/documentation/sitespeed.io/scripting/). Once interactions happen, sitespeed.io collects INP via the [Event Timing API](https://w3c.github.io/event-timing/) and surfaces it on the metrics tab next to LCP and CLS.
+
+### Total Blocking Time (TBT) / First Input Delay
+Total blocking time is harder to measure: it really depends on what CPU you use when you run your tests (test on real mobile phones!). Total blocking time uses the [Long Tasks API](https://w3c.github.io/longtasks/) to get long-running tasks. The API has very limited support for showing what causes the long tasks. Note that INP has replaced FID as a Core Web Vital — TBT remains a useful lab proxy when you can't drive interactions in scripting.
 
 The best way to get valuable information is to use `--cpu` to get the Chrome trace log to download and drag and drop into the performance tab of DevTools in Chrome. If you need a deeper trace log (with more information) you can add extra trace categories to the tracelog. The CPU profiler does that: `--browsertime.chrome.traceCategory disabled-by-default-v8.cpu_profiler`.
 

--- a/docs/documentation/sitespeed.io/graphite/index.md
+++ b/docs/documentation/sitespeed.io/graphite/index.md
@@ -86,8 +86,8 @@ If you use Graphite < 1.0 you need to make sure the tags in the annotations foll
 
 You can choose to send metrics per page and summarised per domain. If you only test a couple of URLs you probably do not need the summarised per-domain metrics and you can disable them by adding <code>--graphite.skipSummary</code>.
 
-You can add the slug of the test to the key (`--slug`). This will be the default in September 2021, and you should start using it now to be able to see screenshots and the latest videos directly in Grafana. Use it like this:
-`--graphite.addSlugToKey true --slug firstView --graphite.namespace sitespeed_io.desktop` and it will generate the key structure **sitespeed_io.desktop.firstView.**.
+The slug of the test (`--slug`) is added to the Graphite key by default (`--graphite.addSlugToKey true`). This is what makes screenshots and the latest videos show up directly in Grafana. Use it like this:
+`--slug firstView --graphite.namespace sitespeed_io.desktop` and it will generate the key structure **sitespeed_io.desktop.firstView.**. Set `--graphite.addSlugToKey false` if you have legacy data without the slug and need to keep the old layout.
 
 ### Debug
 If you want to test and verify what the metrics that you send to Graphite look like, you can use *tools/tcp-server.js* to see.
@@ -154,13 +154,7 @@ In sitespeed.io **17.0.0** we introduced the ability to add the slug of your tes
 ![New look using the slug]({{site.baseurl}}/img/use-slug.jpg){:loading="lazy"}
 {: .img-thumbnail}
 
-
-The change is rolled out like this:
-* In April 2021 you can convert your data and use the slug. You need to add `--graphite.addSlugToKey true` else you will get a log warning that you miss the slug for your test. All default dashboards in sitespeed.io will use the slug, so to use them you should add that new key and convert your data.
-* In September 2021 `--graphite.addSlugToKey true` will be set to default, meaning if you haven't upgraded your Graphite data yet, you need to set `--graphite.addSlugToKey false` to be able to run as before.
-* In November 2021 the CLI functionality will disappear and you need to upgrade your Graphite metrics when you upgrade sitespeed.io.
-
-If you have old data you should convert it as soon as possible. When you do that you need to add the new dashboards, or if you have your own dashboard, you need to convert it so it picks up the slug.
+`--graphite.addSlugToKey` is `true` by default, so new tests already write their data under the slug. If you still have data from sitespeed.io 16 or earlier — written before the slug existed — the section below explains how to convert it so it lines up with the current dashboards.
 
 
 ### Convert Graphite data structure

--- a/docs/documentation/sitespeed.io/index.md
+++ b/docs/documentation/sitespeed.io/index.md
@@ -23,7 +23,7 @@ Sitespeed.io is the complete toolbox for testing the web performance of your web
 
 ## Run your tests
  * [Configuration](configuration/) - there's a lot you can do with sitespeed.io, let's check out how!
- * [Browsers](browsers/) - collect timings using real browsers. We support Firefox, Chrome, Chrome on Android and limited support for Safari on OS X and iOS.
+ * [Browsers](browsers/) - collect timings using real browsers. We support Firefox, Chrome, Edge, Chrome on Android, Safari on iOS over USB (HAR + video + visual metrics), and limited support for Safari on macOS.
  * [Mobile phones](mobile-phones/) - test using your mobile phone. Chrome on Android and Safari on iOS.
  * [Docker](docker/) - how to use our Docker containers.
  * [Connectivity](connectivity/) - set the connectivity to emulate real users' network conditions.

--- a/docs/documentation/sitespeed.io/lighthouse/index.md
+++ b/docs/documentation/sitespeed.io/lighthouse/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Run Lighthouse from sitespeed.io
-description: Since 7.5 you can also run Lighthouse from sitespeed.io
+description: Run Lighthouse from sitespeed.io and store the results alongside your other metrics.
 keywords: lighthouse, sitespeed.io
 nav: documentation
 category: sitespeed.io
@@ -38,7 +38,7 @@ The Lighthouse result is iframed into sitespeed.io:
 {: .img-thumbnail}
 
 ## Configuration
-By default the plugin runs the tests with desktop settings (*lighthouse/lighthouse-core/config/lr-desktop-config*). If you run sitespeed.io with `--mobile`, `--android` or `--ios` the plugin will run the tests with mobile settings (*lighthouse/lighthouse-core/config/lr-mobile-config*).
+By default the plugin runs the tests with desktop settings. If you run sitespeed.io with `--mobile`, `--android` or `--ios` the plugin switches to Lighthouse's mobile preset.
 
 If you want, you can run the tests with your own configuration. You do that by adding your own JavaScript configuration file ```--lighthouse.config config.js```.
 
@@ -61,7 +61,7 @@ You can also add Lighthouse flags via a JSON file ```--lighthouse.flags flag.jso
 }
 ```
 
-Read all about configuring Lighthouse at [https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md).
+Read all about configuring Lighthouse at [https://github.com/GoogleChrome/lighthouse/blob/main/docs/configuration.md](https://github.com/GoogleChrome/lighthouse/blob/main/docs/configuration.md).
 
 
 ## Disable GPSI

--- a/docs/documentation/sitespeed.io/performance-dashboard/index.md
+++ b/docs/documentation/sitespeed.io/performance-dashboard/index.md
@@ -54,7 +54,7 @@ Before you start, make sure you have the following installed:
    In the terminal, run the following command:
 
    ```bash
-   docker-compose up
+   docker compose up
    ```
 
    This command will download the necessary Docker images and start Grafana and Graphite.
@@ -73,7 +73,7 @@ Before you start, make sure you have the following installed:
 
 6. **Stop docker compose**
 
-   When you're done, you can stop the services by pressing `Ctrl+C` in the terminal where you ran `docker-compose up`. To completely remove the services and volumes defined in the `docker-compose.yml` file, you can run `docker-compose down`.
+   When you're done, you can stop the services by pressing `Ctrl+C` in the terminal where you ran `docker compose up`. To completely remove the services and volumes defined in the `docker-compose.yml` file, you can run `docker compose down`.
 
 Remember, these are simplified instructions. For a production setup, you would need to make additional configurations, such as setting up persistent storage and securing the Grafana dashboard. 
 

--- a/docs/documentation/sitespeed.io/plugins/index.md
+++ b/docs/documentation/sitespeed.io/plugins/index.md
@@ -147,7 +147,7 @@ Plugins in sitespeed.io should inherit the [sitespeed.io plugin](https://github.
 In your dependencies for your plugin, make sure to add the latest version of the plugin.
 
 ~~~javascript
- "@sitespeed.io/plugin": "0.0.5"
+ "@sitespeed.io/plugin": "1.0.0"
 ~~~
 
 ### Basic structure
@@ -222,7 +222,7 @@ You can check out the [StorageManager](https://github.com/sitespeedio/sitespeed.
 [messageMaker](https://github.com/sitespeedio/sitespeed.io/blob/main/lib/support/messageMaker.js),
 [statsHelpers](https://github.com/sitespeedio/sitespeed.io/blob/main/lib/support/statsHelpers.js) and [filterRegistry](https://github.com/sitespeedio/sitespeed.io/blob/main/lib/support/filterRegistry.js) to get a feel for how you can use them.
 
-The *options* are the options that a user will supply in the CLI, check out the [CLI implementation](https://github.com/sitespeedio/sitespeed.io/blob/main/lib/support/cli.js) to see all the options.
+The *options* are the options that a user will supply in the CLI, check out the [CLI implementation](https://github.com/sitespeedio/sitespeed.io/tree/main/lib/cli) to see all the options.
 
 ### processMessage(message, queue)
 The processMessage function in your plugin is called for each and every message that is passed in the application. So what's a message, you may ask? Everything is a message in sitespeed.io :) A message contains the following information:
@@ -387,7 +387,7 @@ queue.postMessage(make('budget.addMessageType', {type: 'gpsi.pagesummary'}));
 ~~~
 
 ## Testing your plugin
-If your plugin lives on GitHub you should check out our [example Travis-ci file](https://github.com/sitespeedio/plugin-gpsi/blob/main/.travis.yml) for the GPSI plugin. In the example, we checkout the sitespeed.io project and run the plugin against the latest main (we also run it daily in the Travis crontab).
+If your plugin lives on GitHub you can model your CI on the [GPSI plugin's GitHub Actions](https://github.com/sitespeedio/plugin-gpsi/actions) — it checks out sitespeed.io and runs the plugin against the latest main on a schedule.
 
 ## Example plugin(s)
 You can look at the standalone [GPSI plugin](https://github.com/sitespeedio/plugin-gpsi) or the [WebPageTest plugin](https://github.com/sitespeedio/sitespeed.io/tree/main/lib/plugins/webpagetest).

--- a/docs/documentation/sitespeed.io/s3/index.md
+++ b/docs/documentation/sitespeed.io/s3/index.md
@@ -95,7 +95,7 @@ You should also make sure that all the result files (HTML/videos/screenshots) ar
 As a last thing you should also add `--copyLatestFilesToBase`, which will make it possible to view the latest screenshot and video in Grafana from S3.
 
 # MinIO
-If you want to deploy the storage yourself, you can use the Open Source [https://min.io](https://min.io). You can deploy that using Docker. There's an example of how you can set that up in [sitespeed.io online test](https://github.com/sitespeedio/onlinetest/blob/main/docker-compose.yml).
+If you want to deploy the storage yourself, you can use the Open Source [https://min.io](https://min.io). You can deploy that using Docker. There's an example of how you can set that up in the [sitespeed.io online test](https://github.com/sitespeedio/onlinetest) repo (see the `docker-compose.*.yml` files at the root).
 
 # Digital Ocean Spaces
 [Digital Ocean Spaces](https://developers.digitalocean.com/documentation/spaces/#aws-s3-compatibility)

--- a/docs/documentation/sitespeed.io/scripting/interact-with-the-page/index.md
+++ b/docs/documentation/sitespeed.io/scripting/interact-with-the-page/index.md
@@ -37,13 +37,13 @@ You can use `commands.find(selector, options)` to find an element and get a Sele
 
 ```javascript
 // Find an element (auto-waits using the configured timeout)
-const element = await commands.find(‘#my-element’);
+const element = await commands.find('#my-element');
 
 // Find with a custom timeout
-const element = await commands.find(‘#my-element’, { timeout: 5000 });
+const element = await commands.find('#my-element', { timeout: 5000 });
 
 // Wait for the element to be visible, not just present in the DOM
-const element = await commands.find(‘#my-element’, { timeout: 5000, visible: true });
+const element = await commands.find('#my-element', { timeout: 5000, visible: true });
 ```
 
 One of the key things in your script is to be able to find the right element to invoke. If the element has an id it's easy. If not, you can use developer tools in your favourite browser. They all work mostly the same: open DevTools on the page you want to inspect, click on the element, then right-click on it in DevTools. You will see something like this:

--- a/docs/documentation/sitespeed.io/thirdparty/index.md
+++ b/docs/documentation/sitespeed.io/thirdparty/index.md
@@ -44,7 +44,7 @@ And then also see the exact tools that are used.
 ![Third party tools]({{site.baseurl}}/img/8.9/thirdparty-tools-html.png){:loading="lazy"}
 {: .img-thumbnail}
 
-At the moment we are very liberal in categorising tools as surveillance and need your help to get it right. Do a PR to help by changing [https://github.com/sitespeedio/sitespeed.io/blob/main/lib/plugins/thirdparty/index.js#L34-L38](https://github.com/sitespeedio/sitespeed.io/blob/main/lib/plugins/thirdparty/index.js#L34-L38).
+Categories come from [coach-core's third-party-web data](https://github.com/sitespeedio/coach-core). If a tool is mis-categorised — or you think the `surveillance` bucket is too liberal for a particular tool — open a PR against coach-core.
 
 The new categorisation happens automatically.
 

--- a/docs/documentation/sitespeed.io/video/index.md
+++ b/docs/documentation/sitespeed.io/video/index.md
@@ -18,7 +18,7 @@ twitterdescription: Use the video in sitespeed.io
 ## The stack (easy with Docker)
 We use FFmpeg to record a video at 30 fps of the screen (you can configure the number of frames per second). The easiest way is to use our Docker container with pre-installed FFmpeg, but if you use the npm version, you can record a video too. Video works on Linux and OS X at the moment.
 
-Once we have the video we use [Visual Metrics](https://github.com/WPO-Foundation/visualmetrics) (built by Pat Meenan) to analyse it and get SpeedIndex and other visual metrics. If you use our Docker container you get that for free, otherwise you need to install all the [Visual Metrics dependencies](https://github.com/sitespeedio/browsertime/blob/main/.travis.yml) yourself. You need FFmpeg, ImageMagick and a couple of Python libraries. Check out Browsertime's [Travis-CI configuration](https://github.com/sitespeedio/browsertime/blob/main/.travis.yml) to see what's needed.
+Once we have the video we use [Visual Metrics](https://github.com/WPO-Foundation/visualmetrics) (built by Pat Meenan) to analyse it and get SpeedIndex and other visual metrics. If you use our Docker container you get that for free, otherwise you need to install FFmpeg, ImageMagick and a few Python libraries (`pyssim`, `opencv-python`, `numpy`, `scipy`) — see the [installation instructions](/documentation/sitespeed.io/installation/) for your OS.
 
 We record the video in two steps. First we turn the background orange (this is used by VisualMetrics to know when the navigation starts), set the background to white, and let the browser go to the URL. The video is recorded lossless. Then, when the video has been analysed, we remove the orange frames and convert the video to a compressed mp4.
 
@@ -48,8 +48,7 @@ When you record a video, the video is first recorded with settings to make the r
 The video will by default include a timer and show when visual metrics happen. If you want the video without any text/timer, just add <code>--browsertime.videoParams.addTimer false</code>.
 
 ### Filmstrip parameters
-When the video is analysed with [VisualMetrics](https://github.com/WPO-Foundation/visualmetrics) screenshots for
-a filmstrip is also created. With sitespeed.io 8.1 you can see them in the HTML.
+When the video is analysed with [VisualMetrics](https://github.com/WPO-Foundation/visualmetrics) screenshots for a filmstrip are also created, and shown on the per-iteration page in the HTML report.
 
 ![Page to page]({{site.baseurl}}/img/filmstrip-multiple-pages.jpg){:loading="lazy"}
 {: .img-thumbnail}

--- a/docs/documentation/sitespeed.io/web-performance-testing-in-practice/index.md
+++ b/docs/documentation/sitespeed.io/web-performance-testing-in-practice/index.md
@@ -355,10 +355,7 @@ Running your tests on desktop is the easiest tests to run. You can choose to run
 
 The Docker container comes with pre-installed Chrome and Firefox (latest stable versions) and all the dependencies needed to record and analyse a video of your test to get visual metrics. We release a new Docker container for each stable Chrome/Firefox, so that way you can roll back versions easily. What's also good with the Docker container is that you start a new container per test, so everything is cleaned between tests. The drawbacks of running in a container could be slower metrics and only support for running Chrome and Firefox. If you are new to using Docker you should read our [Docker documentation](/documentation/sitespeed.io/docker/).
 
-If you use the Node.js version directly, you can run tests on Safari and MS Edge as long as your OS supports it. To record a video and analyse it to get visual metrics, you need to install those dependencies yourself. You can check out our GitHub Actions to see how to do that:
-* [Linux](https://github.com/sitespeedio/browsertime/blob/master/.github/workflows/linux.yml)
-* [OS X](https://github.com/sitespeedio/browsertime/blob/master/.github/workflows/safari.yml)
-* [Windows](https://github.com/sitespeedio/browsertime/blob/master/.github/workflows/windows.yml)
+If you use the Node.js version directly, you can run tests on Safari and MS Edge as long as your OS supports it. To record a video and analyse it to get visual metrics, you need to install those dependencies yourself. Our [Browsertime GitHub Actions workflows](https://github.com/sitespeedio/browsertime/tree/main/.github/workflows) (`linux-chrome.yml`, `linux-firefox.yml`, `mac.yml`, `safari.yml`) show what to install per OS.
 
 You also need to manage the browsers by manually updating them when there's a new version. There's more work to keep your tests running, but you are also in control and can test on more browsers.
 


### PR DESCRIPTION
Five years of small additions and version bumps had left the sitespeed.io docs carrying claims that no longer match reality: Safari support gated on macOS Catalina, the slug-in-Graphite-namespace transition still pitched as a future change, dead links to retired services (Travis CI, the legacy chromedriver.storage bucket, retired plugin repos), and a Web Vitals page that never picked up INP after it became a Core Web Vital.

This pass walks through the whole sitespeed.io subtree and replaces the stale claims, retires the dead links, and trims the time-bound migration prose that's long since landed. No structural changes — the navigation, file layout, and tone are intact; only the parts that had drifted from the code or the wider ecosystem are touched.

The HTML report rewrite, Browsertime 27, and coach-core 9 in v40 are all already documented on the upgrade page; this PR is the back-fill across everywhere else they reach.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com
