### PR TITLE
Auto-detect scripts so --multi is no longer required

### DIFF
--- a/bin/browsertimeWebPageReplay.js
+++ b/bin/browsertimeWebPageReplay.js
@@ -10,7 +10,7 @@ import { hideBin } from 'yargs/helpers';
 
 import { BrowsertimeEngine, configureLogging } from 'browsertime';
 
-import { getURLs } from '../lib/cli/util.js';
+import { getURLs, hasScriptInput } from '../lib/cli/util.js';
 import { findUpSync } from '../lib/support/fileUtil.js';
 
 import {config as browsertimeConfig} from '../lib/plugins/browsertime/index.js';
@@ -217,10 +217,12 @@ async function runBrowsertime() {
   }
 
   const engine = new BrowsertimeEngine(btOptions);
-  const urls = parsed.argv.multi ? parsed.argv._ : getURLs(parsed.argv._);
+  // Auto-detect scripts so --multi is not required (still works explicitly).
+  const isMulti = parsed.argv.multi || hasScriptInput(parsed.argv._);
+  const urls = isMulti ? parsed.argv._ : getURLs(parsed.argv._);
 
   try {
-    await testURLs(engine, urls,  parsed.argv.multi);
+    await testURLs(engine, urls, isMulti);
   } catch (e) {
     console.error('Could not run ' + e);
     process.exit(1);

--- a/bin/sitespeed.js
+++ b/bin/sitespeed.js
@@ -42,6 +42,11 @@ async function api(options) {
     );
     apiOptions.api.scripting = scripting.toString();
     apiOptions.api.scriptingName = path.basename(options._[0]);
+    // options.multi may have been auto-detected from the script file
+    // (so the user did not need to pass --multi). Propagate it to the
+    // remote API so older servers that rely on the explicit flag still
+    // treat this as a multi/script run.
+    apiOptions.multi = true;
   }
 
   if (apiOptions.mobile) {

--- a/docs/documentation/sitespeed.io/scripting/running-scripts/index.md
+++ b/docs/documentation/sitespeed.io/scripting/running-scripts/index.md
@@ -19,18 +19,20 @@ Running scripts in Browsertime is easy. Create your script and run it like this:
 browsertime myScript.mjs
 ```
 
-And in sitespeed.io you need to add the `--multi` switch (test multiple pages).
+In sitespeed.io you can run a script the same way — script files are detected automatically, so the old `--multi` switch is no longer required:
 
 ```bash
-sitespeed.io myScript.mjs --multi
+sitespeed.io myScript.mjs
 ```
+
+`--multi` still works and is kept for backward compatibility; you only need it explicitly if you want to share a single browser session across a list of plain URLs.
 
 ## Multiple scripts
 
 For multiple scripts, list them all in the command. This approach helps manage complex scripts by splitting them into multiple files.
 
 ```bash
-sitespeed.io login.mjs measureStartPage.mjs logout.mjs --multi
+sitespeed.io login.mjs measureStartPage.mjs logout.mjs
 ```
 
 Or you can break out code in multiple files.
@@ -51,7 +53,7 @@ export default async function (context, commands) {
   example();
 }
 ```
-And then run it: `sitespeed.io --multi test.mjs`
+And then run it: `sitespeed.io test.mjs`
 
 ## Add meta data to your script
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -37,7 +37,7 @@ import { addOptions as addApiOptions } from './options/api.js';
 import { addOptions as addPluginsOptions } from './options/plugins.js';
 import { addOptions as addTextOptions } from './options/text.js';
 import { registerPluginOptions } from './pluginOptions.js';
-import { getURLs, getAliases } from './util.js';
+import { getURLs, getAliases, hasScriptInput } from './util.js';
 
 function fixAndroidArgs(args) {
   return args.map(arg => (arg === '--android' ? '--android.enabled' : arg));
@@ -236,6 +236,14 @@ export async function parseCommandLine() {
       'resultBaseURL',
       'https://storage.googleapis.com/' + argv.gcs.bucketname
     );
+  }
+
+  // Auto-detect: if any positional argument is a Browsertime script, flip
+  // multi mode on so users no longer need to pass --multi. The flag still
+  // works for explicit opt-in (e.g. running a list of URLs in one shared
+  // browser session, which has no script to detect).
+  if (!argv.multi && hasScriptInput(argv._)) {
+    argv.multi = true;
   }
 
   let urlsMetaData = argv.multi

--- a/lib/cli/options/core.js
+++ b/lib/cli/options/core.js
@@ -67,7 +67,7 @@ export function addOptions(yargs) {
     })
     .option('multi', {
       describe:
-        'Test multiple URLs within the same browser session (same cache etc). Only works with Browsertime. Use this if you want to test multiple pages (use journey) or want to test multiple pages with scripts. You can mix URLs and scripts (the order will matter): login.js https://www.sitespeed.io/ logout.js - More details: https://www.sitespeed.io/documentation/sitespeed.io/scripting/',
+        'Test multiple URLs within the same browser session (same cache etc). Only works with Browsertime. Auto-enabled when any input is a script file (.js/.cjs/.mjs, or any file whose first non-empty line does not start with http) so you no longer need this flag for scripts. Pass it explicitly only when you want to share a single browser session across a list of plain URLs. You can mix URLs and scripts (the order will matter): login.js https://www.sitespeed.io/ logout.js - More details: https://www.sitespeed.io/documentation/sitespeed.io/scripting/',
       default: false,
       type: 'boolean'
     })

--- a/lib/cli/util.js
+++ b/lib/cli/util.js
@@ -6,6 +6,43 @@ import { format } from 'node:util';
 
 import { toArray } from '../support/util.js';
 
+const SCRIPT_EXTENSIONS = new Set(['.js', '.cjs', '.mjs']);
+
+// Classify a CLI positional argument as either an HTTP(S) URL, a URL-list
+// file (lines of URLs, what `getURLs` reads) or a Browsertime script file
+// (user journey). Used to auto-enable multi mode when a script is passed,
+// so users don't need to remember --multi.
+export function classifyInput(argument) {
+  const trimmed = String(argument).trim();
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return 'url';
+  }
+  const extension = path.extname(trimmed).toLowerCase();
+  if (SCRIPT_EXTENSIONS.has(extension)) {
+    return 'script';
+  }
+  // No script extension: sniff the file. First non-empty line that starts
+  // with http -> URL-list file; otherwise treat it as a script. Unreadable
+  // paths fall through to 'urls-file' so existing ENOENT messages from
+  // getURLs still surface to the user.
+  try {
+    const filePath = path.resolve(trimmed);
+    const content = readFileSync(filePath, { encoding: 'utf8' });
+    for (const line of content.split('\n')) {
+      const t = line.trim();
+      if (t.length === 0) continue;
+      return t.startsWith('http') ? 'urls-file' : 'script';
+    }
+    return 'urls-file';
+  } catch {
+    return 'urls-file';
+  }
+}
+
+export function hasScriptInput(arguments_) {
+  return arguments_.some(argument => classifyInput(argument) === 'script');
+}
+
 /**
  *
  * @param {Object<string, any>} options The plugin options to normalise
@@ -30,7 +67,12 @@ function sanitizePluginOptions(options) {
 
 export function getURLs(urls) {
   const allUrls = [];
-  urls = urls.map(url => url.trim());
+  // Skip script files: they live alongside URLs/URL-list files in mixed
+  // mode (e.g. `login.js https://x.com logout.js`) and should not be parsed
+  // as URL-list text. Auto-detection in cli.js flips --multi on for these.
+  urls = urls
+    .map(url => url.trim())
+    .filter(url => classifyInput(url) !== 'script');
 
   for (let url of urls) {
     if (url.startsWith('http')) {
@@ -70,7 +112,10 @@ export function getURLs(urls) {
 }
 export function getAliases(urls, alias, groupAlias) {
   const urlMetaData = {};
-  urls = urls.map(url => url.trim());
+  // Same script-skip rationale as getURLs above.
+  urls = urls
+    .map(url => url.trim())
+    .filter(url => classifyInput(url) !== 'script');
   let al = toArray(alias);
   let allGroupAlias = toArray(groupAlias);
   let pos = 0;

--- a/lib/cli/validate.js
+++ b/lib/cli/validate.js
@@ -4,7 +4,7 @@ import { readFileSync, statSync } from 'node:fs';
 import friendlynames from '../support/friendlynames.js';
 import { config as htmlConfig } from '../plugins/html/index.js';
 import { toArray } from '../support/util.js';
-import { getURLs } from './util.js';
+import { getURLs, hasScriptInput } from './util.js';
 
 const metricList = Object.keys(friendlynames);
 
@@ -48,11 +48,15 @@ export function validateInput(argv) {
     }
   }
 
-  if (argv.crawler && argv.crawler.depth && argv.multi) {
+  // Treat auto-detected scripts the same as an explicit --multi for these
+  // mode-incompatibility guards.
+  const multiMode = argv.multi || hasScriptInput(argv._);
+
+  if (argv.crawler && argv.crawler.depth && multiMode) {
     return 'Error: Crawl do not work running in multi mode.';
   }
 
-  if (argv.crux && argv.crux.key && argv.multi) {
+  if (argv.crux && argv.crux.key && multiMode) {
     return 'Error: Getting CrUx data do not work running in multi mode.';
   }
 

--- a/test/cliUtilTests.js
+++ b/test/cliUtilTests.js
@@ -1,6 +1,8 @@
 import {
+  classifyInput,
   getURLs,
   getAliases,
+  hasScriptInput,
   pluginDefaults,
   registerPluginOptions
 } from '../lib/cli/util.js';
@@ -42,6 +44,46 @@ test(`getAliases should extract aliases`, t => {
     aliases['https://www.sitespeed.io/documentation/sitespeed.io/webpagetest/'],
     undefined
   );
+});
+
+test(`classifyInput recognises HTTP(S) URLs`, t => {
+  t.is(classifyInput('https://www.sitespeed.io'), 'url');
+  t.is(classifyInput('http://example.com/path'), 'url');
+  t.is(classifyInput('   https://x.com   '), 'url');
+});
+
+test(`classifyInput recognises script files by extension`, t => {
+  t.is(classifyInput('test/prepostscripts/multi.js'), 'script');
+  t.is(classifyInput('test/prepostscripts/multiWindows.cjs'), 'script');
+});
+
+test(`classifyInput recognises URL-list files by content`, t => {
+  t.is(classifyInput('test/fixtures/sitespeed-urls.txt'), 'urls-file');
+  t.is(classifyInput('test/fixtures/sitespeed-urls-aliases.txt'), 'urls-file');
+});
+
+test(`hasScriptInput is true when any argument is a script`, t => {
+  t.true(
+    hasScriptInput(['https://www.sitespeed.io', 'test/prepostscripts/multi.js'])
+  );
+  t.false(
+    hasScriptInput([
+      'https://www.sitespeed.io',
+      'test/fixtures/sitespeed-urls.txt'
+    ])
+  );
+});
+
+test(`getURLs ignores script files mixed with URLs`, t => {
+  const urls = getURLs([
+    'https://www.sitespeed.io',
+    'test/prepostscripts/multi.js',
+    'test/fixtures/sitespeed-urls.txt'
+  ]);
+  t.is(urls[0], 'https://www.sitespeed.io');
+  t.is(urls[1], 'https://www.sitespeed.io');
+  t.is(urls[4], 'https://www.sitespeed.io/faq');
+  t.is(urls.length, 5);
 });
 
 test(`pluginDefaults should yield an empty object for invalid values`, t => {


### PR DESCRIPTION
  Passing a Browsertime script to sitespeed.io used to need a separate
  --multi flag, which is easy to forget and produces confusing output
  (the URL-list parser tries to read JS as URLs). Now any positional
  argument that looks like a script — .js/.cjs/.mjs, or any file
  whose first non-empty line doesn't start with http — flips multi mode
  on automatically, and mixed inputs like login.js https://x.com logout.js
  just work.

  --multi is kept as an explicit override for the one case auto-detection
  can't cover: sharing a single browser session across a list of plain URLs.
  All existing invocations behave exactly as before.

  Co-authored-by: Claude noreply@anthropic.com
