### PR TITLE
Stream gzipped JSON reads instead of buffering whole files

### DIFF
--- a/lib/plugins/browsertime/reader.js
+++ b/lib/plugins/browsertime/reader.js
@@ -1,21 +1,21 @@
 import { createReadStream } from 'node:fs';
 import path from 'node:path';
-import { gunzip as _gunzip } from 'node:zlib';
-import { promisify } from 'node:util';
-const gunzip = promisify(_gunzip);
+import { createGunzip } from 'node:zlib';
+import { pipeline } from 'node:stream/promises';
 
-async function streamToString(stream) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    stream.on('error', reject);
-    stream.on('data', chunk => chunks.push(chunk));
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
-  });
-}
-
+// Read a gzipped JSON file and return the parsed object.
+//
+// Streams the file through createGunzip instead of buffering the whole
+// gzipped payload, gunzipping the whole buffer in one shot and then
+// stringifying it. Chrome traces and HARs are routinely 50+ MB, so the
+// old "chunks -> Buffer.concat -> gunzip(buf) -> toString -> JSON.parse"
+// path peaked at gzipped + unzipped + string + object all alive at once.
+// The new path keeps only the unzipped text chunks plus the parsed object.
 export async function getGzippedFileAsJson(dir, file) {
-  const readStream = createReadStream(path.join(dir, file));
-  const text = await streamToString(readStream);
-  const unzipped = await gunzip(text);
-  return JSON.parse(unzipped.toString());
+  const chunks = [];
+  const gunzip = createGunzip();
+  gunzip.setEncoding('utf8');
+  gunzip.on('data', chunk => chunks.push(chunk));
+  await pipeline(createReadStream(path.join(dir, file)), gunzip);
+  return JSON.parse(chunks.join(''));
 }

--- a/test/readerTests.js
+++ b/test/readerTests.js
@@ -1,0 +1,55 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { gzip as _gzip } from 'node:zlib';
+import { promisify } from 'node:util';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import test from 'ava';
+
+import { getGzippedFileAsJson } from '../lib/plugins/browsertime/reader.js';
+
+const gzip = promisify(_gzip);
+
+test('getGzippedFileAsJson reads and parses a gzipped JSON file', async t => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'sitespeed-reader-'));
+  try {
+    const payload = {
+      hello: 'world',
+      nested: { array: [1, 2, 3], unicode: 'åäö' }
+    };
+    const gz = await gzip(Buffer.from(JSON.stringify(payload)));
+    await writeFile(path.join(dir, 'sample.json.gz'), gz);
+
+    const result = await getGzippedFileAsJson(dir, 'sample.json.gz');
+    t.deepEqual(result, payload);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getGzippedFileAsJson handles payloads larger than a single chunk', async t => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'sitespeed-reader-'));
+  try {
+    // Build a >1 MB payload so gunzip emits multiple data chunks; this
+    // is what guards the streaming join() path.
+    const big = Array.from({ length: 20_000 }, (_, i) => ({
+      i,
+      s: 'x'.repeat(64)
+    }));
+    const gz = await gzip(Buffer.from(JSON.stringify(big)));
+    await writeFile(path.join(dir, 'big.json.gz'), gz);
+
+    const result = await getGzippedFileAsJson(dir, 'big.json.gz');
+    t.is(result.length, big.length);
+    t.deepEqual(result[0], big[0]);
+    t.deepEqual(result.at(-1), big.at(-1));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('getGzippedFileAsJson rejects on a missing file', async t => {
+  await t.throwsAsync(() =>
+    getGzippedFileAsJson(tmpdir(), 'does-not-exist.json.gz')
+  );
+});


### PR DESCRIPTION
  The shared helper that loads gzipped JSON result files (Chrome traces,
  console logs, etc.) used to read the entire gzipped payload into a
  Buffer, gunzip the whole buffer, stringify it, then JSON.parse. For a
  50+ MB trace that meant four copies of the data alive at peak.

  Pipe the file through createGunzip and collect utf-8 chunks instead.
  The parsed object still needs to fit in memory, but the gzipped buffer
  and the throwaway unzipped Buffer copies are gone.

Co-authored-by: Claude noreply@anthropic.com
