### PR TITLE
More streaming wins: dedup gzip JSON reads, stream S3 uploads

### DIFF
--- a/lib/plugins/s3/index.js
+++ b/lib/plugins/s3/index.js
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { promises as fsPromises } from 'node:fs';
+import { createReadStream, promises as fsPromises } from 'node:fs';
 
 import { getLogger } from '@sitespeed.io/log';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
@@ -23,13 +23,20 @@ const normalizeExpires = maybeSeconds => {
 };
 
 async function uploadFile(file, s3Client, s3Options, prefix, baseDir) {
-  const stream = await fsPromises.readFile(file);
+  // Stream the file straight into PutObject instead of buffering it in
+  // memory. With maxAsyncS3 defaulting to 20 concurrent uploads, the old
+  // readFile() path peaked at ~20 * largest-file in RSS; large HARs and
+  // videos in a result bundle made this painful. ContentLength is
+  // required so the SDK doesn't fall back to buffering the stream to
+  // compute the signature.
+  const { size: contentLength } = await fsPromises.stat(file);
   const contentType = getContentType(file);
   const subPath = path.relative(baseDir, file);
   const baseParams = {
     Bucket: s3Options.bucketname,
     Key: path.join(s3Options.path || prefix, subPath),
-    Body: stream,
+    Body: createReadStream(file),
+    ContentLength: contentLength,
     ContentType: contentType,
     ACL: s3Options.acl
   };

--- a/lib/plugins/sustainable/index.js
+++ b/lib/plugins/sustainable/index.js
@@ -1,8 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
-import zlib from 'node:zlib';
-import { promisify } from 'node:util';
 
 import { getLogger } from '@sitespeed.io/log';
 import { co2, hosting } from '@tgwf/co2';
@@ -15,6 +13,7 @@ import {
   perPage,
   perDomain
 } from './helper.js';
+import { getGzippedFileAsJson } from '../browsertime/reader.js';
 
 const fsp = fs.promises;
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -26,7 +25,6 @@ const packageJson = JSON.parse(
 );
 const co2Version = packageJson.dependencies['@tgwf/co2'];
 
-const gunzip = promisify(zlib.gunzip);
 const log = getLogger('sitespeedio.plugin.sustainable');
 
 const DEFAULT_METRICS_PAGE_SUMMARY = [
@@ -36,27 +34,14 @@ const DEFAULT_METRICS_PAGE_SUMMARY = [
   'co2ThirdParty'
 ];
 
-async function streamToString(stream) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    stream.on('error', reject);
-    stream.on('data', chunk => chunks.push(chunk));
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
-  });
-}
-
-async function getGzippedFileAsJson(jsonPath) {
-  const readStream = fs.createReadStream(jsonPath);
-  const text = await streamToString(readStream);
-  const unzipped = await gunzip(text);
-  return unzipped.toString();
-}
-
 async function loadJSON(jsonPath) {
-  const jsonBuffer = jsonPath.endsWith('.gz')
-    ? await getGzippedFileAsJson(jsonPath)
-    : await fsp.readFile(jsonPath);
-  return JSON.parse(jsonBuffer);
+  if (jsonPath.endsWith('.gz')) {
+    return getGzippedFileAsJson(
+      path.dirname(jsonPath),
+      path.basename(jsonPath)
+    );
+  }
+  return JSON.parse(await fsp.readFile(jsonPath));
 }
 
 export default class SustainablePlugin extends SitespeedioPlugin {


### PR DESCRIPTION
  Two follow-ups to the gzip-JSON streaming fix that landed in #4726:

  The sustainable plugin had its own copy of the old buffer-everything
  gzipped JSON reader. Point it at the shared streaming helper so we keep
  one implementation and the green-domain data load benefits from the
  same memory profile.

  The S3 plugin loaded every file fully into memory before handing it to
  PutObject. With 20 concurrent uploads that meant RSS could spike to
  roughly twenty times the size of the largest file in a result bundle —
  painful for runs with big HARs or videos. Use createReadStream and
  declare ContentLength so the SDK can sign and ship the stream without
  buffering it back up.

  Co-authored-by: Claude noreply@anthropic.com
