### PR TITLE
Stream gzipped HAR writes instead of buffering the whole payload

### DIFF
--- a/lib/core/resultsStorage/storageManager.js
+++ b/lib/core/resultsStorage/storageManager.js
@@ -6,8 +6,10 @@ import {
   lstat as _lstat,
   readdir as _readdir,
   unlink as _unlink,
-  writeFile as _writeFile
+  writeFile as _writeFile,
+  createWriteStream
 } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
 
 import { cp } from 'node:fs/promises';
 import { getLogger } from '@sitespeed.io/log';
@@ -23,7 +25,15 @@ const rmdir = promisify(_rmdir);
 const writeFile = promisify(_writeFile);
 
 function write(dirPath, filename, data) {
-  return writeFile(path.join(dirPath, filename), data);
+  const target = path.join(dirPath, filename);
+  // If the caller hands us a Readable, stream it to disk instead of
+  // buffering. This lets large gzipped HAR pipelines flow chunk-by-chunk
+  // straight to the file rather than materializing the whole compressed
+  // payload in RSS first. Strings/Buffers keep the existing writeFile path.
+  if (data && typeof data.pipe === 'function') {
+    return pipeline(data, createWriteStream(target));
+  }
+  return writeFile(target, data);
 }
 
 function isValidDirectoryName(name) {

--- a/lib/plugins/harstorer/index.js
+++ b/lib/plugins/harstorer/index.js
@@ -1,7 +1,6 @@
-import { gzip as _gzip } from 'node:zlib';
-import { promisify } from 'node:util';
+import { Readable } from 'node:stream';
+import { createGzip } from 'node:zlib';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
-const gzip = promisify(_gzip);
 
 export default class HarstorerPlugin extends SitespeedioPlugin {
   constructor(options, context, queue) {
@@ -23,26 +22,29 @@ export default class HarstorerPlugin extends SitespeedioPlugin {
       case 'browsertime.har': {
         const json = JSON.stringify(message.data);
 
-        return this.gzipHAR
-          ? gzip(Buffer.from(json), {
-              level: 1
-            }).then(gziped =>
-              this.storageManager.writeDataForUrl(
-                gziped,
-                `${message.type}.gz`,
-                message.url,
-                undefined,
+        if (this.gzipHAR) {
+          // Stream the JSON through gzip straight to disk. The old path
+          // materialized json + Buffer.from(json) + the full gzipped Buffer
+          // simultaneously, so a 200 MB HAR could peak at several hundred
+          // MB of RSS. Now only the JSON string plus gzip's in-flight
+          // chunks are alive at any given moment.
+          const source = Readable.from([json]).pipe(createGzip({ level: 1 }));
+          return this.storageManager.writeDataForUrl(
+            source,
+            `${message.type}.gz`,
+            message.url,
+            undefined,
+            this.alias[message.url]
+          );
+        }
 
-                this.alias[message.url]
-              )
-            )
-          : this.storageManager.writeDataForUrl(
-              json,
-              message.type,
-              message.url,
-              undefined,
-              this.alias[message.url]
-            );
+        return this.storageManager.writeDataForUrl(
+          json,
+          message.type,
+          message.url,
+          undefined,
+          this.alias[message.url]
+        );
       }
     }
   }

--- a/test/storageManagerTests.js
+++ b/test/storageManagerTests.js
@@ -1,4 +1,9 @@
 import path from 'node:path';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { Readable } from 'node:stream';
+import { createGunzip } from 'node:zlib';
+import { pipeline } from 'node:stream/promises';
 
 import dayjs from 'dayjs';
 import test from 'ava';
@@ -56,4 +61,87 @@ test(`Create prefix with custom output folder`, t => {
     '/tmp/sitespeed.io/foo'
   );
   t.is(storageManager.getStoragePrefix(), 'foo');
+});
+
+test(`writeDataForUrl accepts a Readable and streams it to disk`, async t => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'sitespeed-storage-'));
+  try {
+    const storageManager = createManager('http://www.foo.bar', dir);
+    const payload = 'hello-streaming-world';
+    await storageManager.writeDataForUrl(
+      Readable.from([payload]),
+      'streamed.txt',
+      'http://www.foo.bar/page'
+    );
+    const written = await readFile(
+      path.join(dir, 'pages', 'www_foo_bar', 'page', 'data', 'streamed.txt'),
+      'utf8'
+    );
+    t.is(written, payload);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test(`writeDataForUrl still accepts a Buffer/string (backward compat)`, async t => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'sitespeed-storage-'));
+  try {
+    const storageManager = createManager('http://www.foo.bar', dir);
+    await storageManager.writeDataForUrl(
+      'plain text content',
+      'plain.txt',
+      'http://www.foo.bar/page'
+    );
+    const written = await readFile(
+      path.join(dir, 'pages', 'www_foo_bar', 'page', 'data', 'plain.txt'),
+      'utf8'
+    );
+    t.is(written, 'plain text content');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test(`writeDataForUrl streams gzip pipelines round-trip correctly`, async t => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'sitespeed-storage-'));
+  try {
+    const storageManager = createManager('http://www.foo.bar', dir);
+    // Build something HAR-shaped that meaningfully exercises the gzip
+    // path: large enough that gzip emits multiple data chunks.
+    const big = {
+      log: {
+        entries: Array.from({ length: 5000 }, (_, i) => ({
+          i,
+          url: 'https://example.com/' + i
+        }))
+      }
+    };
+    const json = JSON.stringify(big);
+    const { createGzip } = await import('node:zlib');
+    const source = Readable.from([json]).pipe(createGzip({ level: 1 }));
+    await storageManager.writeDataForUrl(
+      source,
+      'browsertime.har.gz',
+      'http://www.foo.bar/page'
+    );
+
+    const gzipped = await readFile(
+      path.join(
+        dir,
+        'pages',
+        'www_foo_bar',
+        'page',
+        'data',
+        'browsertime.har.gz'
+      )
+    );
+    const chunks = [];
+    const gunzip = createGunzip();
+    gunzip.setEncoding('utf8');
+    gunzip.on('data', c => chunks.push(c));
+    await pipeline(Readable.from([gzipped]), gunzip);
+    t.deepEqual(JSON.parse(chunks.join('')), big);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
  Writing a gzipped HAR used to materialize three full copies of the same
  data at once: the JSON string, a Buffer copy of that string, and the
  fully gzipped Buffer that gzip(Buffer.from(json)) produces. For a 200 MB
  HAR that meant several hundred MB of avoidable RSS at peak, multiplied
  again when several pages finish around the same time.

  Pipe the JSON through createGzip straight to disk so only the JSON
  string and gzip's in-flight chunks are alive at any given moment. The
  storage layer now accepts a Readable in addition to strings and Buffers
  so harstorer can hand it a pipeline; existing callers are unaffected.

Co-authored-by: Claude noreply@anthropic.com