### PR TITLE
Drop unused fast-crc32c dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,6 @@
         "browsertime": "27.2.0",
         "coach-core": "9.1.0",
         "dayjs": "1.11.18",
-        "fast-crc32c": "2.0.0",
         "fast-stats": "0.0.7",
         "import-global": "1.1.1",
         "lodash.get": "4.4.2",
@@ -57,7 +56,7 @@
         "sass": "1.93.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -5027,7 +5026,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -6642,14 +6641,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "node_modules/fast-crc32c": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-crc32c/-/fast-crc32c-2.0.0.tgz",
-      "integrity": "sha512-LIREwygxtxzHF11oLJ4xIVKu/ZWNgrj/QaGvaSD8ZggIsgCyCtSYevlrpWVqNau57ZwezV8K1HFBSjQ7FcRbTQ==",
-      "optionalDependencies": {
-        "sse4_crc32": "^6.0.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6812,7 +6803,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -8619,12 +8610,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node_modules/node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
-      "optional": true
-    },
     "node_modules/node-downloader-helper": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.9.tgz",
@@ -10412,20 +10397,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "node_modules/sse4_crc32": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/sse4_crc32/-/sse4_crc32-6.0.1.tgz",
-      "integrity": "sha512-FUTYXpLroqytNKWIfHzlDWoy9E4tmBB/RklNMy6w3VJs+/XEYAHgbiylg4SS43iOk/9bM0BlJ2EDpFAGT66IoQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.3.0",
-        "node-addon-api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/ssh2": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "browsertime": "27.2.0",
     "coach-core": "9.1.0",
     "dayjs": "1.11.18",
-    "fast-crc32c": "2.0.0",
     "fast-stats": "0.0.7",
     "import-global": "1.1.1",
     "lodash.get": "4.4.2",


### PR DESCRIPTION
  We used to pull in fast-crc32c because the old @google-cloud/storage
  client could detect it as a native addon and use it to speed up CRC32C
  hashing on uploads. The modern @google-cloud/storage (we're on 7.19)
  ships its own pure-JS CRC32C implementation and no longer reads
  fast-crc32c at all — it's not in its deps, optionalDependencies or
  peerDependencies, and nothing in sitespeed.io imports it directly.

  Removing it shrinks the dependency tree and stops shipping a native
  addon that's no longer doing any work.

  Co-authored-by: Claude noreply@anthropic.com

