### PR TITLE
Replace lodash.get with a small local helper

### DIFF
--- a/bin/browsertimeWebPageReplay.js
+++ b/bin/browsertimeWebPageReplay.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 
 import merge from 'lodash.merge';
 import set from 'lodash.set';
-import get from 'lodash.get';
+import { get } from '../lib/support/objectPath.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -6,7 +6,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import merge from 'lodash.merge';
 import set from 'lodash.set';
-import get from 'lodash.get';
+import { get } from '../support/objectPath.js';
 
 import { config, globalPluginsToAdd, version } from './configLoader.js';
 import { validateInput } from './validate.js';

--- a/lib/core/queueStatistics.js
+++ b/lib/core/queueStatistics.js
@@ -1,4 +1,4 @@
-import get from 'lodash.get';
+import { get } from '../support/objectPath.js';
 import set from 'lodash.set';
 
 import { pushStats, summarizeStats } from '../support/statsHelpers.js';

--- a/lib/plugins/assets/aggregator.js
+++ b/lib/plugins/assets/aggregator.js
@@ -1,4 +1,4 @@
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import { AssetsBySize } from './assetsBySize.js';
 import { AssetsBySpeed } from './assetsBySpeed.js';
 

--- a/lib/plugins/browsertime/analyzer.js
+++ b/lib/plugins/browsertime/analyzer.js
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import merge from 'lodash.merge';
 import set from 'lodash.set';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import coach from 'coach-core';
 import { BrowsertimeEngine, browserScripts } from 'browsertime';
 const { getDomAdvice } = coach;

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -7,7 +7,7 @@ import { configureLogging } from 'browsertime';
 const log = getLogger('plugin.browsertime');
 
 import dayjs from 'dayjs';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import { Stats } from 'fast-stats';
 import coach from 'coach-core';
 const {

--- a/lib/plugins/budget/deprecatedVerify.js
+++ b/lib/plugins/budget/deprecatedVerify.js
@@ -1,7 +1,7 @@
 /**
  * The old verificatuion and budget.json was deprecated in 8.0
  */
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import { noop, size } from '../../support/helpers/index.js';
 import { getLogger } from '@sitespeed.io/log';
 const log = getLogger('sitespeedio.plugin.budget');

--- a/lib/plugins/budget/verify.js
+++ b/lib/plugins/budget/verify.js
@@ -1,7 +1,7 @@
 /**
  * The old verificatuion and budget.json was deprecated in 8.0
  */
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import merge from 'lodash.merge';
 import { getLogger } from '@sitespeed.io/log';
 const log = getLogger('sitespeedio.plugin.budget');

--- a/lib/plugins/compare/index.js
+++ b/lib/plugins/compare/index.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 import { getLogger } from '@sitespeed.io/log';
 import merge from 'lodash.merge';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import dayjs from 'dayjs';
 
 import {

--- a/lib/plugins/graphite/index.js
+++ b/lib/plugins/graphite/index.js
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import dayjs from 'dayjs';
 import { getLogger } from '@sitespeed.io/log';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';

--- a/lib/plugins/html/dataCollector.js
+++ b/lib/plugins/html/dataCollector.js
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import set from 'lodash.set';
 
 export class DataCollector {

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import { getLogger } from '@sitespeed.io/log';
 import { markdown } from 'markdown';
 import merge from 'lodash.merge';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 
 const log = getLogger('sitespeedio.plugin.html');
 const require = createRequire(import.meta.url);

--- a/lib/plugins/html/index.js
+++ b/lib/plugins/html/index.js
@@ -1,4 +1,4 @@
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import set from 'lodash.set';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 import { DataCollector } from './dataCollector.js';

--- a/lib/plugins/html/metricHelper.js
+++ b/lib/plugins/html/metricHelper.js
@@ -1,4 +1,4 @@
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 
 export function pickMedianRun(runs, pageInfo) {
   // Choose the median run. Early first version, in the future we can make

--- a/lib/plugins/html/setup/summaryBoxes.js
+++ b/lib/plugins/html/setup/summaryBoxes.js
@@ -2,7 +2,7 @@ import { getLogger } from '@sitespeed.io/log';
 const log = getLogger('sitespeedio.plugin.html');
 import { toArray } from '../../../support/util.js';
 import friendlyNames from '../../../support/friendlynames.js';
-import get from 'lodash.get';
+import { get } from '../../../support/objectPath.js';
 import defaultLimits from './summaryBoxesDefaultLimits.js';
 import merge from 'lodash.merge';
 

--- a/lib/plugins/lateststorer/index.js
+++ b/lib/plugins/lateststorer/index.js
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { platform } from 'node:os';
 
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 
 import { getURLAndGroup, getConnectivity } from '../../support/tsdbUtil.js';
 import { cap, plural } from '../../support/helpers/index.js';

--- a/lib/plugins/matrix/index.js
+++ b/lib/plugins/matrix/index.js
@@ -1,5 +1,5 @@
 import { getLogger } from '@sitespeed.io/log';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 
 import send from './send.js';

--- a/lib/plugins/slack/attachements.js
+++ b/lib/plugins/slack/attachements.js
@@ -1,4 +1,4 @@
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import { time, noop, size } from '../../support/helpers/index.js';
 
 function getMetric(metric, f) {

--- a/lib/plugins/slack/dataCollector.js
+++ b/lib/plugins/slack/dataCollector.js
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import set from 'lodash.set';
 
 export class DataCollector {

--- a/lib/plugins/slack/summary.js
+++ b/lib/plugins/slack/summary.js
@@ -1,5 +1,5 @@
 import { format } from 'node:util';
-import get from 'lodash.get';
+import { get } from '../../support/objectPath.js';
 import {
   time,
   noop,

--- a/lib/support/helpers/get.js
+++ b/lib/support/helpers/get.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line unicorn/no-named-default
-import { default as _get } from 'lodash.get';
+import { get as _get } from '../objectPath.js';
 
 export function get(object, property, defaultValue) {
   if (arguments.length < 3) {

--- a/lib/support/metricsFilter.js
+++ b/lib/support/metricsFilter.js
@@ -1,4 +1,4 @@
-import get from 'lodash.get';
+import { get } from './objectPath.js';
 import set from 'lodash.set';
 import merge from 'lodash.merge';
 

--- a/lib/support/objectPath.js
+++ b/lib/support/objectPath.js
@@ -1,0 +1,17 @@
+function toPath(path) {
+  if (Array.isArray(path)) return path;
+  return String(path).split('.');
+}
+
+function isNullish(value) {
+  return value === undefined || value === null;
+}
+
+export function get(object, path, defaultValue) {
+  let current = object;
+  for (const segment of toPath(path)) {
+    if (isNullish(current)) return defaultValue;
+    current = current[segment];
+  }
+  return current === undefined ? defaultValue : current;
+}

--- a/lib/support/statsHelpers.js
+++ b/lib/support/statsHelpers.js
@@ -1,5 +1,5 @@
 import { Stats } from 'fast-stats';
-import get from 'lodash.get';
+import { get } from './objectPath.js';
 import set from 'lodash.set';
 
 function percentileName(percentile) {

--- a/lib/support/tsdbUtil.js
+++ b/lib/support/tsdbUtil.js
@@ -1,4 +1,4 @@
-import get from 'lodash.get';
+import { get } from './objectPath.js';
 import { keypathFromUrl } from './flattenMessage.js';
 
 export function toSafeKey(key, safeChar = '_') {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,6 @@
         "dayjs": "1.11.18",
         "fast-stats": "0.0.7",
         "import-global": "1.1.1",
-        "lodash.get": "4.4.2",
         "lodash.merge": "4.6.2",
         "lodash.set": "4.3.2",
         "markdown": "0.5.0",
@@ -8266,11 +8265,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "node_modules/lodash.groupby": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "dayjs": "1.11.18",
     "fast-stats": "0.0.7",
     "import-global": "1.1.1",
-    "lodash.get": "4.4.2",
     "lodash.merge": "4.6.2",
     "lodash.set": "4.3.2",
     "markdown": "0.5.0",


### PR DESCRIPTION
  lodash.get was used in 24 files for simple path-walking like
  get(obj, 'a.b.c', defaultValue). It's a thousand-line transitive
  package for what amounts to a dozen lines of code. The new helper at
  lib/support/objectPath.js covers the call patterns we actually use:
  dot-string or array paths, defaultValue applied only when the resolved
  value is undefined (null is returned as-is), and an early bail when an
  intermediate node is nullish — matching lodash.get's semantics.

  This change is intentionally isolated to lodash.get only; lodash.set
  and lodash.merge stay for now and will be replaced in separate
  commits so each step can be reviewed and tested in CI on its own.

  Co-authored-by: Claude noreply@anthropic.com
