### PR TITLE
Swap node-scp for ssh2-sftp-client to speed up uploads

### DIFF
--- a/lib/plugins/scp/index.js
+++ b/lib/plugins/scp/index.js
@@ -2,76 +2,74 @@ import path from 'node:path';
 import fs from 'node:fs';
 
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
-import { Client } from 'node-scp';
+import SftpClient from 'ssh2-sftp-client';
 import { getLogger } from '@sitespeed.io/log';
 import { throwIfMissing } from '../../support/util.js';
 import { recursiveReaddir } from '../../support/fileUtil.js';
 
 const log = getLogger('sitespeedio.plugin.scp');
 
-async function getClient(scpOptions) {
-  const options = {
+const CONCURRENT_UPLOADS = 16;
+
+function buildConnectConfig(scpOptions) {
+  const config = {
     host: scpOptions.host,
-    port: scpOptions.port || 22
+    port: scpOptions.port || 22,
+    promiseLimit: CONCURRENT_UPLOADS
   };
   if (scpOptions.username) {
-    options.username = scpOptions.username;
+    config.username = scpOptions.username;
   }
   if (scpOptions.password) {
-    options.password = scpOptions.password;
+    config.password = scpOptions.password;
   }
   if (scpOptions.privateKey) {
-    options.privateKey = fs.readFileSync(scpOptions.privateKey);
+    config.privateKey = fs.readFileSync(scpOptions.privateKey);
   }
   if (scpOptions.passphrase) {
-    options.passphrase = scpOptions.passphrase;
+    config.passphrase = scpOptions.passphrase;
   }
-  return await Client(options);
+  return config;
 }
 
 async function upload(dir, scpOptions, prefix) {
-  let client;
+  const client = new SftpClient();
   try {
-    client = await getClient(scpOptions);
-    const directories = prefix.split('/');
-    let fullPath = '';
-    for (let dir of directories) {
-      fullPath += dir + '/';
-      const doThePathExist = await client.exists(
-        path.join(scpOptions.destinationPath, fullPath)
-      );
-      if (!doThePathExist) {
-        await client.mkdir(path.join(scpOptions.destinationPath, fullPath));
-      }
+    await client.connect(buildConnectConfig(scpOptions));
+    const target = path.join(scpOptions.destinationPath, prefix);
+    if (!(await client.exists(target))) {
+      await client.mkdir(target, true);
     }
-    await client.uploadDir(dir, path.join(scpOptions.destinationPath, prefix));
+    await client.uploadDir(dir, target, { useFastput: true });
   } catch (error) {
     log.error(`Error uploading dir ` + error);
     throw error;
   } finally {
-    if (client) {
-      client.close();
-    }
+    await client.end();
   }
 }
 
 async function uploadFiles(files, scpOptions, prefix) {
-  let client;
+  const client = new SftpClient();
   try {
-    client = await getClient(scpOptions);
-    for (let file of files) {
-      await client.uploadFile(
-        file,
-        path.join(scpOptions.destinationPath, prefix, path.basename(file))
+    await client.connect(buildConnectConfig(scpOptions));
+    const target = path.join(scpOptions.destinationPath, prefix);
+    if (!(await client.exists(target))) {
+      await client.mkdir(target, true);
+    }
+    for (let i = 0; i < files.length; i += CONCURRENT_UPLOADS) {
+      const batch = files.slice(i, i + CONCURRENT_UPLOADS);
+      await Promise.all(
+        batch.map(file =>
+          client.fastPut(file, path.join(target, path.basename(file)))
+        )
       );
     }
   } catch (error) {
     log.error(`Error uploading files ` + error);
     throw error;
   } finally {
-    if (client) {
-      client.close();
-    }
+    await client.end();
   }
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -26,10 +26,10 @@
         "lodash.merge": "4.6.2",
         "lodash.set": "4.3.2",
         "markdown": "0.5.0",
-        "node-scp": "0.0.25",
         "ora": "9.0.0",
         "pug": "3.0.3",
         "simplecrawler": "1.1.9",
+        "ssh2-sftp-client": "12.1.1",
         "waterfall-tools": "https://codeload.github.com/pmeenan/waterfall-tools/tar.gz/123f6e4",
         "yargs": "18.0.0"
       },
@@ -5157,6 +5157,12 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/buildcheck": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
@@ -5650,6 +5656,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "devOptional": true
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/concordance": {
       "version": "5.0.4",
@@ -8691,15 +8712,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-scp": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/node-scp/-/node-scp-0.0.25.tgz",
-      "integrity": "sha512-vodQgKRuxRjrzwTXyRl0JsrF+mjc/P4M2jwIjg4gpdbNC3KBWptTVN9b5PqludLsN402MdKN6lGydlmXGGv1YA==",
-      "license": "MIT",
-      "dependencies": {
-        "ssh2": "^1.16.0"
-      }
-    },
     "node_modules/node-stream-zip": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
@@ -10415,6 +10427,23 @@
         "nan": "^2.20.0"
       }
     },
+    "node_modules/ssh2-sftp-client": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-12.1.1.tgz",
+      "integrity": "sha512-wYVDgwkpcKG2iPGQQ+QR33xkWqLFIaVrYvA+uON4pmxTPaPuB81f1aooUEPN75e/9DCK6rrKYXb6zR6zP3+EtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "ssh2": "^1.16.0"
+      },
+      "engines": {
+        "node": ">=18.20.4"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://square.link/u/4g7sPflL"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -10914,6 +10943,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/uc.micro": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -99,10 +99,10 @@
     "lodash.merge": "4.6.2",
     "lodash.set": "4.3.2",
     "markdown": "0.5.0",
-    "node-scp": "0.0.25",
     "ora": "9.0.0",
     "pug": "3.0.3",
     "simplecrawler": "1.1.9",
+    "ssh2-sftp-client": "12.1.1",
     "waterfall-tools": "https://codeload.github.com/pmeenan/waterfall-tools/tar.gz/123f6e4",
     "yargs": "18.0.0"
   },


### PR DESCRIPTION
  node-scp uploads files serially: its uploadDir is a recursive for-loop
  awaiting one fastPut at a time, so a run that produces a few thousand
  small result files (HTML pages, HARs, screenshots) spends most of its
  wall-clock time on per-file SFTP round-trips. ssh2-sftp-client is built
  on the same ssh2 transport but its uploadDir partitions the file list
  by promiseLimit (we set it to 16) and fans out concurrent uploads,
  which removes the round-trip bottleneck.

  Auth, options and CLI surface are unchanged — host/port/username/
  password/privateKey/passphrase all map directly. node-scp's npm
  version was stuck at 0.0.25 with minimal upstream activity, so this
  also moves us onto a more actively maintained dep with the same
  ssh2 base.

  Co-authored-by: Claude noreply@anthropic.com