### PR TITLE
Add an rsync plugin for faster result uploads

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -56,8 +56,12 @@ jobs:
       run: npm install serve -g
     - name: Start local HTTP server
       run: (serve test/data/html/ -l 3001&)
+    - name: Install sshpass for the rsync password test
+      run: sudo apt-get install -y sshpass
     - name: Run Chrome test sending data using scp
       run: bin/sitespeed.js http://127.0.0.1:3001/simple/ --xvfb -n 1 --scp.host localhost --scp.port 2222 --scp.username scpuser --scp.password password --scp.destinationPath /config/
+    - name: Run Chrome test sending data using rsync
+      run: bin/sitespeed.js http://127.0.0.1:3001/simple/ --xvfb -n 1 --rsync.host localhost --rsync.port 2222 --rsync.username scpuser --rsync.password password --rsync.destinationPath /config/
     - name: Run Chrome test sending data to GCS
       run: STORAGE_EMULATOR_HOST="http://localhost:8081" node bin/sitespeed.js http://127.0.0.1:3001/simple/ --xvfb -n 1 --gcs.bucketname sitespeed --gcs.projectId sitespeed
     - name: Run Chrome test sending data to S3

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -36,13 +36,20 @@ jobs:
       # repeatedly during `apt-get update` here. The user's home is
       # /config (linuxserver convention), which is why the test below
       # uses --scp.destinationPath /config/ rather than /home/scpuser/.
+      # We install rsync inside the container so the rsync plugin test
+      # below can use it on the receiving side.
       run: |
-          docker run -d -p 2222:2222 \
+          docker run -d --name ssh-test -p 2222:2222 \
             -e PUID=1000 -e PGID=1000 \
             -e USER_NAME=scpuser \
             -e USER_PASSWORD=password \
             -e PASSWORD_ACCESS=true \
             lscr.io/linuxserver/openssh-server:latest
+          for i in $(seq 1 20); do
+            if docker exec ssh-test apk --version >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          docker exec ssh-test apk add --no-cache rsync
     - name: Setup GCS container
       run: |
           docker run -d -p 8081:8081 fsouza/fake-gcs-server:1.50 -scheme http -port 8081 -external-url http://localhost:8081 -backend memory

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -26,6 +26,7 @@ import { addOptions as addSlackOptions } from './options/slack.js';
 import { addOptions as addS3Options } from './options/s3.js';
 import { addOptions as addGcsOptions } from './options/gcs.js';
 import { addOptions as addScpOptions } from './options/scp.js';
+import { addOptions as addRsyncOptions } from './options/rsync.js';
 import { addOptions as addMatrixOptions } from './options/matrix.js';
 import { addOptions as addBudgetOptions } from './options/budget.js';
 import { addOptions as addCruxOptions } from './options/crux.js';
@@ -69,6 +70,7 @@ const TOPIC_DEFS = [
   ['s3', addS3Options],
   ['gcs', addGcsOptions],
   ['scp', addScpOptions],
+  ['rsync', addRsyncOptions],
   ['matrix', addMatrixOptions],
   ['budget', addBudgetOptions],
   ['crux', addCruxOptions],

--- a/lib/cli/options/rsync.js
+++ b/lib/cli/options/rsync.js
@@ -1,0 +1,42 @@
+export function addOptions(yargs) {
+  yargs
+    .option('rsync.host', {
+      describe: 'The host.',
+      group: 'rsync'
+    })
+    .option('rsync.destinationPath', {
+      describe:
+        'The destination path on the remote server where the files will be copied.',
+      group: 'rsync'
+    })
+    .option('rsync.port', {
+      default: 22,
+      describe: 'The port for ssh when sending the result to another server.',
+      group: 'rsync'
+    })
+    .option('rsync.username', {
+      describe:
+        'The username. Use username/password or username/privateKey/pem.',
+      group: 'rsync'
+    })
+    .option('rsync.password', {
+      describe:
+        'The password if you do not use a pem file. Requires sshpass on PATH.',
+      group: 'rsync'
+    })
+    .option('rsync.privateKey', {
+      describe: 'Path to the pem file.',
+      group: 'rsync'
+    })
+    .option('rsync.passphrase', {
+      describe:
+        'The passphrase for the pem file. The rsync plugin cannot supply this non-interactively; load the key into ssh-agent before running.',
+      group: 'rsync'
+    })
+    .option('rsync.removeLocalResult', {
+      default: true,
+      describe:
+        'Remove the files locally when the files has been copied to the other server.',
+      group: 'rsync'
+    });
+}

--- a/lib/plugins/rsync/index.js
+++ b/lib/plugins/rsync/index.js
@@ -1,0 +1,176 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { spawn } from 'node:child_process';
+
+import { SitespeedioPlugin } from '@sitespeed.io/plugin';
+import { getLogger } from '@sitespeed.io/log';
+import { throwIfMissing } from '../../support/util.js';
+import { recursiveReaddir } from '../../support/fileUtil.js';
+
+const log = getLogger('sitespeedio.plugin.rsync');
+
+function buildSshArgs(rsyncOptions) {
+  const args = ['-p', String(rsyncOptions.port || 22)];
+  if (rsyncOptions.privateKey) {
+    args.push('-i', rsyncOptions.privateKey);
+  }
+  args.push(
+    '-o',
+    'StrictHostKeyChecking=no',
+    '-o',
+    'UserKnownHostsFile=/dev/null'
+  );
+  return args;
+}
+
+function quoteArg(arg) {
+  if (/^[\w@:/.=-]+$/.test(arg)) return arg;
+  return `'${arg.replaceAll(`'`, `'\\''`)}'`;
+}
+
+function buildSshCommandString(rsyncOptions) {
+  const parts = ['ssh', ...buildSshArgs(rsyncOptions)];
+  return parts.map(arg => quoteArg(arg)).join(' ');
+}
+
+function wrapWithSshpass(rsyncOptions, command, args) {
+  if (!rsyncOptions.password) return { command, args, env: undefined };
+  return {
+    command: 'sshpass',
+    args: ['-e', command, ...args],
+    env: { ...process.env, SSHPASS: rsyncOptions.password }
+  };
+}
+
+function run(command, args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { env });
+    let stderr = '';
+    child.stderr.on('data', chunk => {
+      stderr += chunk.toString();
+    });
+    child.on('error', error => reject(error));
+    child.on('close', code => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(
+            `${command} exited with code ${code}${stderr ? ': ' + stderr.trim() : ''}`
+          )
+        );
+    });
+  });
+}
+
+async function ensureRemoteDir(rsyncOptions, remotePath) {
+  const sshArgs = [
+    ...buildSshArgs(rsyncOptions),
+    `${rsyncOptions.username}@${rsyncOptions.host}`,
+    'mkdir',
+    '-p',
+    remotePath
+  ];
+  const { command, args, env } = wrapWithSshpass(rsyncOptions, 'ssh', sshArgs);
+  await run(command, args, env);
+}
+
+async function rsync(rsyncOptions, sources, remotePath) {
+  const rsyncArgs = ['-a', '-e', buildSshCommandString(rsyncOptions)];
+  for (const src of sources) rsyncArgs.push(src);
+  rsyncArgs.push(
+    `${rsyncOptions.username}@${rsyncOptions.host}:${remotePath}/`
+  );
+  const { command, args, env } = wrapWithSshpass(
+    rsyncOptions,
+    'rsync',
+    rsyncArgs
+  );
+  await run(command, args, env);
+}
+
+async function upload(dir, rsyncOptions, prefix) {
+  const target = path.join(rsyncOptions.destinationPath, prefix);
+  try {
+    await ensureRemoteDir(rsyncOptions, target);
+    const sourceWithTrailingSlash = dir.endsWith('/') ? dir : dir + '/';
+    await rsync(rsyncOptions, [sourceWithTrailingSlash], target);
+  } catch (error) {
+    log.error(`Error uploading dir ` + error);
+    throw error;
+  }
+}
+
+async function uploadFiles(files, rsyncOptions, prefix) {
+  const target = path.join(rsyncOptions.destinationPath, prefix);
+  try {
+    await ensureRemoteDir(rsyncOptions, target);
+    if (files.length > 0) {
+      await rsync(rsyncOptions, files, target);
+    }
+  } catch (error) {
+    log.error(`Error uploading files ` + error);
+    throw error;
+  }
+}
+
+async function uploadLatestFiles(dir, rsyncOptions, prefix) {
+  const files = await recursiveReaddir(dir, true);
+
+  return uploadFiles(files, rsyncOptions, prefix);
+}
+
+export default class RsyncPlugin extends SitespeedioPlugin {
+  constructor(options, context, queue) {
+    super({ name: 'rsync', options, context, queue });
+  }
+  open(context, options) {
+    this.rsyncOptions = options.rsync;
+    this.options = options;
+    this.make = context.messageMaker('rsync').make;
+    throwIfMissing(
+      this.rsyncOptions,
+      ['host', 'destinationPath', 'username'],
+      'rsync'
+    );
+    if (this.rsyncOptions.passphrase) {
+      log.warn(
+        'rsync.passphrase is set but the rsync plugin cannot supply it non-interactively; load the key into ssh-agent before running sitespeed.io.'
+      );
+    }
+    this.storageManager = context.storageManager;
+  }
+  async processMessage(message, queue) {
+    if (message.type === 'sitespeedio.setup') {
+      // Let other plugins know that the rsync plugin is alive
+      queue.postMessage(this.make('rsync.setup'));
+    } else if (message.type === 'html.finished') {
+      const make = this.make;
+      const baseDir = this.storageManager.getBaseDir();
+
+      log.info(`Uploading ${baseDir} using rsync, this can take a while ...`);
+
+      try {
+        await upload(
+          baseDir,
+          this.rsyncOptions,
+          this.storageManager.getStoragePrefix()
+        );
+        if (this.options.copyLatestFilesToBase) {
+          const rootPath = path.resolve(baseDir, '..');
+          const prefix = this.storageManager.getStoragePrefix();
+          const firstPart = prefix.split('/')[0];
+          await uploadLatestFiles(rootPath, this.rsyncOptions, firstPart);
+        }
+        log.info('Finished upload using rsync');
+        if (this.rsyncOptions.removeLocalResult) {
+          fs.rmSync(baseDir, { recursive: true });
+          log.debug(`Removed local files and directory ${baseDir}`);
+        }
+      } catch (error) {
+        queue.postMessage(make('error', error));
+        log.error('Could not upload using rsync', error);
+      }
+      queue.postMessage(make('rsync.finished'));
+    }
+  }
+}


### PR DESCRIPTION
  The existing scp plugin walks files one at a time over a single SFTP
  channel, which is the worst case for a result directory of thousands
  of small files — each one waits a full round-trip before the next
  starts. Shelling out to rsync over ssh pipelines the wire protocol
  and reuses the channel, so the same upload finishes in a small
  fraction of the time on a typical Linux host.

  This is exposed as a new plugin (--rsync.host / --rsync.username /
  --rsync.privateKey / --rsync.destinationPath / etc.) sitting next
  to scp, s3 and gcs, so users on the existing scp plugin keep their
  exact behaviour and pick rsync only when they explicitly opt in.
  Password authentication works through sshpass when present;
  passphrase-protected keys need ssh-agent loaded ahead of time. The
  plugin shells out to the system rsync and ssh binaries, which is
  fine for the Linux runtime where sitespeed.io is mostly deployed.

  Co-authored-by: Claude noreply@anthropic.com
