### PR TITLE
Drop ora in favour of a tiny in-tree blinking-dot spinner

### DIFF
--- a/bin/sitespeed.js
+++ b/bin/sitespeed.js
@@ -10,7 +10,7 @@ import { readFileSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 
 import merge from 'lodash.merge';
-import ora from 'ora';
+import ora from '../lib/support/spinner.js';
 
 import { parseCommandLine } from '../lib/cli/cli.js';
 import { run } from '../lib/sitespeed.js';

--- a/lib/support/spinner.js
+++ b/lib/support/spinner.js
@@ -1,0 +1,60 @@
+const ON = '●';
+const OFF = ' ';
+const BLINK_INTERVAL_MS = 500;
+
+class Spinner {
+  constructor({ text = '', isSilent = false, stream = process.stderr } = {}) {
+    this.text = text;
+    this.color = '';
+    this.isSilent = isSilent;
+    this.stream = stream;
+    this.isTTY = !isSilent && Boolean(stream.isTTY);
+    this.on = true;
+    this.intervalId = undefined;
+    this.lastLineLength = 0;
+  }
+
+  start() {
+    if (this.isSilent) return this;
+    if (this.isTTY) {
+      this.intervalId = setInterval(() => this._render(), BLINK_INTERVAL_MS);
+      this._render();
+    } else {
+      this.stream.write(this.text + '\n');
+    }
+    return this;
+  }
+
+  _render() {
+    const dot = this.on ? ON : OFF;
+    this.on = !this.on;
+    const line = `${dot} ${this.text}`;
+    const padding = ' '.repeat(Math.max(0, this.lastLineLength - line.length));
+    this.stream.write('\r' + line + padding);
+    this.lastLineLength = line.length;
+  }
+
+  _stop(symbol, finalText) {
+    if (this.isSilent) return;
+    if (this.intervalId !== undefined) {
+      clearInterval(this.intervalId);
+      this.intervalId = undefined;
+    }
+    if (this.isTTY) {
+      this.stream.write('\r' + ' '.repeat(this.lastLineLength) + '\r');
+    }
+    this.stream.write(`${symbol} ${finalText ?? this.text}\n`);
+  }
+
+  succeed(text) {
+    this._stop('✔', text);
+  }
+
+  fail(text) {
+    this._stop('✖', text);
+  }
+}
+
+export default function ora(options) {
+  return new Spinner(options);
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,7 +25,6 @@
         "lodash.merge": "4.6.2",
         "lodash.set": "4.3.2",
         "markdown": "0.5.0",
-        "ora": "9.0.0",
         "pug": "3.0.3",
         "simplecrawler": "1.1.9",
         "ssh2-sftp-client": "12.1.1",
@@ -5288,6 +5287,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -5485,33 +5485,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.3.0.tgz",
-      "integrity": "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate": {
@@ -7675,17 +7648,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8309,22 +8271,6 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
     },
-    "node_modules/log-symbols": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
-      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -8530,6 +8476,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -8813,21 +8760,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8843,45 +8775,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ora": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
-      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.6.2",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^3.2.0",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.1.0",
-        "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^8.1.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/os-homedir": {
@@ -9872,22 +9765,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -10457,17 +10334,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stream-events": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "lodash.merge": "4.6.2",
     "lodash.set": "4.3.2",
     "markdown": "0.5.0",
-    "ora": "9.0.0",
     "pug": "3.0.3",
     "simplecrawler": "1.1.9",
     "ssh2-sftp-client": "12.1.1",


### PR DESCRIPTION
  ora is only used by one CLI flow (--api.add / --api.addAndGetResult)
  to show progress while polling the test result. For that single
  pixel of UX we were pulling ora plus its exclusive transitive deps
  (cli-cursor, cli-spinners, log-symbols, is-interactive,
  stdin-discarder, restore-cursor, onetime, mimic-function).

  The replacement at lib/support/spinner.js is ~60 lines: a blinking
  dot toggling between '●' and ' ' on stderr every 500ms while a
  request is in flight, finishing with '✔ text' on success or
  '✖ text' on failure. It exposes the same surface the API code
  expects (start, text setter, color setter as a no-op, succeed,
  fail) and falls back to plain "starting line, final line" output
  when stderr isn't a TTY, so CI logs stay readable.

  Co-authored-by: Claude noreply@anthropic.com

