### PR TITLE
Replace lodash.set with a small local helper

### DIFF
--- a/bin/browsertimeWebPageReplay.js
+++ b/bin/browsertimeWebPageReplay.js
@@ -3,8 +3,7 @@
 import { readFileSync } from 'node:fs';
 
 import merge from 'lodash.merge';
-import set from 'lodash.set';
-import { get } from '../lib/support/objectPath.js';
+import { get, set } from '../lib/support/objectPath.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -5,8 +5,7 @@ import { readFileSync } from 'node:fs';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import merge from 'lodash.merge';
-import set from 'lodash.set';
-import { get } from '../support/objectPath.js';
+import { get, set } from '../support/objectPath.js';
 
 import { config, globalPluginsToAdd, version } from './configLoader.js';
 import { validateInput } from './validate.js';

--- a/lib/core/queueStatistics.js
+++ b/lib/core/queueStatistics.js
@@ -1,5 +1,4 @@
-import { get } from '../support/objectPath.js';
-import set from 'lodash.set';
+import { get, set } from '../support/objectPath.js';
 
 import { pushStats, summarizeStats } from '../support/statsHelpers.js';
 

--- a/lib/plugins/browsertime/analyzer.js
+++ b/lib/plugins/browsertime/analyzer.js
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import merge from 'lodash.merge';
-import set from 'lodash.set';
-import { get } from '../../support/objectPath.js';
+import { get, set } from '../../support/objectPath.js';
 import coach from 'coach-core';
 import { BrowsertimeEngine, browserScripts } from 'browsertime';
 const { getDomAdvice } = coach;

--- a/lib/plugins/html/dataCollector.js
+++ b/lib/plugins/html/dataCollector.js
@@ -1,6 +1,5 @@
 import merge from 'lodash.merge';
-import { get } from '../../support/objectPath.js';
-import set from 'lodash.set';
+import { get, set } from '../../support/objectPath.js';
 
 export class DataCollector {
   constructor(resultUrls) {

--- a/lib/plugins/html/index.js
+++ b/lib/plugins/html/index.js
@@ -1,5 +1,4 @@
-import { get } from '../../support/objectPath.js';
-import set from 'lodash.set';
+import { get, set } from '../../support/objectPath.js';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 import { DataCollector } from './dataCollector.js';
 import { HTMLBuilder } from './htmlBuilder.js';

--- a/lib/plugins/slack/dataCollector.js
+++ b/lib/plugins/slack/dataCollector.js
@@ -1,6 +1,5 @@
 import merge from 'lodash.merge';
-import { get } from '../../support/objectPath.js';
-import set from 'lodash.set';
+import { get, set } from '../../support/objectPath.js';
 
 export class DataCollector {
   constructor(context) {

--- a/lib/plugins/slack/index.js
+++ b/lib/plugins/slack/index.js
@@ -1,7 +1,7 @@
 import { getLogger } from '@sitespeed.io/log';
 import { IncomingWebhook } from '@slack/webhook';
 import merge from 'lodash.merge';
-import set from 'lodash.set';
+import { set } from '../../support/objectPath.js';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 
 import { DataCollector } from './dataCollector.js';

--- a/lib/plugins/text/index.js
+++ b/lib/plugins/text/index.js
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge';
-import set from 'lodash.set';
+import { set } from '../../support/objectPath.js';
 
 import { renderSummary, renderBriefSummary } from './textBuilder.js';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';

--- a/lib/support/metricsFilter.js
+++ b/lib/support/metricsFilter.js
@@ -1,5 +1,4 @@
-import { get } from './objectPath.js';
-import set from 'lodash.set';
+import { get, set } from './objectPath.js';
 import merge from 'lodash.merge';
 
 import { toArray, isEmpty } from './util.js';

--- a/lib/support/objectPath.js
+++ b/lib/support/objectPath.js
@@ -1,3 +1,5 @@
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function toPath(path) {
   if (Array.isArray(path)) return path;
   return String(path).split('.');
@@ -14,4 +16,24 @@ export function get(object, path, defaultValue) {
     current = current[segment];
   }
   return current === undefined ? defaultValue : current;
+}
+
+export function set(object, path, value) {
+  if (isNullish(object)) return object;
+  const segments = toPath(path);
+  let current = object;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    if (FORBIDDEN_KEYS.has(segment)) return object;
+    const next = current[segment];
+    if (isNullish(next) || typeof next !== 'object') {
+      current[segment] = {};
+    }
+    current = current[segment];
+  }
+  const last = segments.at(-1);
+  if (!FORBIDDEN_KEYS.has(last)) {
+    current[last] = value;
+  }
+  return object;
 }

--- a/lib/support/objectPath.js
+++ b/lib/support/objectPath.js
@@ -1,4 +1,5 @@
 const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const INDEX_RE = /^(?:0|[1-9]\d*)$/;
 
 function toPath(path) {
   if (Array.isArray(path)) return path;
@@ -7,6 +8,10 @@ function toPath(path) {
 
 function isNullish(value) {
   return value === undefined || value === null;
+}
+
+function looksLikeArrayIndex(segment) {
+  return INDEX_RE.test(String(segment));
 }
 
 export function get(object, path, defaultValue) {
@@ -27,7 +32,7 @@ export function set(object, path, value) {
     if (FORBIDDEN_KEYS.has(segment)) return object;
     const next = current[segment];
     if (isNullish(next) || typeof next !== 'object') {
-      current[segment] = {};
+      current[segment] = looksLikeArrayIndex(segments[i + 1]) ? [] : {};
     }
     current = current[segment];
   }

--- a/lib/support/statsHelpers.js
+++ b/lib/support/statsHelpers.js
@@ -1,6 +1,5 @@
 import { Stats } from 'fast-stats';
-import { get } from './objectPath.js';
-import set from 'lodash.set';
+import { get, set } from './objectPath.js';
 
 function percentileName(percentile) {
   if (percentile === 0) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,7 +23,6 @@
         "fast-stats": "0.0.7",
         "import-global": "1.1.1",
         "lodash.merge": "4.6.2",
-        "lodash.set": "4.3.2",
         "markdown": "0.5.0",
         "ora": "9.0.0",
         "pug": "3.0.3",
@@ -8297,11 +8296,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "fast-stats": "0.0.7",
     "import-global": "1.1.1",
     "lodash.merge": "4.6.2",
-    "lodash.set": "4.3.2",
     "markdown": "0.5.0",
     "ora": "9.0.0",
     "pug": "3.0.3",


### PR DESCRIPTION
  Continues the lodash unbundling started in #4737. lodash.set was used
  in 11 files for the same simple "walk a dot-separated path, creating
  empty objects as needed, and assign the value at the end" pattern that
  the new objectPath helper already covers for get. We extend objectPath
  with set so both live next to each other.

  The semantics match lodash.set: dot-string or array paths, plain
  object intermediates are created when missing, an existing primitive
  at a path segment is replaced by a new object. The one deliberate
  deviation is that proto, constructor and prototype path segments
  are skipped at every level — that's a prototype-pollution guard,
  mostly relevant for the CLI parser path in lib/cli/cli.js where the
  key comes from yargs-parsed user input.

Co-authored-by: Claude noreply@anthropic.com
