### PR TITLE
Replace lodash.merge with a small local helper

### DIFF
--- a/bin/browsertimeWebPageReplay.js
+++ b/bin/browsertimeWebPageReplay.js
@@ -2,8 +2,7 @@
 
 import { readFileSync } from 'node:fs';
 
-import merge from 'lodash.merge';
-import { get, set } from '../lib/support/objectPath.js';
+import { get, set, merge } from '../lib/support/objectPath.js';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 

--- a/bin/sitespeed.js
+++ b/bin/sitespeed.js
@@ -9,7 +9,7 @@ import path from 'node:path';
 import { readFileSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 
-import merge from 'lodash.merge';
+import { merge } from '../lib/support/objectPath.js';
 import ora from '../lib/support/spinner.js';
 
 import { parseCommandLine } from '../lib/cli/cli.js';

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -4,8 +4,7 @@ import { readFileSync } from 'node:fs';
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import merge from 'lodash.merge';
-import { get, set } from '../support/objectPath.js';
+import { get, set, merge } from '../support/objectPath.js';
 
 import { config, globalPluginsToAdd, version } from './configLoader.js';
 import { validateInput } from './validate.js';

--- a/lib/plugins/browsertime/analyzer.js
+++ b/lib/plugins/browsertime/analyzer.js
@@ -1,6 +1,5 @@
 import path from 'node:path';
-import merge from 'lodash.merge';
-import { get, set } from '../../support/objectPath.js';
+import { get, set, merge } from '../../support/objectPath.js';
 import coach from 'coach-core';
 import { BrowsertimeEngine, browserScripts } from 'browsertime';
 const { getDomAdvice } = coach;

--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line unicorn/no-named-default
-import { default as _merge } from 'lodash.merge';
+import { get, merge as _merge } from '../../support/objectPath.js';
 
 import { getLogger } from '@sitespeed.io/log';
 import { configureLogging } from 'browsertime';
@@ -7,7 +6,6 @@ import { configureLogging } from 'browsertime';
 const log = getLogger('plugin.browsertime');
 
 import dayjs from 'dayjs';
-import { get } from '../../support/objectPath.js';
 import { Stats } from 'fast-stats';
 import coach from 'coach-core';
 const {

--- a/lib/plugins/budget/junit.js
+++ b/lib/plugins/budget/junit.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import merge from 'lodash.merge';
+import { merge } from '../../support/objectPath.js';
 import { getLogger } from '@sitespeed.io/log';
 
 const log = getLogger('sitespeedio.plugin.budget');

--- a/lib/plugins/budget/verify.js
+++ b/lib/plugins/budget/verify.js
@@ -1,8 +1,7 @@
 /**
  * The old verificatuion and budget.json was deprecated in 8.0
  */
-import { get } from '../../support/objectPath.js';
-import merge from 'lodash.merge';
+import { get, merge } from '../../support/objectPath.js';
 import { getLogger } from '@sitespeed.io/log';
 const log = getLogger('sitespeedio.plugin.budget');
 import friendlyNames from '../../support/friendlynames.js';

--- a/lib/plugins/compare/index.js
+++ b/lib/plugins/compare/index.js
@@ -4,8 +4,7 @@ import path from 'node:path';
 
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 import { getLogger } from '@sitespeed.io/log';
-import merge from 'lodash.merge';
-import { get } from '../../support/objectPath.js';
+import { get, merge } from '../../support/objectPath.js';
 import dayjs from 'dayjs';
 
 import {

--- a/lib/plugins/crawler/index.js
+++ b/lib/plugins/crawler/index.js
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import merge from 'lodash.merge';
+import { merge } from '../../support/objectPath.js';
 import { getLogger } from '@sitespeed.io/log';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 

--- a/lib/plugins/crux/index.js
+++ b/lib/plugins/crux/index.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { getLogger } from '@sitespeed.io/log';
-import merge from 'lodash.merge';
+import { merge } from '../../support/objectPath.js';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 
 import { throwIfMissing } from '../../support/util.js';

--- a/lib/plugins/graphite/index.js
+++ b/lib/plugins/graphite/index.js
@@ -1,5 +1,4 @@
-import merge from 'lodash.merge';
-import { get } from '../../support/objectPath.js';
+import { get, merge } from '../../support/objectPath.js';
 import dayjs from 'dayjs';
 import { getLogger } from '@sitespeed.io/log';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';

--- a/lib/plugins/html/dataCollector.js
+++ b/lib/plugins/html/dataCollector.js
@@ -1,5 +1,4 @@
-import merge from 'lodash.merge';
-import { get, set } from '../../support/objectPath.js';
+import { get, set, merge } from '../../support/objectPath.js';
 
 export class DataCollector {
   constructor(resultUrls) {

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -6,8 +6,7 @@ import { fileURLToPath } from 'node:url';
 import dayjs from 'dayjs';
 import { getLogger } from '@sitespeed.io/log';
 import { markdown } from 'markdown';
-import merge from 'lodash.merge';
-import { get } from '../../support/objectPath.js';
+import { get, merge } from '../../support/objectPath.js';
 
 const log = getLogger('sitespeedio.plugin.html');
 const require = createRequire(import.meta.url);

--- a/lib/plugins/html/setup/summaryBoxes.js
+++ b/lib/plugins/html/setup/summaryBoxes.js
@@ -2,9 +2,8 @@ import { getLogger } from '@sitespeed.io/log';
 const log = getLogger('sitespeedio.plugin.html');
 import { toArray } from '../../../support/util.js';
 import friendlyNames from '../../../support/friendlynames.js';
-import { get } from '../../../support/objectPath.js';
+import { get, merge } from '../../../support/objectPath.js';
 import defaultLimits from './summaryBoxesDefaultLimits.js';
-import merge from 'lodash.merge';
 
 function infoBox(stat, name, formatter) {
   if (stat === undefined) {

--- a/lib/plugins/metrics/index.js
+++ b/lib/plugins/metrics/index.js
@@ -1,4 +1,4 @@
-import merge from 'lodash.merge';
+import { merge } from '../../support/objectPath.js';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 import { flattenMessageData } from '../../support/flattenMessage.js';
 

--- a/lib/plugins/slack/dataCollector.js
+++ b/lib/plugins/slack/dataCollector.js
@@ -1,5 +1,4 @@
-import merge from 'lodash.merge';
-import { get, set } from '../../support/objectPath.js';
+import { get, set, merge } from '../../support/objectPath.js';
 
 export class DataCollector {
   constructor(context) {

--- a/lib/plugins/slack/index.js
+++ b/lib/plugins/slack/index.js
@@ -1,7 +1,6 @@
 import { getLogger } from '@sitespeed.io/log';
 import { IncomingWebhook } from '@slack/webhook';
-import merge from 'lodash.merge';
-import { set } from '../../support/objectPath.js';
+import { set, merge } from '../../support/objectPath.js';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 
 import { DataCollector } from './dataCollector.js';

--- a/lib/plugins/text/index.js
+++ b/lib/plugins/text/index.js
@@ -1,5 +1,4 @@
-import merge from 'lodash.merge';
-import { set } from '../../support/objectPath.js';
+import { set, merge } from '../../support/objectPath.js';
 
 import { renderSummary, renderBriefSummary } from './textBuilder.js';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';

--- a/lib/support/messageMaker.js
+++ b/lib/support/messageMaker.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import merge from 'lodash.merge';
+import { merge } from './objectPath.js';
 import { randomUUID } from 'node:crypto';
 
 export function messageMaker(source) {

--- a/lib/support/metricsFilter.js
+++ b/lib/support/metricsFilter.js
@@ -1,5 +1,4 @@
-import { get, set } from './objectPath.js';
-import merge from 'lodash.merge';
+import { get, set, merge } from './objectPath.js';
 
 import { toArray, isEmpty } from './util.js';
 

--- a/lib/support/objectPath.js
+++ b/lib/support/objectPath.js
@@ -42,3 +42,43 @@ export function set(object, path, value) {
   }
   return object;
 }
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function canMergeInto(value) {
+  return value !== null && typeof value === 'object';
+}
+
+function mergeInto(target, source) {
+  for (const key of Object.keys(source)) {
+    if (FORBIDDEN_KEYS.has(key)) continue;
+    const sourceValue = source[key];
+    const targetValue = target[key];
+    if (Array.isArray(sourceValue)) {
+      const into = Array.isArray(targetValue) ? targetValue : [];
+      mergeInto(into, sourceValue);
+      target[key] = into;
+    } else if (isPlainObject(sourceValue)) {
+      const into = canMergeInto(targetValue) ? targetValue : {};
+      mergeInto(into, sourceValue);
+      target[key] = into;
+    } else if (sourceValue === undefined) {
+      if (!(key in target)) target[key] = undefined;
+    } else {
+      target[key] = sourceValue;
+    }
+  }
+}
+
+export function merge(target, ...sources) {
+  if (isNullish(target)) return target;
+  for (const source of sources) {
+    if (isNullish(source)) continue;
+    mergeInto(target, source);
+  }
+  return target;
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,6 @@
         "dayjs": "1.11.18",
         "fast-stats": "0.0.7",
         "import-global": "1.1.1",
-        "lodash.merge": "4.6.2",
         "markdown": "0.5.0",
         "pug": "3.0.3",
         "simplecrawler": "1.1.9",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "dayjs": "1.11.18",
     "fast-stats": "0.0.7",
     "import-global": "1.1.1",
-    "lodash.merge": "4.6.2",
     "markdown": "0.5.0",
     "pug": "3.0.3",
     "simplecrawler": "1.1.9",


### PR DESCRIPTION
  Closes out the lodash unbundling (#4737 dropped lodash.get, #4741
  dropped lodash.set). lodash.merge was the trickiest of the three to
  match — it merges arrays by index, skips undefined source values
  unless the key is missing on the target, and treats plain objects
  differently from Date/RegExp/class instances — so the new merge in
  lib/support/objectPath.js was verified two ways before shipping:

  1. A side-by-side unit comparison against lodash.merge across 23 edge cases (deep nesting, arrays by index, undefined/null handling, Date/RegExp by-reference, mixed types).
  2. A full parseCommandLine() A/B run against the same commands that broke previously (SCP upload, Edge test, the old-budget run) plus a deeply-nested-args case — all four produce byte-identical parsed argv structures.

  That puts an end to the lodash subtree: package.json no longer
  declares any lodash.* package.

  Co-authored-by: Claude noreply@anthropic.com

