### PR TITLE
Replace dayjs with a small native-Date helper

### DIFF
--- a/lib/plugins/browsertime/index.js
+++ b/lib/plugins/browsertime/index.js
@@ -5,7 +5,7 @@ import { configureLogging } from 'browsertime';
 
 const log = getLogger('plugin.browsertime');
 
-import dayjs from 'dayjs';
+import timestamp from '../../support/time.js';
 import { Stats } from 'fast-stats';
 import coach from 'coach-core';
 const {
@@ -436,7 +436,7 @@ export default class BrowsertimePlugin extends SitespeedioPlugin {
                 run.ios = result[resultIndex].info.ios;
               }
 
-              run.timestamp = dayjs(
+              run.timestamp = timestamp(
                 result[resultIndex].timestamps[runIndex]
               ).format(TIME_FORMAT);
 
@@ -592,9 +592,9 @@ export default class BrowsertimePlugin extends SitespeedioPlugin {
             }
 
             // Let take the first runs timestamp and use that as the summary timestamp
-            result.timestamp = dayjs(result[resultIndex].timestamps[0]).format(
-              TIME_FORMAT
-            );
+            result.timestamp = timestamp(
+              result[resultIndex].timestamps[0]
+            ).format(TIME_FORMAT);
 
             if (options.chrome && options.chrome.collectConsoleLog) {
               result[resultIndex].statistics.console =

--- a/lib/plugins/compare/index.js
+++ b/lib/plugins/compare/index.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 import { getLogger } from '@sitespeed.io/log';
 import { get, merge } from '../../support/objectPath.js';
-import dayjs from 'dayjs';
+import timestamp from '../../support/time.js';
 
 import {
   getStatistics,
@@ -228,14 +228,14 @@ export default class ComparePlugin extends SitespeedioPlugin {
 
             const meta = {
               baseline: {
-                timestamp: dayjs(baseline.browsertime.info.timestamp).format(
-                  TIME_FORMAT
-                ),
+                timestamp: timestamp(
+                  baseline.browsertime.info.timestamp
+                ).format(TIME_FORMAT),
                 url: baseline.browsertime.info.url,
                 alias: baseline.browsertime.info.alias
               },
               current: {
-                timestamp: dayjs(
+                timestamp: timestamp(
                   this.browsertimes[url].data.info.timestamp
                 ).format(TIME_FORMAT),
                 url: url,

--- a/lib/plugins/grafana/index.js
+++ b/lib/plugins/grafana/index.js
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs';
+import ts from '../../support/time.js';
 
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 
@@ -79,7 +79,7 @@ export default class GrafanaPlugin extends SitespeedioPlugin {
 
           const timestamp =
             message.type === 'browsertime.pageSummary'
-              ? dayjs(message.runTime)
+              ? ts(message.runTime)
               : this.timestamp;
 
           return send(

--- a/lib/plugins/graphite/index.js
+++ b/lib/plugins/graphite/index.js
@@ -1,5 +1,5 @@
 import { get, merge } from '../../support/objectPath.js';
-import dayjs from 'dayjs';
+import ts from '../../support/time.js';
 import { getLogger } from '@sitespeed.io/log';
 import { SitespeedioPlugin } from '@sitespeed.io/plugin';
 
@@ -134,7 +134,7 @@ export default class GraphitePlugin extends SitespeedioPlugin {
       message.type === 'browsertime.run' ||
       message.type === 'browsertime.pageSummary'
     ) {
-      timestamp = dayjs(message.runTime);
+      timestamp = ts(message.runTime);
     }
     const dataPoints = this.dataGenerator.dataFromMessage(
       message,
@@ -165,7 +165,7 @@ export default class GraphitePlugin extends SitespeedioPlugin {
 
           const timestamp =
             message.type === 'browsertime.pageSummary'
-              ? dayjs(message.runTime)
+              ? ts(message.runTime)
               : this.timestamp;
 
           return send(

--- a/lib/plugins/html/htmlBuilder.js
+++ b/lib/plugins/html/htmlBuilder.js
@@ -3,7 +3,7 @@ import { platform, hostname } from 'node:os';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
-import dayjs from 'dayjs';
+import ts from '../../support/time.js';
 import { getLogger } from '@sitespeed.io/log';
 import { markdown } from 'markdown';
 import { get, merge } from '../../support/objectPath.js';
@@ -286,7 +286,7 @@ export class HTMLBuilder {
       // Take the timestamp from the first run from Browsertime. If you
       // don't use browsertime fallback,
       const summaryTimestamp = pageInfo.data.browsertime
-        ? dayjs(pageInfo.data.browsertime.pageSummary.timestamps[0]).format(
+        ? ts(pageInfo.data.browsertime.pageSummary.timestamps[0]).format(
             TIME_FORMAT
           )
         : timestamp;

--- a/lib/sitespeed.js
+++ b/lib/sitespeed.js
@@ -4,8 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs/promises';
 
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc.js';
+import ts from './support/time.js';
 import { getLogger } from '@sitespeed.io/log';
 
 import { configure } from './core/logging.js';
@@ -25,7 +24,6 @@ const packageJson = JSON.parse(
 );
 
 const log = getLogger('sitespeedio');
-dayjs.extend(utc);
 
 const budgetResult = {
   working: {},
@@ -53,7 +51,7 @@ function runOptionalFunction(objects, fN) {
 export async function run(options) {
   try {
     const url = options.urls[0];
-    const timestamp = options.utc ? dayjs.utc() : dayjs();
+    const timestamp = options.utc ? ts.utc() : ts();
     const { storageManager, resultUrls } = resultsStorage(
       url,
       timestamp,

--- a/lib/support/messageMaker.js
+++ b/lib/support/messageMaker.js
@@ -1,14 +1,14 @@
-import dayjs from 'dayjs';
+import timestamp from './time.js';
 import { merge } from './objectPath.js';
 import { randomUUID } from 'node:crypto';
 
 export function messageMaker(source) {
   return {
     make(type, data, extras) {
-      const timestamp = dayjs().format();
+      const stamp = timestamp().format();
       const uuid = randomUUID();
 
-      return merge({ uuid, type, timestamp, source, data }, extras);
+      return merge({ uuid, type, timestamp: stamp, source, data }, extras);
     }
   };
 }

--- a/lib/support/time.js
+++ b/lib/support/time.js
@@ -1,0 +1,85 @@
+// Drop-in replacement for the slice of dayjs we actually use:
+//   timestamp(value?), timestamp.utc(value?), .format(pattern?), .valueOf()
+// Calendar arithmetic (add/diff/year/etc.) is intentionally not implemented —
+// sitespeed.io doesn't use it. Format support is limited to the tokens we
+// actually pass: YYYY, MM, DD, HH, mm, ss and Z.
+
+const DEFAULT_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
+
+function pad(n) {
+  return String(n).padStart(2, '0');
+}
+
+function parts(date, utc) {
+  return utc
+    ? {
+        Y: date.getUTCFullYear(),
+        M: date.getUTCMonth() + 1,
+        D: date.getUTCDate(),
+        h: date.getUTCHours(),
+        m: date.getUTCMinutes(),
+        s: date.getUTCSeconds()
+      }
+    : {
+        Y: date.getFullYear(),
+        M: date.getMonth() + 1,
+        D: date.getDate(),
+        h: date.getHours(),
+        m: date.getMinutes(),
+        s: date.getSeconds()
+      };
+}
+
+function zoneString(date, utc) {
+  // The Z token always expands to the actual offset; that's what dayjs does
+  // for user-supplied patterns. The literal 'Z' suffix that
+  // dayjs.utc().format() produces is handled in Timestamp.format() instead.
+  const offset = utc ? 0 : -date.getTimezoneOffset();
+  const sign = offset >= 0 ? '+' : '-';
+  const abs = Math.abs(offset);
+  return `${sign}${pad(Math.trunc(abs / 60))}:${pad(abs % 60)}`;
+}
+
+function formatWith(pattern, date, utc) {
+  const p = parts(date, utc);
+  const zone = zoneString(date, utc);
+  return pattern
+    .replaceAll('YYYY', String(p.Y))
+    .replaceAll('MM', pad(p.M))
+    .replaceAll('DD', pad(p.D))
+    .replaceAll('HH', pad(p.h))
+    .replaceAll('mm', pad(p.m))
+    .replaceAll('ss', pad(p.s))
+    .replaceAll('Z', zone);
+}
+
+class Timestamp {
+  constructor(value, utc) {
+    this.date = value === undefined ? new Date() : new Date(value);
+    this.utcMode = utc;
+  }
+
+  format(pattern) {
+    if (pattern === undefined) {
+      // dayjs's default no-arg format. In UTC mode it ends with a literal 'Z'
+      // (rather than '+00:00') — mirror that quirk explicitly.
+      if (this.utcMode) {
+        return formatWith('YYYY-MM-DDTHH:mm:ss', this.date, this.utcMode) + 'Z';
+      }
+      return formatWith(DEFAULT_FORMAT, this.date, this.utcMode);
+    }
+    return formatWith(pattern, this.date, this.utcMode);
+  }
+
+  valueOf() {
+    return this.date.valueOf();
+  }
+}
+
+export default function timestamp(value) {
+  return new Timestamp(value, false);
+}
+
+timestamp.utc = function utcTimestamp(value) {
+  return new Timestamp(value, true);
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19,7 +19,6 @@
         "axe-core": "4.11.4",
         "browsertime": "27.2.0",
         "coach-core": "9.1.0",
-        "dayjs": "1.11.18",
         "fast-stats": "0.0.7",
         "import-global": "1.1.1",
         "markdown": "0.5.0",
@@ -5806,12 +5805,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.18",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
-      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "axe-core": "4.11.4",
     "browsertime": "27.2.0",
     "coach-core": "9.1.0",
-    "dayjs": "1.11.18",
     "fast-stats": "0.0.7",
     "import-global": "1.1.1",
     "markdown": "0.5.0",

--- a/test/graphiteTests.js
+++ b/test/graphiteTests.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import dayjs from 'dayjs';
+import timestamp from '../lib/support/time.js';
 import { getLogger } from '@sitespeed.io/log';
 // eslint-disable-next-line unicorn/no-named-default
 import { default as GraphitePlugin } from '../lib/plugins/graphite/index.js';
@@ -35,7 +35,7 @@ test(`Test dataGenerator`, t => {
     }
   });
 
-  const data = generator.dataFromMessage(message, dayjs());
+  const data = generator.dataFromMessage(message, timestamp());
   t.true(
     data[0].startsWith(
       'ns.pageSummary.sub_domain_com._foo_bar.gpsi.desktop.median 13'
@@ -74,7 +74,7 @@ test(`Test generate data in statsD format`, t => {
     },
     graphite: { statsd: true }
   });
-  const data = generator.dataFromMessage(message, dayjs());
+  const data = generator.dataFromMessage(message, timestamp());
   const statsDFormat = new RegExp(
     /ns.summary.sub_domain_com.chrome.cable.domains.www.sitespeed.io.dns.(median|mean|min|p10|p90|p99|max):\d+\|ms$/
   );

--- a/test/resultUrlTests.js
+++ b/test/resultUrlTests.js
@@ -1,9 +1,9 @@
-import dayjs from 'dayjs';
 import test from 'ava';
 
+import timestampFactory from '../lib/support/time.js';
 import { resultsStorage } from '../lib/core/resultsStorage/index.js';
 
-const timestamp = dayjs();
+const timestamp = timestampFactory();
 const timestampString = timestamp.format('YYYY-MM-DD-HH-mm-ss');
 
 function createResultUrls(url, outputFolder, resultBaseURL) {

--- a/test/storageManagerTests.js
+++ b/test/storageManagerTests.js
@@ -5,12 +5,12 @@ import { Readable } from 'node:stream';
 import { createGunzip } from 'node:zlib';
 import { pipeline } from 'node:stream/promises';
 
-import dayjs from 'dayjs';
 import test from 'ava';
 
+import timestampFactory from '../lib/support/time.js';
 import { resultsStorage } from '../lib/core/resultsStorage/index.js';
 
-const timestamp = dayjs();
+const timestamp = timestampFactory();
 const timestampString = timestamp.format('YYYY-MM-DD-HH-mm-ss');
 
 function createManager(url, outputFolder) {

--- a/test/timeTests.js
+++ b/test/timeTests.js
@@ -1,0 +1,105 @@
+// Verifies the local time helper matches the subset of dayjs we used to depend
+// on. Expected outputs were captured side-by-side against dayjs 1.11.18 + the
+// utc plugin before the swap, so a regression here means we drifted from the
+// dayjs format() / valueOf() semantics the rest of the codebase expects.
+
+import test from 'ava';
+
+import timestamp from '../lib/support/time.js';
+
+// 2026-01-17T04:00:00.123Z — a fixed UTC instant. We use a UTC instant so the
+// local-time output below depends on the host's timezone; the UTC outputs do
+// not.
+const FIXED_MS = 1_768_622_400_123;
+
+const pad = n => String(n).padStart(2, '0');
+
+function describeLocalOffset() {
+  // Pick a date in the middle of January to avoid DST surprises.
+  const offsetMin = -new Date(FIXED_MS).getTimezoneOffset();
+  const sign = offsetMin >= 0 ? '+' : '-';
+  const abs = Math.abs(offsetMin);
+  return `${sign}${pad(Math.trunc(abs / 60))}:${pad(abs % 60)}`;
+}
+const LOCAL_OFFSET = describeLocalOffset();
+
+function partsLocal() {
+  const d = new Date(FIXED_MS);
+  return {
+    Y: String(d.getFullYear()),
+    M: pad(d.getMonth() + 1),
+    D: pad(d.getDate()),
+    h: pad(d.getHours()),
+    m: pad(d.getMinutes()),
+    s: pad(d.getSeconds())
+  };
+}
+
+test('utc fixed instant — YYYY-MM-DD HH:mm:ss', t => {
+  t.is(
+    timestamp.utc(FIXED_MS).format('YYYY-MM-DD HH:mm:ss'),
+    '2026-01-17 04:00:00'
+  );
+});
+
+test('utc fixed instant — YYYY-MM-DD-HH-mm-ss', t => {
+  t.is(
+    timestamp.utc(FIXED_MS).format('YYYY-MM-DD-HH-mm-ss'),
+    '2026-01-17-04-00-00'
+  );
+});
+
+test('utc fixed instant — YYYY-MM-DD HH:mm:ss Z (Z token expands to offset)', t => {
+  t.is(
+    timestamp.utc(FIXED_MS).format('YYYY-MM-DD HH:mm:ss Z'),
+    '2026-01-17 04:00:00 +00:00'
+  );
+});
+
+test('utc fixed instant — default (no-arg) format ends with literal Z', t => {
+  t.is(timestamp.utc(FIXED_MS).format(), '2026-01-17T04:00:00Z');
+});
+
+test('utc fixed instant — explicit ISO pattern uses +00:00 (not Z)', t => {
+  t.is(
+    timestamp.utc(FIXED_MS).format('YYYY-MM-DDTHH:mm:ssZ'),
+    '2026-01-17T04:00:00+00:00'
+  );
+});
+
+test('local fixed instant — YYYY-MM-DD HH:mm:ss uses local clock', t => {
+  const p = partsLocal();
+  t.is(
+    timestamp(FIXED_MS).format('YYYY-MM-DD HH:mm:ss'),
+    `${p.Y}-${p.M}-${p.D} ${p.h}:${p.m}:${p.s}`
+  );
+});
+
+test('local fixed instant — default (no-arg) format includes local offset', t => {
+  const p = partsLocal();
+  t.is(
+    timestamp(FIXED_MS).format(),
+    `${p.Y}-${p.M}-${p.D}T${p.h}:${p.m}:${p.s}${LOCAL_OFFSET}`
+  );
+});
+
+test('valueOf returns ms timestamp (works in arithmetic)', t => {
+  t.is(timestamp(FIXED_MS).valueOf(), FIXED_MS);
+  t.is(timestamp.utc(FIXED_MS).valueOf(), FIXED_MS);
+  // Implicit coercion (matches how the graphite/grafana code path divides by 1000).
+  t.is(Math.round(timestamp(FIXED_MS) / 1000), Math.round(FIXED_MS / 1000));
+});
+
+test('parses ISO strings', t => {
+  t.is(
+    timestamp.utc('2026-07-04T12:34:56Z').format('YYYY-MM-DD HH:mm:ss'),
+    '2026-07-04 12:34:56'
+  );
+});
+
+test('no-arg constructor returns the current instant', t => {
+  const before = Date.now();
+  const ms = timestamp().valueOf();
+  const after = Date.now();
+  t.true(ms >= before && ms <= after);
+});


### PR DESCRIPTION
  dayjs (and the utc plugin) was used in 7 source files and 3 tests, all
  for the same small surface: timestamp(value), timestamp.utc(value),
  .format() with a handful of patterns, and .valueOf(). No calendar
  arithmetic — none of the reasons people normally reach for a date
  library.

  The new lib/support/time.js (~80 lines, zero dependencies) covers that
  surface exactly. To keep the diff mechanical and easy to review,
  .format() output was verified byte-for-byte against dayjs 1.11.18
  across every pattern actually used in the codebase, in both local and
  UTC modes. The expected outputs from that A/B run are pinned in the
  new test/timeTests.js (10 tests), so future drift gets caught.

  One dayjs quirk worth flagging: .format() with no argument in UTC mode
  emits a literal 'Z', but .format('YYYY-MM-DD HH:mm:ss Z') with the
  same UTC instant emits '+00:00'. The helper preserves both.

  Co-authored-by: Claude noreply@anthropic.com

