### PR TITLE
Fix missing visual-change lines on gzipped HAR waterfalls

### DIFF
--- a/lib/plugins/html/templates/url/waterfall/_waterfallRender.pug
+++ b/lib/plugins/html/templates/url/waterfall/_waterfallRender.pug
@@ -27,7 +27,22 @@ script(type='text/javascript').
     };
     let renderBuffer = rawBuffer;
     try {
-      const har = JSON.parse(new TextDecoder().decode(rawBuffer));
+      // The fetched HAR may be gzipped (`browsertime.har.gz`). Sniff the
+      // gzip magic bytes and inflate via DecompressionStream before parsing —
+      // a raw TextDecoder over gzip bytes produces garbage that throws in
+      // JSON.parse, the catch below swallows it, and the visual-metric
+      // injection silently never runs (so the visual-change lines disappear).
+      const u8 = ArrayBuffer.isView(rawBuffer) ? rawBuffer : new Uint8Array(rawBuffer);
+      let jsonText;
+      if (u8.length >= 2 && u8[0] === 0x1f && u8[1] === 0x8b) {
+        const inflated = await new Response(
+          new Blob([u8]).stream().pipeThrough(new DecompressionStream('gzip'))
+        ).arrayBuffer();
+        jsonText = new TextDecoder().decode(inflated);
+      } else {
+        jsonText = new TextDecoder().decode(u8);
+      }
+      const har = JSON.parse(jsonText);
       let mutated = false;
       for (const page of (har.log && har.log.pages) || []) {
         const t = page.pageTimings;


### PR DESCRIPTION
  The waterfall renderer that ships in every report tries to inflate the
  visual-metric values into pageTimings._userTimings before handing the
  HAR to waterfall-tools, so the renderer paints them as vertical lines
  alongside the existing user-timing marks. That pre-processing decodes
  the fetched bytes as UTF-8 and calls JSON.parse — but the HAR that the
  report fetches by default is gzipped (browsertime.har.gz), so the
  parse throws and the surrounding catch silently passes the original
  bytes straight through to waterfall-tools. waterfall-tools' own loader
  inflates the gzip and renders the waterfall, but our injection never
  runs, so First Visual Change / Last Visual Change / Visual Complete 85%
  are missing from the canvas (and from the user-timings list below it).
  The pre-existing browser user-timing marks still show, because those
  are already in pageTimings._userTimings on disk — which is why this
  looked like "sometimes the visual-metric lines are missing while the
  user timings are fine."

  Sniff the gzip magic bytes and inflate via DecompressionStream before
  parsing, so the injection runs whether the HAR is gzipped or not.

  Co-authored-by: Claude noreply@anthropic.com

