### PR TITLE
scp: retry the initial SFTP handshake on transient failures

### DIFF
--- a/lib/plugins/scp/index.js
+++ b/lib/plugins/scp/index.js
@@ -10,6 +10,22 @@ import { recursiveReaddir } from '../../support/fileUtil.js';
 const log = getLogger('sitespeedio.plugin.scp');
 
 const CONCURRENT_UPLOADS = 16;
+const CONNECT_RETRIES = 3;
+
+async function connectWithRetry(client, config) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await client.connect(config);
+      return;
+    } catch (error) {
+      if (attempt > CONNECT_RETRIES) throw error;
+      log.info(
+        `scp connect failed (attempt ${attempt}/${CONNECT_RETRIES}), retrying: ${error.message}`
+      );
+      await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
+    }
+  }
+}
 
 function buildConnectConfig(scpOptions) {
   const config = {
@@ -35,7 +51,7 @@ function buildConnectConfig(scpOptions) {
 async function upload(dir, scpOptions, prefix) {
   const client = new SftpClient();
   try {
-    await client.connect(buildConnectConfig(scpOptions));
+    await connectWithRetry(client, buildConnectConfig(scpOptions));
     const target = path.join(scpOptions.destinationPath, prefix);
     if (!(await client.exists(target))) {
       await client.mkdir(target, true);
@@ -52,7 +68,7 @@ async function upload(dir, scpOptions, prefix) {
 async function uploadFiles(files, scpOptions, prefix) {
   const client = new SftpClient();
   try {
-    await client.connect(buildConnectConfig(scpOptions));
+    await connectWithRetry(client, buildConnectConfig(scpOptions));
     const target = path.join(scpOptions.destinationPath, prefix);
     if (!(await client.exists(target))) {
       await client.mkdir(target, true);


### PR DESCRIPTION
  The scp plugin occasionally fails an entire result upload with
  "Connection lost before handshake" when the remote server briefly
  drops the TCP connection during SSH handshake. ssh2-sftp-client v12
  removed its built-in connection retries and the upstream README now
  explicitly recommends wrapping connect() yourself, so a single network
  blip surfaces to the user as a complete upload error even though the
  next attempt would succeed.

  Wrap client.connect() in a small retry helper (3 attempts, linear
  backoff) for both upload paths. The retry is scoped to the handshake
  phase only — mid-upload failures still bubble up as before, so we
  don't silently mask real problems.

  Co-authored-by: Claude noreply@anthropic.com