### PR TITLE
 graphite: retry transient annotation send failures

### DIFF
--- a/lib/plugins/graphite/send-annotation.js
+++ b/lib/plugins/graphite/send-annotation.js
@@ -15,7 +15,29 @@ const require = createRequire(import.meta.url);
 const version = require('../../../package.json').version;
 const log = getLogger('sitespeedio.plugin.graphite');
 
-export function send(
+const SEND_RETRIES = 3;
+
+function postAnnotation(postOptions, postData, library) {
+  return new Promise((resolve, reject) => {
+    const request = library.request(postOptions, res => {
+      if (res.statusCode === 200) {
+        res.setEncoding('utf8');
+        resolve();
+      } else {
+        const e = new Error(
+          `Got ${res.statusCode} from Graphite when sending annotation`
+        );
+        e.statusCode = res.statusCode;
+        reject(e);
+      }
+    });
+    request.on('error', reject);
+    request.write(postData);
+    request.end();
+  });
+}
+
+export async function send(
   url,
   group,
   absolutePagePath,
@@ -104,28 +126,31 @@ export function send(
     postOptions.auth = options.graphite.auth;
   }
 
-  return new Promise((resolve, reject) => {
-    log.verbose('Send annotation to Graphite: %j', postData);
-    // not perfect but maybe work for us
-    const library = options.graphite.httpPort === 443 ? https : http;
-    const request = library.request(postOptions, res => {
-      if (res.statusCode === 200) {
-        res.setEncoding('utf8');
-        log.debug('Sent annotation to Graphite');
-        resolve();
-      } else {
-        const e = new Error(
-          `Got ${res.statusCode} from Graphite when sending annotation`
-        );
-        log.warn(e.message);
-        reject(e);
+  log.verbose('Send annotation to Graphite: %j', postData);
+  // not perfect but maybe work for us
+  const library = options.graphite.httpPort === 443 ? https : http;
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await postAnnotation(postOptions, postData, library);
+      log.debug('Sent annotation to Graphite');
+      return;
+    } catch (error) {
+      const retryable =
+        error.code !== undefined ||
+        (error.statusCode >= 500 && error.statusCode < 600);
+      if (!retryable || attempt > SEND_RETRIES) {
+        if (error.statusCode === undefined) {
+          log.error('Got error from Graphite when sending annotation', error);
+        } else {
+          log.warn(error.message);
+        }
+        throw error;
       }
-    });
-    request.on('error', error => {
-      log.error('Got error from Graphite when sending annotation', error);
-      reject(error);
-    });
-    request.write(postData);
-    request.end();
-  });
+      log.info(
+        `Graphite annotation failed (attempt ${attempt}/${SEND_RETRIES}), retrying: ${error.message}`
+      );
+      await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
+    }
+  }
 }


### PR DESCRIPTION
  Sending the post-run Graphite annotation occasionally bubbled up as
  "Got 500 from Graphite when sending annotation" and flagged the whole
  run as failed, even though the Graphite server typically recovered
  within a second or two. A single transient hiccup on a metadata POST
  shouldn't waste a full sitespeed.io run.

  The send is now retried up to three times with linear backoff for
  network errors and 5xx responses. 4xx responses (bad payload, auth)
  fall through immediately as before, and exhausted retries surface the
  same warning/error that callers see today, so the failure-path
  contract for the rest of the pipeline is unchanged.

  Co-authored-by: Claude noreply@anthropic.com
