### PR TITLE
Remove useless backslash in pathToFolder regex

### DIFF
--- a/lib/core/resultsStorage/pathToFolder.js
+++ b/lib/core/resultsStorage/pathToFolder.js
@@ -89,7 +89,7 @@ export function pathToFolder(input, options, alias) {
     // Everything else (filesystem-unsafe chars like <>:"/\|?* and bare spaces)
     // is replaced with '-'. This fixes collisions when aliases use CJK or other
     // non-ASCII scripts (Issue #3880) while leaving ASCII aliases unchanged.
-    if (seg) pathSegments[i] = seg.replaceAll(/[^\p{L}\p{N}\._-]/gu, '-');
+    if (seg) pathSegments[i] = seg.replaceAll(/[^\p{L}\p{N}._-]/gu, '-');
   }
 
   return `${pathSegments.join('/')}/`;


### PR DESCRIPTION
  Inside a character class the dot is already literal, so the \. in
  /[^\p{L}\p{N}\._-]/gu is an unnecessary escape — eslint's
  no-useless-escape rule trips on it and fails the lint job on every PR,
  which has been blocking unrelated PRs from merging cleanly.

  Co-authored-by: Claude noreply@anthropic.com
