### PR TITLE
fix: unblock arm64 Docker release build

### DIFF
--- a/.github/workflows/building-docker-release.yml
+++ b/.github/workflows/building-docker-release.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
         with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
+          image: tonistiigi/binfmt:qemu-v9.2.2
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -9,6 +9,7 @@ ENV SITESPEED_IO_BROWSERTIME__VISUAL_METRICS=false
 ENV SITESPEED_IO_BROWSERTIME__HEADLESS=true
 
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list && \
+    printf 'Package: *\nPin: release a=unstable\nPin-Priority: 100\n\nPackage: firefox\nPin: release a=unstable\nPin-Priority: 990\n' > /etc/apt/preferences.d/99-firefox-unstable && \
     apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests \
         firefox tcpdump iproute2 ca-certificates sudo && \


### PR DESCRIPTION
  The release workflow's arm64 image build was crashing under QEMU. Adding Debian unstable to pull a recent Firefox was also
  dragging in a release-candidate systemd (261~rc2), and that postinst trips an RCU assertion in the pinned QEMU 7.0
  emulator, aborting the build for every tagged release.

  Two targeted changes so this stops happening:

  Bump the QEMU emulator (tonistiigi/binfmt) to a 9.2 build that handles modern systemd correctly.

  Add an APT preferences file so unstable is only used as a fallback (priority 100) except for the firefox package itself
  (priority 990). The rest of the base system stays on bookworm, so we don't silently pick up RC versions of unrelated
  packages that happen to land in unstable on any given day.

  Co-authored-by: Claude noreply@anthropic.com
