### PR TITLE
build(docker): move slim image to Debian trixie and drop the apt pin

### DIFF
--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,4 +1,4 @@
-FROM node:24.11.0-bookworm-slim
+FROM node:24.11.0-trixie-slim
 
 ARG TARGETPLATFORM=linux/amd64
 
@@ -9,7 +9,6 @@ ENV SITESPEED_IO_BROWSERTIME__VISUAL_METRICS=false
 ENV SITESPEED_IO_BROWSERTIME__HEADLESS=true
 
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list && \
-    printf 'Package: *\nPin: release a=unstable\nPin-Priority: 100\n\nPackage: firefox\nPin: release a=unstable\nPin-Priority: 990\n' > /etc/apt/preferences.d/99-firefox-unstable && \
     apt-get update && \
     apt-get install -y --no-install-recommends --no-install-suggests \
         firefox tcpdump iproute2 ca-certificates sudo && \


### PR DESCRIPTION
  The apt preferences file added in the last release-build fix turns out to be too strict. Pin-Priority 100 means apt refuses
   to upgrade an already-installed package, so it won't pull a newer libc6/libnss3 from unstable to satisfy Firefox's
  dependency requirements. The next tagged release would have failed with "firefox: Depends: libc6 (>= 2.42) but 2.36 is to
  be installed" before ever getting to a postinst.

  Removing the pin and bumping the base image from bookworm to trixie at the same time. Trixie is the new Debian stable, so
  we drift less from unstable and end up with fewer packages to reach across the boundary for. The QEMU emulator bump from
  the previous fix stays in place — that one really did address the systemd postinst crash, the apt pin was redundant
  belt-and-suspenders that turned out to be a foot-gun.

  Co-authored-by: Claude noreply@anthropic.com