### PR TITLE
ci(linux): allow Docker Hub's CloudFront CDN

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,6 +39,7 @@ jobs:
           nodejs.org:443
           packages.microsoft.com:443
           production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
           pypi.org:443
           registry-1.docker.io:443
           registry.npmjs.org:443


### PR DESCRIPTION
  The Harden-Runner egress allowlist in .github/workflows/linux.yml only
  permitted production.cloudflare.docker.com, but Docker Hub serves
  image layer blobs from both the Cloudflare and AWS CloudFront edges
  depending on geo and runner-side routing. When a runner happens to be
  routed to the CloudFront edge, the docker compose ... up -d step that
  sets up the test environment fails with "error pulling image
  configuration: connect: connection refused", because StepSecurity
  blocks the unallowed destination.

  Adding production.cloudfront.docker.com:443 alongside the existing
  Cloudflare entry stops the test job from flaking out the moment the
  DNS happens to resolve to CloudFront.

  Co-authored-by: Claude noreply@anthropic.com

