### PR TITLE
Fix scripting examples that call non-existent commands

### DIFF
--- a/docs/documentation/sitespeed.io/scripting/custom-metrics/index.md
+++ b/docs/documentation/sitespeed.io/scripting/custom-metrics/index.md
@@ -92,7 +92,7 @@ export default async function (context, commands) {
 };
 ```
 
-`addObject` takes a flat object of `{ name: value }` pairs. Booleans get sent as numbers (`true` → 1, `false` → 0) so they're chartable in Grafana.
+`addObject` takes a flat object of `{ name: value }` pairs. The values are stored as-is — nothing is coerced for you — so convert booleans to numbers yourself (`true` → `1`, `false` → `0`, as `hasSearchBox` does above) to make them chartable in Grafana.
 
 ## Pattern 3: time something the browser doesn't time for you
 

--- a/docs/documentation/sitespeed.io/scripting/iframes-and-popups/index.md
+++ b/docs/documentation/sitespeed.io/scripting/iframes-and-popups/index.md
@@ -71,35 +71,39 @@ export default async function (context, commands) {
 
 ## Switching back
 
-Three options for getting out of a frame:
+Two ways to get out of a frame:
 
 ```javascript
 // Up one level (back to the parent of the current frame)
 await commands.switch.toParentFrame();
 
-// All the way back to the top-level document
-await commands.switch.toTopFrame();
+// All the way back to the top-level document (through Selenium directly)
+await context.selenium.driver.switchTo().defaultContent();
 ```
 
-For nested iframes (an iframe inside an iframe), use `toParentFrame` repeatedly or jump straight to the top with `toTopFrame`.
+For nested iframes (an iframe inside an iframe), call `toParentFrame` repeatedly, or jump straight to the top-level document with `context.selenium.driver.switchTo().defaultContent()`.
 
 ## Popups and new tabs
 
 Clicks that open a new window or tab don't change the active context — Browsertime keeps targeting the original window. To drive the popup you have to switch:
 
 ```javascript
+// Remember the original window before the popup opens
+const original = await context.selenium.driver.getWindowHandle();
+
 // Click the link that opens the popup
 await commands.click('a[target="_blank"]');
 
 // Switch to the most recently opened window/tab
-await commands.switch.toNewTab();
+const handles = await context.selenium.driver.getAllWindowHandles();
+await commands.switch.toWindow(handles[handles.length - 1]);
 
 // Now interact with the popup
 await commands.wait('id:popup-content');
 await commands.click('id:popup-close');
 
 // Back to the original window
-await commands.switch.toPreviousTab();
+await commands.switch.toWindow(original);
 ```
 
 If the popup is the auth flow, this is the dance: click → switch into popup → fill form → click submit → switch back. The original tab usually waits for the popup to close before continuing — wait on a marker in the original page after the switch-back rather than guessing how long the auth round-trip takes.

--- a/docs/documentation/sitespeed.io/scripting/tips-and-tricks/index.md
+++ b/docs/documentation/sitespeed.io/scripting/tips-and-tricks/index.md
@@ -168,7 +168,7 @@ export default async function (context, commands) {
     // Do something smart that means you need to test the same URL again
     // ...
 
-    return commands.navigate('https://www.sitespeed.io/?dummy', 'BackToHomepage');
+    return commands.measure.start('https://www.sitespeed.io/?dummy', 'BackToHomepage');
 };
 ```
 


### PR DESCRIPTION
  Several scripting examples used commands that don't exist or don't do what
  the text claims. switch.toTopFrame() and switch.toPreviousTab() aren't
  part of the API, and switch.toNewTab() opens a fresh tab rather than
  switching to a popup the page opened — so the iframe/popup recipes couldn't
  work as written; they now use the real frame/window APIs. The custom-metrics
  page claimed booleans are auto-converted to numbers, but values are stored
  as-is (the example itself converts manually). And the "test the same URL
  twice" tip called commands.navigate(url, alias), which ignores the alias
  and doesn't measure — it should be commands.measure.start.

  Co-authored-by: Claude Opus 4.8 (1M context) noreply@anthropic.com

