### PR TITLE
Fix outdated plugin-authoring and developer docs

### DIFF
--- a/docs/documentation/sitespeed.io/developers/index.md
+++ b/docs/documentation/sitespeed.io/developers/index.md
@@ -120,7 +120,7 @@ On your local machine you need:
 - Install Chrome/Firefox/Edge
 - Go to the cloned directory and run <code>npm install</code>
 - You are ready to go! To run locally: <code>bin/sitespeed.js https://www.sitespeed.io -n 1</code>
-- You can change the log level by adding the verbose flag. Verbose mode prints progress messages to the console. Enter up to three times (-vvv) to increase the level of detail: <code>bin/sitespeed.io https://www.sitespeed.io -n 1 -v</code>
+- You can change the log level by adding the verbose flag. Verbose mode prints progress messages to the console. Enter up to three times (-vvv) to increase the level of detail: <code>bin/sitespeed.js https://www.sitespeed.io -n 1 -v</code>
 
 
 To run the Docker version:
@@ -144,7 +144,7 @@ We use *main* as our default branch, send all PRs to *main*.
 ### Log and debug
 To get a better understanding of what happens you should use the log. You can change log level by using multiple <code>-v</code>. If you want to log at the lowest level and get all information, you can use <code>-vvv</code>. If that is too much information, use <code>-vv</code> or <code>-v</code>.
 
-You can also debug all the messages sent inside of the queue of sitespeed.io. That way you can see how plugins are communicating with each other. To turn that on use <code>--debug</code>.
+You can also debug all the messages sent inside of the queue of sitespeed.io. That way you can see how plugins are communicating with each other. To turn that on use <code>--debugMessages</code>.
 
 ### Plugins
 Everything in sitespeed.io (well almost everything) is a plugin. Each plugin will be called, for each message sent in the application and then called when everything is finished.

--- a/docs/documentation/sitespeed.io/plugins/index.md
+++ b/docs/documentation/sitespeed.io/plugins/index.md
@@ -147,7 +147,7 @@ Plugins in sitespeed.io should inherit the [sitespeed.io plugin](https://github.
 In your dependencies for your plugin, make sure to add the latest version of the plugin.
 
 ~~~javascript
- "@sitespeed.io/plugin": "1.0.0"
+ "@sitespeed.io/plugin": "1.0.2"
 ~~~
 
 ### Basic structure
@@ -211,7 +211,8 @@ The *context* holds information for this specific run that is generated at runti
   timestamp, // The timestamp of when you started the run
   budget, // If you run with budget, the result will be here
   name, // The name of the run (the start URL )
-  intel, // The log system that is used within sitespeed.io https://github.com/seanmonstar/intel
+  log, // The logger used within sitespeed.io (from @sitespeed.io/log)
+  getLogger, // Create your own named logger with getLogger('sitespeedio.myplugin')
   messageMaker, // Help methods to send messages in the queue,
   statsHelpers, // Help methods to collect data per domain/tests instead of per URL
   filterRegistry // Register metrics that will be sent to Graphite/InfluxDB
@@ -273,7 +274,7 @@ Data from different tools is passed with three different message types:
 * ***.summary** - metrics collected for all pages tested.
 
 ### Debug/log
-You can use the sitespeed.io log to log messages. We use [intel](https://www.npmjs.com/package/intel) for logging.
+You can use the sitespeed.io log to log messages. We use [@sitespeed.io/log](https://github.com/sitespeedio/log) for logging.
 
 You get the log object in the context object (so there's no need to require the log), but you should get a specific instance so that you can filter the log/see which part of sitespeed.io is writing to the log.
 
@@ -332,7 +333,7 @@ queue.postMessage(
 );
 ~~~
 
-You can look at the standalone [GPSI plugin](https://github.com/sitespeedio/plugin-gpsi) or the [WebPageTest plugin](https://github.com/sitespeedio/sitespeed.io/tree/main/lib/plugins/webpagetest) as an example plugin that both sends run and pageSummary data.
+You can look at the standalone [GPSI plugin](https://github.com/sitespeedio/plugin-gpsi) or the [WebPageTest plugin](https://github.com/sitespeedio/plugin-webpagetest) as an example plugin that both sends run and pageSummary data.
 
 ## Let your plugin collect metrics using Browsertime
 
@@ -375,7 +376,7 @@ And if you want to use it in your pug template you will find it under **pageInfo
 
 ## Let your plugin add metrics to the performance budget
 
-In the *sitespeedio.config* phase (where plugins can talk to each other) make sure to tell the budget plugin that you want it to collect metrics from your plugin. Do that by sending a message of the type *budget.addMessageType* and add the type of the metrics message you want it to collect.
+In the *sitespeedio.setup* phase (where plugins can talk to each other) make sure to tell the budget plugin that you want it to collect metrics from your plugin. Do that by sending a message of the type *budget.addMessageType* and add the type of the metrics message you want it to collect.
 
 In this example we tell the budget plugin that it should collect metrics of the type *gpsi.pagesummary*.
 
@@ -390,7 +391,7 @@ queue.postMessage(make('budget.addMessageType', {type: 'gpsi.pagesummary'}));
 If your plugin lives on GitHub you can model your CI on the [GPSI plugin's GitHub Actions](https://github.com/sitespeedio/plugin-gpsi/actions) — it checks out sitespeed.io and runs the plugin against the latest main on a schedule.
 
 ## Example plugin(s)
-You can look at the standalone [GPSI plugin](https://github.com/sitespeedio/plugin-gpsi) or the [WebPageTest plugin](https://github.com/sitespeedio/sitespeed.io/tree/main/lib/plugins/webpagetest).
+You can look at the standalone [GPSI plugin](https://github.com/sitespeedio/plugin-gpsi) or the [WebPageTest plugin](https://github.com/sitespeedio/plugin-webpagetest).
 
 ## Find plugins
 We keep a list of plugins at [https://github.com/sitespeedio/plugins](https://github.com/sitespeedio/plugins). If you want to add your plugin, send a PR!


### PR DESCRIPTION
  The plugin-authoring guide still described the old logging stack: the run
  context exposed intel, but that was replaced by @sitespeed.io/log long ago
  and the context now provides log and getLogger. It also named a
  sitespeedio.config phase that doesn't exist (the cross-plugin phase is
  sitespeedio.setup), pinned an old @sitespeed.io/plugin version, and linked
  the WebPageTest example to an in-repo path that no longer exists now that it
  ships as a standalone plugin. The developer guide pointed queue-message
  debugging at --debug (that's the browser-debug alias) instead of
  --debugMessages, and had a bin/sitespeed.io typo for the JS entry point.

  Co-authored-by: Claude Opus 4.8 (1M context) noreply@anthropic.com

