### PR TITLE
Fix stale references across the sitespeed.io docs

### DIFF
--- a/docs/documentation/sitespeed.io/best-practice/index.md
+++ b/docs/documentation/sitespeed.io/best-practice/index.md
@@ -195,10 +195,10 @@ Another alternative to minimize the amount of data is to disable plugins. You sh
 You can list which plugins are running by adding the flag <code>--plugins.list</code> and in the log you will see something like:
 
 ~~~
-INFO: The following plugins are enabled: assets, browsertime, budget, coach, domains, harstorer, html, metrics, pagexray, screenshot, text, tracestorer
+INFO: The following plugins are enabled: assets, browsertime, budget, coach, domains, harstorer, html, lateststorer, metrics, pagexray, remove, text, thirdparty, tracestorer
 ~~~
 
-If you want to disable the screenshot plugin (that stores screenshots to disk) you do that by adding <code>--plugins.remove screenshot</code>.
+If you want to disable the screenshots (that are stored to disk) you do that by adding <code>--browsertime.screenshot false</code>.
 
 #### Graphite
 Make sure to edit your *storage-schemas.conf* to match your metrics and how long you want to keep them. See [Graphite setup in production]({{site.baseurl}}/documentation/sitespeed.io/performance-dashboard/#setup-important).

--- a/docs/documentation/sitespeed.io/configuration/index.md
+++ b/docs/documentation/sitespeed.io/configuration/index.md
@@ -32,7 +32,7 @@ Sitespeed.io has hundreds of options across many areas (browsers, video, Graphit
 * <code>sitespeed.io --help &lt;topic&gt;</code> shows only the options belonging to that topic. For example <code>--help chrome</code>, <code>--help firefox</code>, <code>--help graphite</code> or <code>--help video</code>.
 * <code>sitespeed.io --help-all</code> prints the complete reference (the same content as in the box above) and is what scripts and CI jobs should use if they want every option.
 
-The available topics are: <code>browser</code>, <code>video</code>, <code>firefox</code>, <code>chrome</code>, <code>edge</code>, <code>safari</code>, <code>android</code>, <code>screenshot</code>, <code>graphite</code>, <code>grafana</code>, <code>html</code>, <code>slack</code>, <code>s3</code>, <code>gcs</code>, <code>scp</code>, <code>matrix</code>, <code>budget</code>, <code>crux</code>, <code>sustainable</code>, <code>crawler</code>, <code>metrics</code>, <code>compare</code>, <code>api</code>, <code>plugins</code> and <code>text</code>.
+The available topics are: <code>browser</code>, <code>video</code>, <code>firefox</code>, <code>chrome</code>, <code>edge</code>, <code>safari</code>, <code>android</code>, <code>screenshot</code>, <code>graphite</code>, <code>grafana</code>, <code>html</code>, <code>slack</code>, <code>s3</code>, <code>gcs</code>, <code>scp</code>, <code>rsync</code>, <code>matrix</code>, <code>budget</code>, <code>crux</code>, <code>sustainable</code>, <code>crawler</code>, <code>metrics</code>, <code>compare</code>, <code>api</code>, <code>plugins</code> and <code>text</code>.
 
 To see only the Chrome options, for example:
 

--- a/docs/documentation/sitespeed.io/docker/index.md
+++ b/docs/documentation/sitespeed.io/docker/index.md
@@ -32,7 +32,7 @@ We have three ready-made containers:
 
 The Docker structure in the default container looks like this:
 
-[Node.js + VisualMetrics deps + Firefox/Chrome/Edge/xvfb](https://github.com/sitespeedio/docker-browsers) -> [sitespeed.io](https://github.com/sitespeedio/sitespeed.io/blob/main/Dockerfile)
+[Node.js + VisualMetrics deps + Firefox/Chrome/Edge/xvfb](https://github.com/sitespeedio/docker-webbrowsers) -> [sitespeed.io](https://github.com/sitespeedio/sitespeed.io/blob/main/Dockerfile)
 
 The base container ([sitespeedio/webbrowsers](https://hub.docker.com/r/sitespeedio/webbrowsers)) bundles Node.js, the dependencies (FFmpeg, ImageMagick and some Python libraries) needed to run [VisualMetrics](https://github.com/WPO-Foundation/visualmetrics), specific versions of Firefox, Chrome, and Edge, and xvfb. In the last step, we add sitespeed.io and tag it with the sitespeed.io version number.
 

--- a/docs/documentation/sitespeed.io/leaderboard/index.md
+++ b/docs/documentation/sitespeed.io/leaderboard/index.md
@@ -16,7 +16,7 @@ twitterdescription: The web performance leaderboard.
 
 {:toc}
 
-The [leaderboard dashboard](https://dashboard.sitespeed.io/d/000000060/leaderboard) is the easiest way to compare how you are doing against your competition. To get it going you need [Grafana](https://grafana.com) (6.2 or later) and Graphite. If you don't have that already, you can follow the instructions in [performance dashboard documentation](/documentation/sitespeed.io/performance-dashboard/#up-and-running-in-almost-5-minutes). And to run your tests, you should follow [our example](https://github.com/sitespeedio/dashboard.sitespeed.io).
+The [leaderboard dashboard](https://dashboard.sitespeed.io/d/000000060/leaderboard) is the easiest way to compare how you are doing against your competition. To get it going you need [Grafana](https://grafana.com) (6.2 or later) and Graphite. If you don't have that already, you can follow the instructions in [performance dashboard documentation](/documentation/sitespeed.io/performance-dashboard/#using-docker-compose). And to run your tests, you should follow [our example](https://github.com/sitespeedio/dashboard.sitespeed.io).
 
 The dashboard lists the pages that you test, with the fastest/best URL first (yes, it is a leaderboard!). It looks like this:
 ![Leaderboard example]({{site.baseurl}}/img/leaderboard-example.png)

--- a/docs/documentation/sitespeed.io/scripting/examples/index.md
+++ b/docs/documentation/sitespeed.io/scripting/examples/index.md
@@ -377,7 +377,7 @@ export default async function (context, commands) {
 
 ### Test multiple URLs
 
-If you want to test multiple URLs and need to do some specific things before each URL, you can do something like this (we pass on our [own options](#pass-your-own-options-to-your-script) to the script):
+If you want to test multiple URLs and need to do some specific things before each URL, you can do something like this (we pass on our [own options]({{site.baseurl}}/documentation/sitespeed.io/scripting/tips-and-tricks/#pass-your-own-options-to-your-script) to the script):
 
 ```javascript
 /**

--- a/docs/documentation/sitespeed.io/video/index.md
+++ b/docs/documentation/sitespeed.io/video/index.md
@@ -57,7 +57,7 @@ By default we only show screenshots that differ or have a metric collected at th
 
 If you don't use those images you can turn them off with <code>--videoParams.createFilmstrip false</code>.
 
-If you use them and want them the same size as the video (they are 200x200 by default), you can turn on
+If you use them and want them the same size as the video (they are max 400 pixels in either direction by default), you can turn on
 full size with <code>--videoParams.filmstripFullSize</code>.
 
 If you want to change the quality (compression level 0-100) of the images, you do that with <code>--videoParams.filmstripQuality</code>.

--- a/docs/documentation/sitespeed.io/web-performance-testing-in-practice/index.md
+++ b/docs/documentation/sitespeed.io/web-performance-testing-in-practice/index.md
@@ -377,7 +377,7 @@ With scripting you can test the performance of visiting multiple pages, clicking
 
 
 ### What data storage should I choose (Graphite vs InfluxDB)
-By default sitespeed.io supports both Graphite and InfluxDB, and you can write your own plugin to store metrics elsewhere.
+sitespeed.io supports Graphite out of the box and InfluxDB through a separate plugin, and you can write your own plugin to store metrics elsewhere.
 
 But what should you choose? We recommend that you use Graphite. We use Graphite in our setup so Graphite will get a little more love. Keeping a Graphite instance up and running for years and years is really easy and the maintenance work is really small.
 


### PR DESCRIPTION
  A scattering of docs had drifted from the current code. The best-practice
  page listed a screenshot plugin that was removed (screenshots come from
  browsertime now, disabled with --browsertime.screenshot false) and its
  sample plugin list was out of date. The config help-topics list was missing
  rsync, the Docker diagram linked the old docker-browsers repo instead of
  docker-webbrowsers, the filmstrip thumbnail default is 400 not 200, and the
  storage section implied InfluxDB ships by default when it's now a separate
  plugin. Also fixed two dead cross-page anchors in the leaderboard and
  scripting-examples pages.

  Co-authored-by: Claude Opus 4.8 (1M context) noreply@anthropic.com

