### PR TITLE
build: exclude npm-shrinkwrap.json from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,8 @@ Gemfile
 Gemfile.lock
 wpr-record.log
 wpr-replay.log
+# Keep npm-shrinkwrap.json in the repo (used by `npm install` for
+# reproducible dev installs), but exclude it from the published package.
+# Some downstream users run internal npm proxies that reject packages
+# containing npm-shrinkwrap.json. See discussion in issue #4592.
+npm-shrinkwrap.json


### PR DESCRIPTION
Fixes sitespeedio/sitespeed.io#4592

## Problem

The published \sitespeed.io\ npm tarball includes \
pm-shrinkwrap.json\. Some downstream users run internal npm proxies (e.g. corporate registries) that reject packages containing a shrinkwrap file, which blocks them from installing sitespeed.io.

## Fix

Keep \
pm-shrinkwrap.json\ in the repo (it's used by \
pm install\ for reproducible dev installs) but exclude it from the published package via \.npmignore\. This is the standard pattern for libraries that use shrinkwrap files.

## Verification

\
pm pack --dry-run\ on this branch:
- WITHOUT the fix: \
pm-shrinkwrap.json\ (388KB) is in the tarball contents.
- WITH the fix: \
pm-shrinkwrap.json\ is excluded; tarball size drops from ~984KB to 596.1KB; total files: 347.

\package.json\ does not define a \iles\ field, so \.npmignore\ is the sole authority for what ships. \
pm install\ inside the repo (post-clone) is unaffected because shrinkwrap is read from the working tree, not from the package contents.

## Diff

\\\diff
--- a/.npmignore
+++ b/.npmignore
@@ -9,4 +9,9 @@ release/*
 Gemfile
 Gemfile.lock
 wpr-record.log
-wpr-replay.log
\ No newline at end of file
+wpr-replay.log
+# Keep npm-shrinkwrap.json in the repo (used by \
pm install\ for
+# reproducible dev installs), but exclude it from the published package.
+# Some downstream users run internal npm proxies that reject packages
+# containing npm-shrinkwrap.json. See discussion in issue #4592.
+npm-shrinkwrap.json
\\\

Single file, 6 insertions, 1 deletion. No source code touched.