### PR TITLE
fix: show CLS metric when value is 0

### DIFF
--- a/lib/plugins/browsertime/browsertimeAggregator.js
+++ b/lib/plugins/browsertime/browsertimeAggregator.js
@@ -126,16 +126,24 @@ export class BrowsertimeAggregator {
       }
     }
 
-    if (
-      browsertimeRunData.pageinfo &&
-      browsertimeRunData.pageinfo.cumulativeLayoutShift !== undefined
-    ) {
-      pushGroupStats(
-        this.statsPerType,
-        this.groups[group],
-        ['pageinfo', 'cumulativeLayoutShift'],
-        browsertimeRunData.pageinfo.cumulativeLayoutShift
-      );
+    if (browsertimeRunData.pageinfo) {
+      // Default to 0 when CLS observer never fired (no layout shifts detected)
+      const cls = browsertimeRunData.pageinfo.cumulativeLayoutShift;
+      if (cls !== undefined) {
+        pushGroupStats(
+          this.statsPerType,
+          this.groups[group],
+          ['pageinfo', 'cumulativeLayoutShift'],
+          cls
+        );
+      } else {
+        pushGroupStats(
+          this.statsPerType,
+          this.groups[group],
+          ['pageinfo', 'cumulativeLayoutShift'],
+          0
+        );
+      }
     }
 
     // pick up one level of custom metrics

--- a/lib/plugins/browsertime/browsertimeAggregator.js
+++ b/lib/plugins/browsertime/browsertimeAggregator.js
@@ -129,19 +129,19 @@ export class BrowsertimeAggregator {
     if (browsertimeRunData.pageinfo) {
       // Default to 0 when CLS observer never fired (no layout shifts detected)
       const cls = browsertimeRunData.pageinfo.cumulativeLayoutShift;
-      if (cls !== undefined) {
+      if (cls === undefined) {
         pushGroupStats(
           this.statsPerType,
           this.groups[group],
           ['pageinfo', 'cumulativeLayoutShift'],
-          cls
+          0
         );
       } else {
         pushGroupStats(
           this.statsPerType,
           this.groups[group],
           ['pageinfo', 'cumulativeLayoutShift'],
-          0
+          cls
         );
       }
     }

--- a/lib/plugins/html/templates/url/metrics/index.pug
+++ b/lib/plugins/html/templates/url/metrics/index.pug
@@ -27,7 +27,7 @@ if browsertime
     - metricsLinks.push({href: '#google-web-vitals', label: 'Google Web Vitals'})
   if timings.largestContentfulPaint
     - metricsLinks.push({href: '#largestContentfulPaint', label: 'Largest Contentful Paint'})
-  if browsertime.pageinfo && browsertime.pageinfo.cumulativeLayoutShift !== undefined
+  if browsertime.pageinfo
     - metricsLinks.push({href: '#cumulativeLayoutShift', label: 'Cumulative Layout Shift'})
   if timings.interactionToNextPaint
     - metricsLinks.push({href: '#interactionToNextPaint', label: 'Interaction To Next Paint'})

--- a/lib/plugins/html/templates/url/metrics/layoutShift.pug
+++ b/lib/plugins/html/templates/url/metrics/layoutShift.pug
@@ -1,5 +1,5 @@
-if browsertime.pageinfo && browsertime.pageinfo.cumulativeLayoutShift !== undefined
-  - const clsValue = browsertime.pageinfo.cumulativeLayoutShift
+if browsertime.pageinfo
+  - const clsValue = browsertime.pageinfo.cumulativeLayoutShift !== undefined ? browsertime.pageinfo.cumulativeLayoutShift : 0
   - const clsLabel = (() => { if (clsValue >= 0.25) return 'error'; if (clsValue >= 0.1) return 'warning'; return 'ok'; })()
   - const shifts = (browsertime.pageinfo.cumulativeLayoutShiftInfo || []).slice().sort((a, b) => b.score - a.score)
   //- Attribute values can hold huge payloads (e.g. an ad iframe name containing a whole serialized document), so clip what we show.


### PR DESCRIPTION
## Description

When Chrome's Layout Instability API observer never fires (no layout shifts on the page), \cumulativeLayoutShift\ stays \undefined\. The aggregator skipped it entirely, so no stats were generated and the template never rendered the CLS section — making it look like the metric was missing.

### Root cause

In \rowsertimeAggregator.js\, the guard \!== undefined\ prevented pushing a 0 value when the observer never fired. The Pug templates had matching guards that hid the entire CLS section.

### Fix

1. **browsertimeAggregator.js** — default to \