### PR TITLE
Fix crashing Toplist page on runs with no asset data

### DIFF
--- a/lib/plugins/assets/aggregator.js
+++ b/lib/plugins/assets/aggregator.js
@@ -105,13 +105,13 @@ export class AssetsAggregator {
         total: {},
         thirdParty: this.largestAssetsThirdParty
           ? this.largestAssetsThirdParty.getItems()
-          : {}
+          : []
       },
       timing: {
-        total: {},
+        total: [],
         thirdParty: this.slowestAssetsThirdParty
           ? this.slowestAssetsThirdParty.getItems()
-          : {}
+          : []
       }
     };
 
@@ -133,7 +133,7 @@ export class AssetsAggregator {
 
     summary.timing.total = this.slowestAssets
       ? this.slowestAssets.getItems()
-      : {};
+      : [];
 
     return summary;
   }


### PR DESCRIPTION
When a run collects no HAR/pagexray data at all (for example a CrUx-only config), the assets plugin still posts its summary messages, but the aggregator's empty fallbacks were plain objects while the real values are arrays. The Toplist template's short-cache derivation iterates those lists, so the report died with "pool is not iterable" and the whole toplist page was lost. The empty case now ships the same shape as the populated case: an empty array.

Co-authored-by: Claude Fable 5 noreply@anthropic.com