### PR TITLE
Show profile run coverage when the median run is not run 1

### DIFF
--- a/lib/plugins/html/templates/url/coverage/index.pug
+++ b/lib/plugins/html/templates/url/coverage/index.pug
@@ -1,7 +1,10 @@
 - const coverage = pageInfo.data.browsertime && pageInfo.data.browsertime.pageSummary && pageInfo.data.browsertime.pageSummary.coverage
 - const covRunIndex = medianRun ? medianRun.runIndex - 1 : 0
-- const jsCov = coverage && coverage.js ? coverage.js[covRunIndex] : undefined
-- const cssCov = coverage && coverage.css ? coverage.css[covRunIndex] : undefined
+//- Coverage from --enableProfileRun is a single side-run sample, so the
+//- array has length 1 regardless of -n; fall back to it when the median
+//- run has no per-iteration sample of its own.
+- const jsCov = coverage && coverage.js ? (coverage.js[covRunIndex] || coverage.js[0]) : undefined
+- const cssCov = coverage && coverage.css ? (coverage.css[covRunIndex] || coverage.css[0]) : undefined
 - const jsFiles = jsCov && jsCov.files ? jsCov.files : []
 - const cssFiles = cssCov && cssCov.files ? cssCov.files : []
 - const MAX_ROWS = 25


### PR DESCRIPTION
Coverage collected via --enableProfileRun is a single side-run sample, so the coverage arrays always have length 1 regardless of -n. The coverage section indexed them by the median run, so any run with -n >= 2 whose median was not the first iteration showed "No coverage data was collected" even though the data existed. Fall back to the only sample when the median run has no per-iteration sample of its own.

Co-authored-by: Claude Fable 5 noreply@anthropic.com
