### PR TITLE
Fix toplist run links pointing at the wrong iteration page

### DIFF
--- a/lib/plugins/assets/aggregator.js
+++ b/lib/plugins/assets/aggregator.js
@@ -16,7 +16,8 @@ export class AssetsAggregator {
   addToAggregate(data, group, url, resultUrls, runIndex, options, alias) {
     const maxSize = get(options, 'html.topListSize', 10);
     let page = resultUrls.relativeSummaryPageUrl(url, alias[url]);
-    let runPage = page + runIndex;
+    // Iteration pages are named 1.html and up, but runIndex is 0-based
+    let runPage = page + (runIndex + 1);
 
     if (!this.slowestAssets) {
       this.slowestAssets = new AssetsBySpeed(maxSize);


### PR DESCRIPTION
The "open the run where this asset was loaded" links on the Toplist page were off by one ever since #1993 renamed the first iteration page from 0.html to 1.html: the assets aggregator kept building the link from the 0-based runIndex. With a single iteration every link 404:ed on the nonexistent 0.html; with more iterations the link silently opened the previous run's page, which is why it went unnoticed for so long.

Co-authored-by: Claude Fable 5 noreply@anthropic.com