### PR TITLE
Use short Web Vitals names in the Pages table headers

### DIFF
--- a/lib/plugins/html/templates/_tableMixins.pug
+++ b/lib/plugins/html/templates/_tableMixins.pug
@@ -1,8 +1,13 @@
+//- Items are strings, or { text, title } when the visible heading is an
+//- abbreviation and the full name should live in the tooltip.
 mixin rowHeading(items)
   thead
     tr
       each item in items
-        th= item
+        if typeof item === 'object'
+          th(title=item.title)= item.text
+        else
+          th= item
 
 mixin numberCell(title, number)
   td.number(data-title=title, data-value= number)= number

--- a/lib/plugins/html/templates/pages.pug
+++ b/lib/plugins/html/templates/pages.pug
@@ -51,9 +51,16 @@ block content
   - const columns = []
   - for (const metric of html.pageSummaryMetrics) { const [group, key] = metric.split('.'); for (const tool of Object.keys(friendlyNames)) { const def = friendlyNames[tool][group] && friendlyNames[tool][group][key]; if (def) { columns.push({ tool, path: def.path, name: def.name, format: def.format, isScore: group === 'score', isHttpErrors: key.toLowerCase() === 'httperrors' }); break; } } }
 
+  //- Long metric names make the header row the widest thing in the
+  //- table and force a horizontal scroll even for a single page. The
+  //- report speaks TTFB/FCP/LCP/CLS/INP/TBT everywhere else (Web Vitals
+  //- tiles, the verdict dots in this very table), so headers use the
+  //- short vocabulary with the full name in the tooltip. Cells keep the
+  //- full name in data-title for the stacked mobile view.
+  - const shortHeadings = { 'Time to First Byte': 'TTFB', 'First Contentful Paint': 'FCP', 'Largest Contentful Paint': 'LCP', 'Interaction to Next Paint': 'INP', 'Total Blocking Time': 'TBT', 'Cumulative Layout Shift': 'CLS', 'Total Transfer Size': 'Transfer', 'Total Requests': 'Requests', 'Coach Performance Score': 'Coach score' }
   - const headings = ['URL']
   - if (hasVitals) headings.push('Web Vitals')
-  - for (const col of columns) headings.push(col.name)
+  - for (const col of columns) headings.push(shortHeadings[col.name] ? { text: shortHeadings[col.name], title: col.name } : col.name)
 
   .row
     .column


### PR DESCRIPTION
The metric columns' full friendly names (Largest Contentful Paint, Coach Performance Score, ...) made the header row the widest part of the table, forcing a horizontal scroll even for a single tested page while the value cells sat mostly empty. The report already speaks TTFB/FCP/LCP/CLS/INP/TBT in the Web Vitals tiles and in this table's own verdict dots, so the headers now use that vocabulary with the full name in the tooltip and in the stacked mobile labels. Columns are still driven by --html.pageSummaryMetrics; unmapped metrics keep their full name.

Co-authored-by: Claude Fable 5 noreply@anthropic.com