### PR TITLE
Replace Chrome-internals jargon in the HTML report

### DIFF
--- a/lib/plugins/html/templates/domains.pug
+++ b/lib/plugins/html/templates/domains.pug
@@ -24,7 +24,7 @@ mixin rows(domainStats, transferMax, phaseTone, isThirdParty)
       td.number.cell--bar(data-title='Bytes', data-value=transferSum)
         span.cell-bar-fill(style='width: ' + transferPct.toFixed(2) + '%')
         span.cell-bar-text= h.size.format(transferSum)
-      +phaseCell(domain.blocked, 'Blocked')
+      +phaseCell(domain.blocked, 'Queued')
       +phaseCell(domain.dns, 'DNS', tones.dns)
       +phaseCell(domain.connect, 'Connect', tones.connect)
       +phaseCell(domain.ssl, 'SSL', tones.ssl)
@@ -183,7 +183,7 @@ block content
       p.listing-card-help Ordered worst first by estimated time footprint (requests × median request time). Phase times are per-request medians; hover a value for min and max. Yellow/red cells mark DNS, connect, SSL and wait medians above conservative thresholds. Click any column header to re-sort.
       .responsive
         table.domains-table.data-table(data-sortable, id='domains')
-          +rowHeading(['Domain', 'Requests', 'Bytes', 'Blocked', 'DNS', 'Connect', 'SSL', 'Send', 'Wait (TTFB)', 'Receive', 'Total'])
+          +rowHeading(['Domain', 'Requests', 'Bytes', 'Queued', 'DNS', 'Connect', 'SSL', 'Send', 'Wait (TTFB)', 'Receive', 'Total'])
           +rows(orderedDomains, transferMax, phaseTone, isThirdParty)
   else
     p.domains-empty No domain information available: the HAR file wasn't generated.

--- a/lib/plugins/html/templates/help.pug
+++ b/lib/plugins/html/templates/help.pug
@@ -96,7 +96,7 @@ block content
       p The time it takes for the server to send the response. Collected using the Navigation Timing API with the definition: responseEnd - requestStart
 
       h5(id='firstPaint') FirstPaint
-      p This is when the first paint happens on the screen. In Firefox we use timeToNonBlankPaint (that is behind a Firefox preference).
+      p This is when the first paint happens on the screen. In Firefox this comes from the browser's time-to-non-blank-paint measurement, which sitespeed.io enables automatically (it is off by default in Firefox).
 
       h5(id='first-contentful-paint') First Contentful Paint
       p First Contentful Paint (FCP) measures the time from navigation to the time when the browser renders the first bit of content from the DOM.
@@ -105,19 +105,19 @@ block content
       p The Largest Contentful Paint (LCP) metric reports the render time of the largest content element visible in the viewport.
 
       h5(id='timeToDomContentFlushed') Time To DOM Content Flushed
-      p Internal Firefox metric activated by setting the preference
+      p When Firefox has finished laying out the initial page content. Firefox only; sitespeed.io enables it automatically via the browser preference
         i dom.performance.time_to_dom_content_flushed.enabled
-        | &nbsp;to true.
+        | .
 
       h5(id='timeToContentfulPaint') Time To Contentful Paint
-      p Firefox implementation of First Contentful Paint. Activated by setting the preference
+      p Firefox's equivalent of First Contentful Paint. Firefox only; sitespeed.io enables it automatically via the browser preference
         i dom.performance.time_to_contentful_paint.enabled
-        | &nbsp;to true.
+        | .
 
       h5(id='timeToFirstInteractive') Time To First Interactive
-      p Firefox implementation of Time to first interactive. Activated by setting the preference
+      p When Firefox considers the page ready to respond to input. Firefox only; sitespeed.io enables it automatically via the browser preference
         i dom.performance.time_to_first_interactive.enabled
-        | &nbsp;to true.
+        | .
 
       h5(id='loadEventEnd') Load Event End
       p The time when the load event of the current document is completed.

--- a/lib/plugins/html/templates/index.pug
+++ b/lib/plugins/html/templates/index.pug
@@ -330,7 +330,7 @@ block content
       - addCpu('Max Potential FID', 'cpu.longTasks.maxPotentialFid.median', h.time.ms)
       - const cpuCategories = get(btSummary, 'cpu.categories')
       - let cpuCategoryRows = []
-      - if (cpuCategories) cpuCategoryRows = Object.keys(cpuCategories).map(nm => ({ label: nm, value: get(cpuCategories[nm], 'median', 0) })).filter(r => r.value > 0).sort((a, b) => b.value - a.value)
+      - if (cpuCategories) cpuCategoryRows = Object.keys(cpuCategories).map(nm => ({ label: h.cpuCategoryName(nm), value: get(cpuCategories[nm], 'median', 0) })).filter(r => r.value > 0).sort((a, b) => b.value - a.value)
       - const showCpu = cpuRows.length > 0 || cpuCategoryRows.length > 0
 
       //- Accessibility card (axe plugin).

--- a/lib/plugins/html/templates/settings.pug
+++ b/lib/plugins/html/templates/settings.pug
@@ -60,11 +60,11 @@ block content
           span.settings-tile-value #{get(browser, 'userAgent')}
         if get(browser, 'traceCategories') !== undefined
           .settings-tile.settings-tile--wide
-            span.settings-tile-label Trace categories
+            span.settings-tile-label Chrome trace categories
             span.settings-tile-value #{get(browser, 'traceCategories')}
         if get(browser, 'geckoProfilerFeatures') !== undefined
           .settings-tile.settings-tile--wide
-            span.settings-tile-label Gecko Profiler Features
+            span.settings-tile-label Firefox profiler features (Gecko)
             span.settings-tile-value #{get(browser, 'geckoProfilerFeatures')}
 
     //- Mobile emulation (Chrome only) — recorded by Browsertime 27 from the
@@ -214,7 +214,7 @@ block content
               span.settings-tile-label Wifi
               span.settings-tile-value #{android.wifi}
           .settings-tile
-            span.settings-tile-label Using gnirehtet
+            span.settings-tile-label Reverse tethering (gnirehtet)
             span.settings-tile-value #{get(options, 'browsertime.android.gnirehtet', 'No')}
           .settings-tile
             span.settings-tile-label Rooted phone

--- a/lib/plugins/html/templates/url/coverage/index.pug
+++ b/lib/plugins/html/templates/url/coverage/index.pug
@@ -90,10 +90,10 @@ p
   else
     | JavaScript and CSS coverage collected on every timed iteration (
     code --chrome.coverage
-    | ); shown here is the median iteration (run #{covRunIndex + 1}). Note that detailed coverage instrumentation deoptimizes V8 and can affect the timing metrics of the same runs.
-  |  For JS, Chrome's V8 profiler reports per-block execution counts: a byte is&nbsp;
+    | ); shown here is the median iteration (run #{covRunIndex + 1}). Note that detailed coverage measurement slows down Chrome's JavaScript engine and can affect the timing metrics of the same runs.
+  |  For JS, Chrome tracks which blocks of each script actually ran: a byte is&nbsp;
   em unused
-  | &nbsp;when its innermost containing range executed zero times. For CSS, Chrome's rule tracker flags every selector that no element on the page matched during the iteration. Enable with&nbsp;
+  | &nbsp;when the innermost block of code around it never ran. For CSS, Chrome records every selector that no element on the page matched during the iteration. Enable with&nbsp;
   code --chrome.coverage
   | &nbsp;on every run, or&nbsp;
   code --enableProfileRun

--- a/lib/plugins/html/templates/url/cpu/index.pug
+++ b/lib/plugins/html/templates/url/cpu/index.pug
@@ -50,12 +50,12 @@ include ../includes/_quicklinks
 - const timers = useProfileTimers ? profileTimers : measuredTimers
 - const timersFromProfileRun = useProfileTimers
 
-//- Human names for the trace work categories, shared by "What kind of
-//- work blocked" and "Where the time went" so both cards read the
-//- same. The raw trace keys stay visible in the category definitions
-//- card because the JSON data and exported metrics use them.
-- const cpuCategoryLabels = { parseHTML: 'Parsing HTML & CSS', styleLayout: 'Style & layout', scriptParseCompile: 'Parsing & compiling JavaScript', scriptEvaluation: 'Running JavaScript', paintCompositeRender: 'Paint & composite', garbageCollection: 'Garbage collection', other: 'Other browser work' }
-- const cpuCategoryLabel = key => cpuCategoryLabels[key] || key
+//- Human names for the trace work categories (h.cpuCategoryName),
+//- shared by "What kind of work blocked", "Where the time went" and
+//- the start page's CPU card so they all read the same. The raw trace
+//- keys stay visible in the category definitions card because the
+//- JSON data and exported metrics use them.
+- const cpuCategoryLabel = h.cpuCategoryName
 
 //- Cross-link targets for the "what kind of work blocked" remedy
 //- lines. Each link only renders when its target section does:
@@ -269,7 +269,7 @@ if cpu && cpu.longTasks
     - const phaseClass = (ms) => ms === 0 ? 'ok' : (ms <= 200 ? 'warning' : 'error')
     .cpu-kpis.cpu-kpis-secondary
       .cpu-kpi(class=phaseClass(cpu.longTasks.beforeFirstPaint.totalDuration))
-        span.cpu-kpi-label Before FP
+        span.cpu-kpi-label Before first paint
         span.cpu-kpi-value #{h.time.ms(cpu.longTasks.beforeFirstPaint.totalDuration.toFixed(0))}
         span.cpu-kpi-sub #{cpu.longTasks.beforeFirstPaint.tasks} #{cpu.longTasks.beforeFirstPaint.tasks === 1 ? 'task' : 'tasks'}
       .cpu-kpi(class=phaseClass(cpu.longTasks.beforeFirstContentfulPaint.totalDuration))
@@ -336,7 +336,7 @@ if cpu && cpu.blocking && cpu.blocking.urls && cpu.blocking.urls.length > 0
   h3
     +cpuIcon('ban')
     | Blocking time per script (trace)
-  p Total Blocking Time attributed per script from the Chrome trace: every main-thread task longer than 50 ms blocks input for the remainder, and each blocking task is credited to the script that contributed the most self-time.
+  p Total Blocking Time attributed per script from the Chrome trace: every main-thread task longer than 50 ms blocks input for the remainder, and each blocking task is credited to the script whose own code ran the longest during that task.
   .cpu-kpis
     - const traceTbtClass = cpu.blocking.totalBlockingTime >= 600 ? 'error' : (cpu.blocking.totalBlockingTime >= 200 ? 'warning' : 'ok')
     .cpu-kpi(class=traceTbtClass)
@@ -432,7 +432,7 @@ if cpu && cpu.blocking && cpu.blocking.urls && cpu.blocking.urls.length > 0
         .cpu-bar-row
           if entry.url === 'unknown'
             span.cpu-bar-asset
-              span.cpu-bar-anon Browser internal / unattributed
+              span.cpu-bar-anon Browser's own work (no script responsible)
           else if entry.url === daurl
             //- Blocking HTML-parse tasks are attributed to the
             //- document itself — name it so nobody hunts for a
@@ -481,7 +481,7 @@ if cpu && cpu.categories
     //- so on quiet pages the note simply doesn't render.
     - const schedulingEventNames = ['RunTask', 'ThreadControllerImpl::RunTask', 'ThreadControllerImpl::DoWork', 'MessageLoop::RunTask', 'TaskQueueManager::ProcessTaskFromWorkQueue']
     - const schedulingMs = cpu.events ? schedulingEventNames.reduce((s, n) => s + (cpu.events[n] || 0), 0) : 0
-    - const schedulingTitle = 'Mostly Chrome task-scheduling overhead: per-task entry/exit cost and thousands of sub-millisecond scheduler ticks (RunTask self time), not attributable page work.'
+    - const schedulingTitle = 'Mostly the browser\'s own cost of starting and finishing each task, spread over thousands of tiny slices. Not page work you can optimize away.'
     .cpu-cat-legend
       each entry in catEntries
         - const pct = catTotal > 0 ? (entry[1] / catTotal * 100) : 0
@@ -539,7 +539,7 @@ if cpu && cpu.categories
         dd
           | Chrome’s own task management: per-task overhead and thousands of sub-millisecond scheduler ticks — not page work you can attribute or optimize away.
           if schedulingMs > 0
-            |  On this page #{h.time.ms(schedulingMs.toFixed(0))} of it is RunTask self time.
+            |  On this page #{h.time.ms(schedulingMs.toFixed(0))} of it is this per-task bookkeeping (RunTask self time in the trace).
 
 //- CPU time per script — the top of the drill-down ladder: which
 //- URL is costing main thread. Capped at top 10 because longer
@@ -603,7 +603,7 @@ if moduleCosts && moduleCosts.length > 0
             tr
               th Module
               th Version
-              th.number Self time
+              th.number(title='Time spent running code inside the module itself') Self time
           tbody
             each m in shownModules
               tr
@@ -614,7 +614,7 @@ if moduleCosts && moduleCosts.length > 0
             if bundle.otherTime > 0
               tr
                 td
-                  span.cpu-bar-anon (other)
+                  span.cpu-bar-anon (rest of the bundle, not tied to one module)
                 td –
                 td.number #{bundle.otherTime.toFixed(1)} ms
 
@@ -633,7 +633,7 @@ if functionCosts && functionCosts.length > 0
     | Slowest JS functions
     if functionCostsFromProfileRun
       span.profile-run-badge(title=profileRunExplanation) Profile run
-  p The functions where main-thread JavaScript time was actually spent, sampled by the V8 profiler. Self time is spent in the function itself; total time includes the functions it called. For loader/dispatcher functions whose total dwarfs their self time, the #[em runs] line shows the top functions and modules (up to five, ≥ 1 ms) the total was actually spent running.
+  p The functions where main-thread JavaScript time was actually spent, sampled by Chrome's JavaScript profiler. Self time is spent in the function itself; total time includes the functions it called. For loader/dispatcher functions whose total dwarfs their self time, the #[em runs] line shows the top functions and modules (up to five, ≥ 1 ms) the total was actually spent running.
   if functionCostsFromProfileRun
     p.small The data comes from the extra profile run, not from the timed iterations.
   .listing-card
@@ -673,7 +673,7 @@ if functionCosts && functionCosts.length > 0
                 else if fn.url
                   a(href=fn.url, title=fn.url)= fn.label || h.shortAsset(fn.url, true)
                 else
-                  span.cpu-bar-anon Browser / engine
+                  span.cpu-bar-anon Browser internal (not your code)
               td.number #{fn.selfTime.toFixed(1)} ms
               td.number #{fn.totalTime.toFixed(1)} ms
 
@@ -688,7 +688,7 @@ if timers && timers.fires > 0
     | Timers
     if timersFromProfileRun
       span.profile-run-badge(title=profileRunExplanation) Profile run
-  p How much setTimeout/setInterval work the page runs, credited to the script that scheduled each timer. Many timeout-0 installs mean work sliced into a machine-gun of tiny tasks; recurring installs are polling.
+  p How much setTimeout/setInterval work the page runs, credited to the script that scheduled each timer. Many zero-delay timers mean work sliced into a machine-gun of tiny tasks; repeating timers are polling.
   .cpu-kpis
     .cpu-kpi
       span.cpu-kpi-label Timers set
@@ -700,10 +700,10 @@ if timers && timers.fires > 0
       span.cpu-kpi-label Fire time
       span.cpu-kpi-value #{h.time.ms(timers.fireTime)}
     .cpu-kpi
-      span.cpu-kpi-label Timeout-0 installs
+      span.cpu-kpi-label Zero-delay timers
       span.cpu-kpi-value #{timers.timeoutZeroInstalls}
     .cpu-kpi
-      span.cpu-kpi-label Recurring installs
+      span.cpu-kpi-label Repeating timers
       span.cpu-kpi-value #{timers.recurringInstalls}
   //- Turn the intro's generic warnings into this page's findings:
   //- name the worst polling loop and the worst timeout-0 slicer with
@@ -714,9 +714,9 @@ if timers && timers.fires > 0
   - const timerSiteOwner = site => { const where = site.module || site.label || (site.url === 'unknown' ? 'an unattributed script' : h.shortAsset(site.url, true)); return site.functionName ? site.functionName + ' in ' + where : where }
   - const timerFindings = []
   - const topPoller = (timers.sites || []).filter(s => s.recurring && s.fires >= 10).sort((a, b) => b.fireTime - a.fireTime)[0]
-  - if (topPoller) timerFindings.push({ label: 'Polling', text: timerSiteOwner(topPoller) + ' keeps a ' + topPoller.timeout + ' ms timer running: ' + topPoller.fires + ' fires costing ' + topPoller.fireTime.toFixed(0) + ' ms. Consider reacting to events instead, or a longer interval.' })
+  - if (topPoller) timerFindings.push({ label: 'Polling', text: timerSiteOwner(topPoller) + ' keeps a ' + topPoller.timeout + ' ms timer running: it fired ' + topPoller.fires + ' times costing ' + topPoller.fireTime.toFixed(0) + ' ms. Consider reacting to events instead, or a longer interval.' })
   - const topSlicer = (timers.sites || []).filter(s => !s.recurring && s.timeout === 0 && s.installs >= 10).sort((a, b) => b.fireTime - a.fireTime)[0]
-  - if (topSlicer) timerFindings.push({ label: 'Timeout-0 slicing', text: timerSiteOwner(topSlicer) + ' split work into ' + topSlicer.installs + ' back-to-back tasks costing ' + topSlicer.fireTime.toFixed(0) + ' ms. Consider batching the work or moving it to requestIdleCallback or a worker.' })
+  - if (topSlicer) timerFindings.push({ label: 'Zero-delay slicing', text: timerSiteOwner(topSlicer) + ' split work into ' + topSlicer.installs + ' back-to-back tasks costing ' + topSlicer.fireTime.toFixed(0) + ' ms. Consider batching the work or moving it to requestIdleCallback or a worker.' })
   if timerFindings.length > 0
     .cpu-kind-actions
       each finding in timerFindings
@@ -736,14 +736,14 @@ if timers && timers.fires > 0
           .cpu-bar-row
             if entry.url === 'unknown'
               span.cpu-bar-asset
-                span.cpu-bar-anon Unattributed
+                span.cpu-bar-anon Unknown script
             else
               a.cpu-bar-asset(href=entry.url, title=entry.url)= entry.label || h.shortAsset(entry.url, true)
             .cpu-bar-track
               span.cpu-bar-fill(style=`width: ${pct.toFixed(2)}%`)
             span.cpu-bar-value
               | #{entry.fireTime.toFixed(0)} ms
-              span.cpu-bar-sub  · #{entry.installs} #{entry.installs === 1 ? 'install' : 'installs'} · #{entry.fires} #{entry.fires === 1 ? 'fire' : 'fires'}
+              span.cpu-bar-sub  · set #{entry.installs} #{entry.installs === 1 ? 'time' : 'times'} · fired #{entry.fires} #{entry.fires === 1 ? 'time' : 'times'}
   //- The individual timers, identified by install site (source
   //- position + timeout + kind). A polling loop reinstalling from
   //- the same line collapses into one row, so "45 installs,
@@ -751,24 +751,24 @@ if timers && timers.fires > 0
   if timers.sites && timers.sites.length > 0
     .listing-card
       .listing-card-header
-        h3.listing-card-title The timers, by install site
+        h3.listing-card-title The timers, by where they were set
         span.listing-card-meta top #{timers.sites.length} by fire time
       .responsive
         table
           thead
             tr
-              th Installed by
-              th.number Timeout
+              th Set by
+              th.number Delay
               th Type
-              th.number Installs
-              th.number Fires
+              th.number Times set
+              th.number Times fired
               th.number Fire time
           tbody
             each site in timers.sites
               tr
                 td
                   if site.url === 'unknown'
-                    span.cpu-bar-anon Unattributed
+                    span.cpu-bar-anon Unknown script
                   else
                     //- `module` is the resolved ResourceLoader module
                     //- owning the install position — far more useful
@@ -816,7 +816,7 @@ if cpu && cpu.forcedReflows && cpu.forcedReflows.length > 0
               if entry.url
                 a(href=entry.url, title=entry.url)= entry.label || h.shortAsset(entry.url, true)
               else
-                span.cpu-bar-anon Anonymous / inline
+                span.cpu-bar-anon Inline or unnamed script
             .cpu-bar-track
               span.cpu-bar-fill(style=`width: ${pct.toFixed(2)}%`)
             span.cpu-bar-value

--- a/lib/plugins/html/templates/url/cpu/loaf.pug
+++ b/lib/plugins/html/templates/url/cpu/loaf.pug
@@ -38,6 +38,11 @@ if loaf
     //- page itself is an inline script — say so instead of rendering
     //- the article name as if it were a file.
     - const loafDisplayName = sc => sc.label || (sc.sourceURL ? (sc.sourceURL === loafPageUrl ? 'inline script in the document' : loafScriptName(sc.sourceURL)) : (sc.invoker || 'unknown'))
+    //- The LoAF API reports how a script started and where it ran as
+    //- raw spec tokens (classic-script, descendant, ...) - translate
+    //- them, falling back to the raw token for values the maps miss.
+    - const loafInvokerLabel = t => ({ 'classic-script': 'script tag', 'module-script': 'module script', 'event-listener': 'event handler', 'user-callback': 'timer or animation callback', 'resolve-promise': 'promise callback', 'reject-promise': 'promise rejection' })[t] || t
+    - const loafWindowLabel = t => ({ 'descendant': 'an iframe inside this page', 'ancestor': 'a parent page', 'same-page': 'another frame of this page', 'other': 'another window' })[t] || t
 
     //- Frame start: shipped directly by browsertime 28.1+; older data
     //- recovers it from renderStart − workDuration for frames that
@@ -146,7 +151,7 @@ if loaf
                                 td.number #{c.runTime > 0 ? loafFmt(c.runTime) : '–'}
                             td.number #{loafFmt(c.blocking)}
                             td.number #{c.forced > 0 ? loafFmt(c.forced) : '–'}
-                            td= [...c.invokerTypes].join(', ')
+                            td= [...c.invokerTypes].map(loafInvokerLabel).join(', ')
         if loafHasDurations
             p.small A frame's blocking time is split between its scripts by their share of the frame's work, capped at each script's own run time — blocking from work no script owns (HTML parsing, browser internals) stays unattributed. #[a(href='#cpu-loaf-blocking') The per-script blocking view below] uses the same attribution.
         else
@@ -157,7 +162,7 @@ if loaf
             //- duration = work + render; render = pre-layout + style & layout
             //- (plus whatever render time isn't attributed to either).
             - const renderRest = Math.max(0, oneLoaf.renderDuration - oneLoaf.preLayoutDuration - oneLoaf.styleAndLayoutDuration)
-            - const phases = [{ key: 'work', name: 'Work', value: oneLoaf.workDuration }, { key: 'pre-layout', name: 'Pre-layout', value: oneLoaf.preLayoutDuration }, { key: 'style-layout', name: 'Style & layout', value: oneLoaf.styleAndLayoutDuration }, { key: 'render', name: 'Render', value: renderRest }]
+            - const phases = [{ key: 'work', name: 'Scripts & other work', value: oneLoaf.workDuration }, { key: 'pre-layout', name: 'Animation callbacks', value: oneLoaf.preLayoutDuration }, { key: 'style-layout', name: 'Style & layout', value: oneLoaf.styleAndLayoutDuration }, { key: 'render', name: 'Render', value: renderRest }]
             - const loafWhenText = loafWhen(oneLoaf)
             .loaf-card
                 .loaf-header
@@ -212,21 +217,21 @@ if loaf
                                     //- URL (classic/module scripts) — only show
                                     //- it when it adds information.
                                     if theScript.invoker && theScript.invoker !== theScript.sourceURL
-                                        dt Invoker
+                                        dt Started by
                                         dd= theScript.invoker
-                                    dt Invoker type
-                                    dd= theScript.invokerType
+                                    dt How it started
+                                    dd= loafInvokerLabel(theScript.invokerType)
                                     if theScript.sourceFunctionName
                                         dt Source function
                                         dd= theScript.sourceFunctionName
                                     if theScript.windowAttribution && theScript.windowAttribution !== 'self'
-                                        dt Window attribution
-                                        dd= theScript.windowAttribution
+                                        dt Ran in
+                                        dd= loafWindowLabel(theScript.windowAttribution)
                                     if theScript.sourceCharPosition > 0
-                                        dt Source char position
-                                        dd #{theScript.sourceCharPosition} (locate it via DevTools → Performance → the LoAF track)
+                                        dt Position in source
+                                        dd character #{theScript.sourceCharPosition} into the file (locate it via DevTools → Performance → the Long Animation Frames track)
                 else
-                    p.loaf-no-scripts No script attribution for this frame — typically browser-internal style/layout or cross-origin work.
+                    p.loaf-no-scripts The browser did not report which script was responsible for this frame — typically its own style/layout work, or a cross-origin script it will not name.
 
     - const loafQuiet = loafFrames.filter(f => f.blockingDuration === 0).length
     if loafQuiet > 0

--- a/lib/plugins/html/templates/url/metrics/index.pug
+++ b/lib/plugins/html/templates/url/metrics/index.pug
@@ -42,7 +42,7 @@ if browsertime
   if timings.firstInput !== undefined
     - metricsLinks.push({href: '#firstInput', label: 'First Input Delay'})
   if cdp
-    - metricsLinks.push({href: '#cdp-performance', label: 'Metrics from CDP'})
+    - metricsLinks.push({href: '#cdp-performance', label: 'Chrome internal metrics'})
   if timings.serverTimings && timings.serverTimings.length > 0
     - metricsLinks.push({href: '#server-timings', label: 'Server timings'})
   +quicklinks(metricsLinks)
@@ -119,11 +119,11 @@ if browsertime
               if tile.cls
                 .web-vital-status
                   if tile.field
-                    span.web-vital-source Lab
+                    span.web-vital-source This test
                   span #{wvStatusLabel(tile.cls)}
               if tile.field
                 .web-vital-field
-                  span.web-vital-source Field p75 · #{cruxFFLabel}
+                  span.web-vital-source(title='75th percentile of real Chrome users over the last 28 days (Chrome UX Report)') Real users p75 · #{cruxFFLabel}
                   .web-vital-field-measure
                     span.web-vital-field-dot(class='web-vital-field-dot--' + tile.field.cls)
                     span.web-vital-field-value #{tile.field.formatted}
@@ -151,7 +151,7 @@ if browsertime
       each value, name in timings.pageTimings
         .metric-tile
           span.metric-tile-label
-            a(href=baseHelpURL + name) #{name}
+            a(href=baseHelpURL + name, title=name) #{h.metricName(name)}
           span.metric-tile-value #{h.time.ms(value)}
 
   //- The recalculate-style tiles (and the run-with---cpu hint) live on
@@ -183,7 +183,7 @@ if browsertime
             a(href=baseHelpURL + 'firstPaint') First paint
           span.metric-tile-value #{h.time.ms(timings.firstPaint.toFixed(0))}
       if timings.timeToDomContentFlushed
-        .metric-tile
+        .metric-tile(title='When Firefox has laid out the initial page content. Firefox only.')
           span.metric-tile-label
             a(href=baseHelpURL + 'timeToDomContentFlushed') DOM Content Flushed
           span.metric-tile-value #{h.time.ms(timings.timeToDomContentFlushed.toFixed(0))}
@@ -276,12 +276,14 @@ if browsertime
     a#cdp-performance
     details.iter-group(open)
       summary.iter-group-summary
-        span.iter-group-title CDP Performance
+        span.iter-group-title Chrome internal metrics (CDP)
         span.iter-group-count #{Object.keys(cdp.performance).length}
       .metric-tiles
         each value, name in cdp.performance
           .metric-tile
-            span.metric-tile-label #{name}
+            //- The raw protocol key stays in the tooltip - it is the
+            //- name in the JSON data.
+            span.metric-tile-label(title=name) #{h.metricName(name)}
             span.metric-tile-value #{value.toFixed(0)}
 
   if options.browsertime.visualElements

--- a/lib/plugins/html/templates/url/metrics/lcp.pug
+++ b/lib/plugins/html/templates/url/metrics/lcp.pug
@@ -50,12 +50,12 @@ if timings.largestContentfulPaint
           dd #{h.time.ms(lcp.loadTime)}
           if renderBlocking && renderBlocking.recalculateStyle.beforeLCP
             - const recalcLCP = renderBlocking.recalculateStyle.beforeLCP
-            dt Recalculate-style elements before LCP
+            dt Style recalculation before LCP
             //- count/maxElements/maxDurationInMillis are additive
             //- (Browsertime PR #2496); the full picture lives on the
             //- Rendering tab — this stays a one-liner.
             if recalcLCP.count !== undefined
-              dd #{recalcLCP.count} events, #{recalcLCP.elements} elements (#{h.time.ms(recalcLCP.durationInMillis)}) — largest #{recalcLCP.maxElements} elements (#{h.time.ms(recalcLCP.maxDurationInMillis)})
+              dd #{recalcLCP.count} recalculations touching #{recalcLCP.elements} elements (#{h.time.ms(recalcLCP.durationInMillis)}) — the largest touched #{recalcLCP.maxElements} elements (#{h.time.ms(recalcLCP.maxDurationInMillis)})
             else
               dd #{recalcLCP.elements} (#{h.time.ms(recalcLCP.durationInMillis)})
 

--- a/lib/plugins/html/templates/url/metrics/visualProgress.pug
+++ b/lib/plugins/html/templates/url/metrics/visualProgress.pug
@@ -109,7 +109,11 @@ if vpData.length > 0
             - const ltLeft = task.startTime / vpMax * 100
             - const ltWidth = Math.min(Math.max(0.4, task.duration / vpMax * 100), 100 - ltLeft).toFixed(2)
             - const ltClass = task.duration >= 250 ? 'vp-longtask--severe' : (task.duration >= 100 ? 'vp-longtask--major' : 'vp-longtask--minor')
-            .vp-longtask(class=ltClass, style='left: ' + ltLeft.toFixed(2) + '%; width: ' + ltWidth + '%;', title='Long task ' + task.duration.toFixed(0) + ' ms at ' + task.startTime.toFixed(0) + ' ms (' + (task.attribution && task.attribution[0] ? task.attribution[0].containerType : 'unknown') + ')')
+            //- The Long Task API reports where the task ran as a raw
+            //- container type (window/iframe/embed) - translate it.
+            - const ltContainer = task.attribution && task.attribution[0] ? task.attribution[0].containerType : undefined
+            - const ltWhere = ltContainer ? (ltContainer === 'window' ? 'in the main page' : 'in an ' + ltContainer) : 'unknown origin'
+            .vp-longtask(class=ltClass, style='left: ' + ltLeft.toFixed(2) + '%; width: ' + ltWidth + '%;', title='Long task ' + task.duration.toFixed(0) + ' ms at ' + task.startTime.toFixed(0) + ' ms (' + ltWhere + ')')
     .vp-axis
       each tick in vpTicks
         span.vp-axis-tick(style='left: ' + tick.pct + '%') #{tick.sec.toFixed(1)}s

--- a/lib/plugins/html/templates/url/rendering/blocking.pug
+++ b/lib/plugins/html/templates/url/rendering/blocking.pug
@@ -49,4 +49,4 @@ if pagexray && pagexray.renderBlocking
                   td.number(data-title='Transfer', data-value=asset.transferSize || 0) #{h.size.format(asset.transferSize || 0)}
                   td.number(data-title='Total time', data-value=asset.totalTime || 0) #{h.time.ms(asset.totalTime || 0)}
                   if section.raw
-                    td(data-title='Status') #{asset.renderBlocking}
+                    td(data-title='Status') #{asset.renderBlocking.split('_').join(' ')}

--- a/lib/plugins/html/templates/url/rendering/index.pug
+++ b/lib/plugins/html/templates/url/rendering/index.pug
@@ -108,11 +108,11 @@ include ../../_tableMixins
 - if (screenshots.length > 0) renderingLinks.push({href: '#screenshots', label: 'Screenshots'})
 - if (hasFrames) renderingLinks.push({href: '#frames', label: 'Frames'})
 - if (ttfbSlow) renderingLinks.push({href: '#slow-ttfb', label: 'TTFB'})
-- if (hasRecalculateStyle) renderingLinks.push({href: '#recalculate-style', label: 'Recalculate style'})
+- if (hasRecalculateStyle) renderingLinks.push({href: '#recalculate-style', label: 'Style recalculation'})
 - if (reflowsMaterial) renderingLinks.push({href: '#reflows-before-paint', label: 'Forced reflows'})
 - if (pagexray && pagexray.renderBlocking) renderingLinks.push({href: '#requests-render-blocking', label: 'Render-blocking requests'})
 - if (selectorStats && selectorStats.selectors && selectorStats.selectors.length > 0) renderingLinks.push({href: '#css-selectors', label: 'CSS selectors'})
-- if (styleInvalidations) renderingLinks.push({href: '#style-invalidations', label: 'Invalidations'})
+- if (styleInvalidations) renderingLinks.push({href: '#style-invalidations', label: 'Style invalidations'})
 - if (nonCompositedCount > 0) renderingLinks.push({href: '#main-thread-animations', label: 'Animations'})
 //- A lone Playback pill is just noise — only show jump links when the
 //- tab has more than one section to jump between.
@@ -320,12 +320,12 @@ if screenshots.length > 0
 if hasFrames
   a#frames
   h3 Frames
-  p Frame delivery from the Chrome trace. Dropped counts only frames Chrome flags as affecting smoothness. On mostly-static pages the longest gap includes idle time where there was simply nothing to draw.
+  p How smoothly Chrome delivered frames to the screen during the test. Dropped counts only frames Chrome flags as affecting smoothness. On mostly-static pages the longest gap includes idle time where there was simply nothing to draw.
   .cpu-kpis
     .cpu-kpi
-      span.cpu-kpi-label Presented
+      span.cpu-kpi-label Frames shown
       span.cpu-kpi-value #{whyCpu.frames.presented}
-    .cpu-kpi
+    .cpu-kpi(title='Frames where only part of the screen updated in time')
       span.cpu-kpi-label Partial
       span.cpu-kpi-value #{whyCpu.frames.partial}
     .cpu-kpi(class=whyCpu.frames.dropped === 0 ? 'ok' : (whyCpu.frames.dropped <= 5 ? 'warning' : 'error'))
@@ -371,10 +371,10 @@ if hasRecalculateStyle
   a#recalculate-style
   .listing-card
     .listing-card-header
-      h3.listing-card-title Recalculate style
-      span.listing-card-meta from the Chrome trace
+      h3.listing-card-title Style recalculation
+      span.listing-card-meta measured by Chrome during this run
     p.listing-card-help
-      | Style the browser had to recalculate before it could paint: many elements or a lot of time spent here points at expensive CSS on the critical rendering path. The event count and the largest single event tell the two problems apart: one massive style invalidation (few events, the largest close to the total) needs different medicine than thousands of small forced recalcs (many events, each tiny).
+      | Style the browser had to recalculate before it could paint: many elements or a lot of time spent here points at expensive CSS on the critical rendering path. The recalculation count and the largest single one tell the two problems apart: one massive style change touching most of the page (few recalculations, the largest close to the total) needs different medicine than thousands of tiny ones (many recalculations, each tiny).
     //- count / maxElements / maxDurationInMillis are additive fields
     //- (Browsertime PR #2496) — guard each so older browsertime data
     //- still renders the totals. One tile row per phase with a small
@@ -390,7 +390,7 @@ if hasRecalculateStyle
       .metric-tiles
         if recalc.count !== undefined
           .metric-tile
-            span.metric-tile-label Events
+            span.metric-tile-label Recalculations
             span.metric-tile-value #{recalc.count}
         .metric-tile
           span.metric-tile-label Elements
@@ -402,7 +402,7 @@ if hasRecalculateStyle
           //- One value line like the neighbouring tiles — a sub-line
           //- here made this the only two-row tile in the row.
           .metric-tile
-            span.metric-tile-label Largest event
+            span.metric-tile-label Largest recalculation
             span.metric-tile-value #{recalc.maxElements} elements#{recalc.maxDurationInMillis !== undefined ? ' · ' + h.time.ms(recalc.maxDurationInMillis) : ''}
 else if showRecalculateHint
   //- The recalculate-style counts come from parsing a Chrome timeline
@@ -411,7 +411,7 @@ else if showRecalculateHint
   //- events, so the hint is Chromium-only — pointing Firefox or Safari
   //- users at --cpu would be misleading.
   p.metrics-cpu-hint
-    | Want recalculate-style metrics for FCP and LCP, plus CPU long tasks? Run with&nbsp;
+    | Want to see how much CSS style-recalculation work delayed FCP and LCP, plus CPU long tasks? Run with&nbsp;
     code --cpu
     | .
 
@@ -431,7 +431,7 @@ if reflowsMaterial
   .listing-card
     .listing-card-header
       h3.listing-card-title Forced reflows before the page painted
-      span.listing-card-meta from the Chrome trace
+      span.listing-card-meta measured by Chrome during this run
     p.listing-card-help
       | JavaScript read a layout value (offsetTop, getBoundingClientRect, …) while the page was mid-change, so the browser had to re-layout synchronously, work that blocks rendering. Reflows before First Contentful Paint delayed the first pixels; reflows before Largest Contentful Paint delayed the main content.
     .metric-tiles
@@ -466,7 +466,7 @@ if reflowsMaterial
               if reflow.triggeredByUrl
                 a(href=reflow.triggeredByUrl, title=reflow.triggeredByUrl)= h.shortAsset(reflow.triggeredByUrl, true)
               else
-                span.cpu-bar-anon Anonymous / inline
+                span.cpu-bar-anon Inline or unnamed script
             .cpu-bar-track
               span.cpu-bar-fill(style=`width: ${pct.toFixed(2)}%`)
             span.cpu-bar-value
@@ -487,7 +487,7 @@ if selectorStats && selectorStats.selectors && selectorStats.selectors.length > 
     | Slowest CSS selectors
     if selectorStatsFromProfileRun
       span.profile-run-badge(title=renderingProfileRunExplanation) Profile run
-  p Per-selector matching cost during style recalculation, from Chrome's selector stats. A selector with many match attempts and zero matches is evaluated against the document over and over for rules that never apply.
+  p How long Chrome spent testing each CSS selector against the page while recalculating styles. A selector with many match attempts and zero matches is evaluated against the document over and over for rules that never apply.
   .cpu-kpis
     .cpu-kpi
       span.cpu-kpi-label Matching time
@@ -548,10 +548,10 @@ if styleInvalidations
     | Style invalidations
     if styleInvalidationsFromProfileRun
       span.profile-run-badge(title=renderingProfileRunExplanation) Profile run
-  p Why the browser had to recalculate style and layout: every DOM/style change invalidates some set of nodes, and the same class or attribute churning over and over is the pattern to hunt. Counts, not milliseconds — the time is in the recalculate style numbers above.
+  p Why the browser had to recalculate style and layout: every DOM/style change invalidates some set of nodes, and the same class or attribute churning over and over is the pattern to hunt. Counts, not milliseconds — the time is in the style recalculation numbers above.
   .cpu-kpis
     .cpu-kpi
-      span.cpu-kpi-label Style recalcs
+      span.cpu-kpi-label Style recalculations
       span.cpu-kpi-value #{styleInvalidations.styleRecalcs.toLocaleString('sv-SE')}
     .cpu-kpi
       span.cpu-kpi-label Layout invalidations
@@ -575,7 +575,7 @@ if styleInvalidations
           thead
             tr
               th Reason
-              th.number Style recalc
+              th.number Style recalculations
               th.number Layout
           tbody
             each reason in styleInvalidations.recalcReasons
@@ -615,6 +615,6 @@ if styleInvalidations
 if nonCompositedCount > 0
   a#main-thread-animations
   p.rendering-why-note
-    | #{nonCompositedCount} #{nonCompositedCount === 1 ? 'animation runs' : 'animations run'} on the main thread instead of the compositor; they can make the rendering you see above janky.&nbsp;
+    | #{nonCompositedCount} #{nonCompositedCount === 1 ? 'animation runs' : 'animations run'} on the main thread instead of on the browser's fast path that animates without blocking other page work (the compositor); they can make the rendering you see above janky.&nbsp;
     a(href='#cpu-animations', onclick='const cpuTab = document.querySelector("#tabs #cpu"); if (cpuTab) selectTab(cpuTab, false)') See them on the CPU tab
     | .

--- a/lib/plugins/html/templates/url/summary/index.pug
+++ b/lib/plugins/html/templates/url/summary/index.pug
@@ -88,7 +88,7 @@ block content
       if options.browsertime.video
         - summaryLinks.push({href: '#downloads', label: 'Download Video'})
       if options.browsertime.chrome && options.browsertime.chrome.timeline
-        - summaryLinks.push({href: '#downloads', label: 'Download Timeline Log'})
+        - summaryLinks.push({href: '#downloads', label: 'Download Chrome trace'})
       if d.browsertime && d.browsertime.har
         - summaryLinks.push({href: '#downloads', label: 'Download HAR'})
       if options.browsertime.chrome && options.browsertime.chrome.collectConsoleLog
@@ -137,7 +137,7 @@ block content
           if cruxFCP || cruxLCP || cruxFID || (cruxCLS || cruxCLS === 0) || (d.crux && d.crux.pageSummary && d.crux.pageSummary.loadingExperience && d.crux.pageSummary.loadingExperience.ALL && d.crux.pageSummary.loadingExperience.ALL.data && !d.browsertime)
             details.iter-group(open)
               summary.iter-group-summary
-                span.iter-group-title Chrome UX Report (CrUx p75)
+                span.iter-group-title Chrome UX Report (real users, p75)
               dl.iter-group-list
                 if cruxFCP
                   dt First Contentful Paint

--- a/lib/plugins/html/templates/url/summary/metrics/index.pug
+++ b/lib/plugins/html/templates/url/summary/metrics/index.pug
@@ -30,7 +30,7 @@ block content
     -    }
     - }
 
-    - const categoryNames = {googleWebVitals: "Google Web Vitals", timings: "Timing metrics", cpu: "CPU metrics", browser: 'Browser metrics', pageinfo: "Page metrics", thirdParty: "Third Party metrics", firstParty: "First Party metrics"}
+    - const categoryNames = {googleWebVitals: "Google Web Vitals", timings: "Timing metrics", cpu: "CPU metrics", browser: 'Browser metrics', pageinfo: "Page metrics", visualMetrics: "Visual Metrics", thirdParty: "Third Party metrics", firstParty: "First Party metrics"}
     - const noCategory = ['requests','transferSize', 'contentSize']
     - const columnCount = runPages.length + 5
 
@@ -57,7 +57,7 @@ block content
                                 - if (noCategory.indexOf(metricType) === -1) {
                                     - category = metricType
                                     tr
-                                        td.extraheader(colspan=columnCount) #{categoryNames[metricType] ? categoryNames[metricType] : metricType}
+                                        td.extraheader(colspan=columnCount) #{categoryNames[metricType] ? categoryNames[metricType] : h.metricName(metricType)}
                                 - } else {
                                     - category = metricType
                                 - }

--- a/lib/plugins/html/templates/url/summary/summaryBox.pug
+++ b/lib/plugins/html/templates/url/summary/summaryBox.pug
@@ -123,7 +123,7 @@ if btStatistics
             td.extraheader(colspan=extraColspan) Visual Metrics
           each visualMetric, name in btStatistics.visualMetrics
             if name !== 'videoRecordingStart'
-              +getRow(name, pageInfo, 'data.browsertime.pageSummary.statistics.visualMetrics.' + name, pageInfo.data.browsertime.pageSummary.visualMetrics, name, h.time.ms)
+              +getRow(h.metricName(name), pageInfo, 'data.browsertime.pageSummary.statistics.visualMetrics.' + name, pageInfo.data.browsertime.pageSummary.visualMetrics, name, h.time.ms)
         if btStatistics.timings && btStatistics.timings.pageTimings
           tr
             td.extraheader(colspan=extraColspan) Google Web Vitals
@@ -134,7 +134,7 @@ if btStatistics
           tr
             td.extraheader(colspan=extraColspan) More metrics
           each timing in timingMetrics
-            +getRow(timing, pageInfo, 'data.browsertime.pageSummary.statistics.timings.' + timing , pageInfo.data.browsertime.pageSummary.browserScripts, 'timings.' + timing, h.time.ms)
+            +getRow(h.metricName(timing), pageInfo, 'data.browsertime.pageSummary.statistics.timings.' + timing , pageInfo.data.browsertime.pageSummary.browserScripts, 'timings.' + timing, h.time.ms)
 
         if btStatistics.timings && btStatistics.timings.userTimings && btStatistics.timings.userTimings.marks
           tr

--- a/lib/plugins/html/templates/url/waterfall/_waterfallRender.pug
+++ b/lib/plugins/html/templates/url/waterfall/_waterfallRender.pug
@@ -304,7 +304,7 @@ script(type='text/javascript').
         + '<tr><th>Response body</th><td>' + escAttr(fmtBytes(responseSize)) + '</td></tr>'
         + (transferSize && transferSize !== responseSize ? '<tr><th>Transferred</th><td>' + escAttr(fmtBytes(transferSize)) + '</td></tr>' : '')
         + '<tr><th>Protocol</th><td>' + escAttr(protocol) + '</td></tr>'
-        + '<tr><th>Priority</th><td>' + escAttr(priority) + '</td></tr>'
+        + '<tr><th>Fetch priority</th><td>' + escAttr(priority) + '</td></tr>'
         + (initiator !== '–' ? '<tr><th>Initiated by</th><td>' + escAttr(initiator) + '</td></tr>' : '')
         + '</table>';
 
@@ -429,6 +429,9 @@ script(type='text/javascript').
         ssl: '#facc15', send: '#22c55e', wait: '#0ea5e9', receive: '#0073b0'
       };
       const phaseRows = ['blocked','dns','connect','ssl','send','wait','receive'];
+      // The HAR's raw phase keys mean little outside waterfall tools -
+      // show readable labels in the detail panel.
+      const PHASE_LABELS = { blocked: 'Queued (blocked)', dns: 'DNS lookup', connect: 'Connecting', ssl: 'TLS setup', send: 'Sending request', wait: 'Waiting (TTFB)', receive: 'Downloading' };
       let totalKnown = 0;
       for (const p of phaseRows) if (typeof t[p] === 'number' && t[p] > 0) totalKnown += t[p];
       const max = Math.max(totalKnown, 1);
@@ -437,7 +440,7 @@ script(type='text/javascript').
         const w = v > 0 ? (v / max * 100).toFixed(1) : 0;
         const color = PHASE_COLORS[p] || '#cbd5e1';
         return '<div class="wt-detail-timing-bar">'
-          + '<span class="label">' + p + '</span>'
+          + '<span class="label">' + (PHASE_LABELS[p] || p) + '</span>'
           + '<span class="track">' + (v > 0 ? '<span style="width: ' + w + '%; background: ' + color + ';"></span>' : '') + '</span>'
           + '<span class="ms">' + escAttr(v < 0 ? '–' : fmtMs(v)) + '</span>'
           + '</div>';

--- a/lib/plugins/html/templates/url/waterfall/index.pug
+++ b/lib/plugins/html/templates/url/waterfall/index.pug
@@ -27,11 +27,11 @@ if (options.html.showAllWaterfallSummary === true)
         span Page metrics
       label
         input(type='checkbox', id='wt-show-marks', checked)
-        span Marks &amp; visual metrics
+        span User Timing marks &amp; visual metrics
       label
         input(type='checkbox', id='wt-show-longtasks', checked)
         span Long tasks
-      label
+      label(title='Group requests by network connection instead of one row per request')
         input(type='checkbox', id='wt-connection-view')
         span Connection view
 

--- a/lib/support/helpers/cpuCategoryName.js
+++ b/lib/support/helpers/cpuCategoryName.js
@@ -1,0 +1,16 @@
+// Human names for the Chrome-trace work categories shown in the HTML
+// report (the CPU tab's category bars and the start page's CPU card).
+// Falls back to the raw key so new categories still render.
+const CATEGORY_NAMES = {
+  parseHTML: 'Parsing HTML & CSS',
+  styleLayout: 'Style & layout',
+  scriptParseCompile: 'Parsing & compiling JavaScript',
+  scriptEvaluation: 'Running JavaScript',
+  paintCompositeRender: 'Paint & composite',
+  garbageCollection: 'Garbage collection',
+  other: 'Other browser work'
+};
+
+export function cpuCategoryName(key) {
+  return CATEGORY_NAMES[key] || key;
+}

--- a/lib/support/helpers/index.js
+++ b/lib/support/helpers/index.js
@@ -4,6 +4,8 @@ export * from './time.js';
 export * from './plural.js';
 export * from './scoreLabel.js';
 export * from './label.js';
+export * from './metricName.js';
+export * from './cpuCategoryName.js';
 export * from './get.js';
 export * from './short.js';
 export * from './shortAsset.js';

--- a/lib/support/helpers/metricName.js
+++ b/lib/support/helpers/metricName.js
@@ -1,0 +1,51 @@
+// Turn a raw camelCase data key into a readable label
+// ("domContentLoadedTime" -> "DOM content loaded time") for the
+// places where the HTML report would otherwise show the key verbatim.
+// Well-known acronyms keep their casing so the result reads as the
+// term developers know, not "Dom" or "Cls".
+const ACRONYMS = new Set([
+  'js',
+  'css',
+  'dom',
+  'url',
+  'html',
+  'http',
+  'https',
+  'cdp',
+  'v8',
+  'lcp',
+  'fcp',
+  'cls',
+  'tbt',
+  'ttfb',
+  'fid',
+  'inp',
+  'cpu',
+  'gpu',
+  'tls',
+  'ssl',
+  'dns',
+  'cdn',
+  'har'
+]);
+
+export function metricName(key) {
+  if (!key) {
+    return key;
+  }
+  const words = String(key)
+    .replaceAll(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replaceAll(/([a-z])(\d)/g, '$1 $2')
+    .split(/[\s_]+/);
+  return words
+    .map((word, index) => {
+      if (ACRONYMS.has(word.toLowerCase())) {
+        return word.toUpperCase();
+      }
+      return index === 0
+        ? word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+        : word.toLowerCase();
+    })
+    .join(' ');
+}


### PR DESCRIPTION
The report leaned on vocabulary only trace readers know: raw camelCase data keys shown as metric labels (backEndTime, RecalcStyleCount, FirstVisualChange), spec tokens from the LoAF and Long Task APIs, HAR phase keys (blocked, ssl, wait), trace event names used as headings (Recalculate style, RunTask), and profiler terms like self time, unattributed and invoker. Readers had to decode the report before they could act on it.

Visible text now uses plain language across every page, with the raw keys kept in tooltips and explainer folds since the JSON data and exported metrics still use them. Two small helpers (metricName, cpuCategoryName) turn data keys into readable labels wherever templates would otherwise print them verbatim, and the help page's Firefox metric entries now lead with what each metric means instead of which browser preference enables it.

Co-Authored-By: Claude Fable 5 noreply

